### PR TITLE
Fix std iota dependancy

### DIFF
--- a/src/algorithms/kruskal.h
+++ b/src/algorithms/kruskal.h
@@ -12,6 +12,7 @@ All rights reserved (see LICENSE).
 
 #include <algorithm>
 #include <vector>
+#include <numeric>
 
 #include "../structures/abstract/edge.h"
 #include "../structures/abstract/undirected_graph.h"


### PR DESCRIPTION
`
algorithms/kruskal.cpp: In function ‘undirected_graph<T> minimum_spanning_tree(const undirected_graph<T>&)’:
algorithms/kruskal.cpp:30:8: error: ‘iota’ is not a member of ‘std’
   std::iota(representative.begin(), representative.end(), 0);
        ^~~~
algorithms/kruskal.cpp:30:8: note: suggested alternative: ‘not2’
   std::iota(representative.begin(), representative.end(), 0);
`

This fixes the above compilation error