### PR TITLE
C++11 compilation for android application.

### DIFF
--- a/src/algorithms/kruskal.h
+++ b/src/algorithms/kruskal.h
@@ -23,7 +23,7 @@ undirected_graph<T> minimum_spanning_tree(const undirected_graph<T>& graph){
 
   // First sorting edges by weight.
   std::sort(edges.begin(), edges.end(),
-            [] (const auto &a, const auto &b){
+            [] (const edge<T> &a, const edge<T> &b){
               return a.get_weight() < b.get_weight();
             });
 

--- a/src/algorithms/munkres.h
+++ b/src/algorithms/munkres.h
@@ -279,7 +279,7 @@ std::unordered_map<index_t, index_t> branch_and_bound_symmetric_mwpm(const matri
         // Else sure to get a bigger weight in the end so doing
         // nothing cuts the branch.
         std::list<edge<T>> children_edges = current_node.get_children_edges();
-        children_edges.sort([](auto const& a, auto const& b)
+        children_edges.sort([](edge<T> const& a, edge<T> const& b)
                             {
                               return (a.get_weight() < b.get_weight());
                             });

--- a/src/heuristics/local_search.cpp
+++ b/src/heuristics/local_search.cpp
@@ -40,7 +40,7 @@ local_search::local_search(const matrix<distance_t>& matrix,
   std::size_t range_width = _edges.size() / _nb_threads;
   std::iota(_rank_limits.begin(), _rank_limits.end(), 0);
   std::transform(_rank_limits.begin(), _rank_limits.end(), _rank_limits.begin(),
-                 [range_width](auto v){return range_width * v;});
+                 [range_width](std::size_t v){return range_width * v;});
   // Shifting the limits to dispatch remaining ranks among more
   // threads for a more even load balance. This way the load
   // difference between ranges should be at most 1.
@@ -286,7 +286,7 @@ distance_t local_search::avoid_loop_step(){
   // Reorder to try the longest chains first.
   std::sort(relocatable_chains.begin(),
             relocatable_chains.end(),
-            [](const auto& lhs, const auto& rhs){
+            [](const std::list<index_t>& lhs, const std::list<index_t>& rhs){
               return lhs.size() > rhs.size();
             });
 

--- a/src/loaders/tsplib_loader.h
+++ b/src/loaders/tsplib_loader.h
@@ -210,7 +210,7 @@ public:
         // Input start is a node index. Retrieving the rank of this
         // node in _nodes.
         auto start_node = std::find_if(_nodes.begin(), _nodes.end(),
-                                       [input_start] (const auto& n){
+                                       [input_start] (const Node& n){
                                          return n.index == input_start;
                                        });
         if(start_node == _nodes.end()){
@@ -236,7 +236,7 @@ public:
         // Input end is a node index. Retrieving the rank of this node
         // in _nodes.
         auto end_node = std::find_if(_nodes.begin(), _nodes.end(),
-                                       [input_end] (const auto& n){
+                                       [input_end] (const Node& n){
                                          return n.index == input_end;
                                        });
         if(end_node == _nodes.end()){


### PR DESCRIPTION
I am currently compiling and linking Vroom in an android application. The native c++ android code source is compiled with std=c++11 parameter.

The "auto" type in lambda functions parameters wasn't accepte in c++11, I replace by real type.

With this modification Vroom can be compil as static library for c++11 or c++14 project.