### PR TITLE
Handle duplicate location_index

### DIFF
--- a/src/problems/tsp/tsp.cpp
+++ b/src/problems/tsp/tsp.cpp
@@ -307,9 +307,7 @@ solution tsp::solve(unsigned nb_threads) const {
   if (_has_start) {
     // Add start step.
     assert(current_sol.front() == _start);
-    auto rank = _input.get_location_rank_from_index(
-      _tsp_index_to_global[current_sol.front()]);
-    steps.emplace_back(TYPE::START, _input._locations[rank]);
+    steps.emplace_back(TYPE::START, _input._vehicles[_vehicle_rank].start.get());
     // Remember that jobs start further away in the list.
     ++job_start;
   }
@@ -337,9 +335,7 @@ solution tsp::solve(unsigned nb_threads) const {
   // Handle end.
   if (_has_end) {
     // Add end step.
-    auto rank =
-      _input.get_location_rank_from_index(_tsp_index_to_global[end_index]);
-    steps.emplace_back(TYPE::END, _input._locations[rank]);
+    steps.emplace_back(TYPE::END, _input._vehicles[_vehicle_rank].end.get());
   }
 
   // Route.

--- a/src/problems/tsp/tsp.cpp
+++ b/src/problems/tsp/tsp.cpp
@@ -307,7 +307,8 @@ solution tsp::solve(unsigned nb_threads) const {
   if (_has_start) {
     // Add start step.
     assert(current_sol.front() == _start);
-    steps.emplace_back(TYPE::START, _input._vehicles[_vehicle_rank].start.get());
+    steps.emplace_back(TYPE::START,
+                       _input._vehicles[_vehicle_rank].start.get());
     // Remember that jobs start further away in the list.
     ++job_start;
   }
@@ -326,11 +327,7 @@ solution tsp::solve(unsigned nb_threads) const {
 
   // Handle jobs.
   for (auto job = job_start; job != job_end; ++job) {
-    auto current_rank =
-      _input.get_job_rank_from_index(_tsp_index_to_global[*job]);
-    steps.emplace_back(TYPE::JOB,
-                       _input._jobs[current_rank],
-                       _input._jobs[current_rank].id);
+    steps.emplace_back(TYPE::JOB, _input._locations[*job], _input._ids[*job]);
   }
   // Handle end.
   if (_has_end) {

--- a/src/problems/tsp/tsp.cpp
+++ b/src/problems/tsp/tsp.cpp
@@ -31,22 +31,32 @@ tsp::tsp(const input& input,
 
   if (_has_start) {
     // Use index in _matrix for start.
-    auto search =
-      std::find(_tsp_index_to_global.begin(),
-                _tsp_index_to_global.end(),
-                _input._vehicles[_vehicle_rank].start.get().index());
-    assert(search != _tsp_index_to_global.end());
-    _start = std::distance(_tsp_index_to_global.begin(), search);
-    assert(_start < _matrix.size());
+    bool start_found;
+    for (index_t i = 0; i < _tsp_index_to_global.size(); ++i) {
+      start_found = (_input._type_with_ids[i].type == TYPE::START) and
+        (_tsp_index_to_global[i] == _input._vehicles[_vehicle_rank].start.get().index());
+      if (start_found) {
+        _start = i;
+        break;
+      }
+    }
+    assert(start_found);
   }
   if (_has_end) {
-    // Use index in _matrix for start.
-    auto search = std::find(_tsp_index_to_global.begin(),
-                            _tsp_index_to_global.end(),
-                            _input._vehicles[_vehicle_rank].end.get().index());
-    assert(search != _tsp_index_to_global.end());
-    _end = std::distance(_tsp_index_to_global.begin(), search);
-    assert(_end < _matrix.size());
+    // Use index in _matrix for end.
+    bool end_found;
+    for (index_t i = 0; i < _tsp_index_to_global.size(); ++i) {
+      // Not checking for TYPE::END here because when start_index and
+      // end_index are both provided and equal, then the end location
+      // is not duplicated in input::_locations.
+      end_found = (_input._type_with_ids[i].type != TYPE::JOB) and
+        (_tsp_index_to_global[i] == _input._vehicles[_vehicle_rank].end.get().index());
+      if (end_found) {
+        _end = i;
+        break;
+      }
+    }
+    assert(end_found);
   }
 
   _round_trip = _has_start and _has_end and (_start == _end);

--- a/src/problems/tsp/tsp.cpp
+++ b/src/problems/tsp/tsp.cpp
@@ -22,6 +22,13 @@ tsp::tsp(const input& input,
     _has_start(_input._vehicles[_vehicle_rank].has_start()),
     _has_end(_input._vehicles[_vehicle_rank].has_end()) {
 
+  // Distances on the diagonal are never used except in the minimum
+  // weight perfect matching (munkres call during the heuristic). This
+  // makes sure no node will be matched with itself at that time.
+  for (index_t i = 0; i < _matrix.size(); ++i) {
+    _matrix[i][i] = INFINITE_COST;
+  }
+
   if (_has_start) {
     // Use index in _matrix for start.
     auto search =

--- a/src/problems/tsp/tsp.cpp
+++ b/src/problems/tsp/tsp.cpp
@@ -334,7 +334,10 @@ solution tsp::solve(unsigned nb_threads) const {
 
   // Handle jobs.
   for (auto job = job_start; job != job_end; ++job) {
-    steps.emplace_back(TYPE::JOB, _input._locations[*job], _input._ids[*job]);
+    assert(_input._type_with_ids[*job].type == TYPE::JOB);
+    steps.emplace_back(TYPE::JOB,
+                       _input._locations[*job],
+                       _input._type_with_ids[*job].id);
   }
   // Handle end.
   if (_has_end) {

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -58,4 +58,7 @@ struct cl_args_t {
 // Problem types.
 enum class PROBLEM_T { TSP };
 
+// Available location status.
+enum class TYPE { START, JOB, END };
+
 #endif

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -65,7 +65,10 @@ void input::add_vehicle(const vehicle_t& vehicle) {
     auto end_index = current_v.end.get().index();
     _all_indices.insert(end_index);
 
-    _locations.push_back(current_v.end.get());
+    if (!has_start or (current_v.start.get().index() != end_index)) {
+      // Avoiding duplicate for start/end location.
+      _locations.push_back(current_v.end.get());
+    }
   }
 }
 
@@ -143,9 +146,10 @@ PROBLEM_T input::get_problem_type() const {
 
 std::unique_ptr<vrp> input::get_problem() const {
   std::vector<index_t> problem_indices;
-  for (const auto& i : _all_indices) {
-    problem_indices.push_back(i);
-  }
+  std::transform(_locations.begin(),
+                 _locations.end(),
+                 std::back_inserter(problem_indices),
+                 [](const auto& loc) { return loc.index(); });
 
   return std::make_unique<tsp>(*this, problem_indices, 0);
 }

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -119,14 +119,6 @@ void input::set_matrix() {
 
   // Check for potential overflow in solution cost.
   this->check_cost_bound();
-
-  // Distances on the diagonal are never used except in the minimum
-  // weight perfect matching (munkres call during the TSP
-  // heuristic). This makes sure no node will be matched with itself
-  // at that time.
-  for (index_t i = 0; i < _matrix.size(); ++i) {
-    _matrix[i][i] = INFINITE_COST;
-  }
 }
 
 PROBLEM_T input::get_problem_type() const {

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -28,7 +28,7 @@ void input::add_job(const job_t& job) {
     current_job.set_index(_locations.size());
   }
 
-  _ids.push_back(current_job.id);
+  _type_with_ids.push_back({TYPE::JOB, current_job.id});
   _locations.push_back(current_job);
 }
 
@@ -47,7 +47,7 @@ void input::add_vehicle(const vehicle_t& vehicle) {
       current_v.start.get().set_index(_locations.size());
     }
 
-    _ids.push_back(current_v.id);
+    _type_with_ids.push_back({TYPE::START, current_v.id});
     _locations.push_back(current_v.start.get());
   }
 
@@ -61,7 +61,7 @@ void input::add_vehicle(const vehicle_t& vehicle) {
     if (!has_start or
         (current_v.start.get().index() != current_v.end.get().index())) {
       // Avoiding duplicate for start/end location.
-      _ids.push_back(current_v.id);
+      _type_with_ids.push_back({TYPE::END, current_v.id});
       _locations.push_back(current_v.end.get());
     }
   }

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -28,11 +28,7 @@ void input::add_job(const job_t& job) {
     current_job.set_index(_locations.size());
   }
 
-  // Remember mapping between the job index in the matrix and its rank
-  // in _jobs.
-  _index_to_job_rank.insert({current_job.index(), _jobs.size() - 1});
-  _all_indices.insert(current_job.index());
-
+  _ids.push_back(current_job.id);
   _locations.push_back(current_job);
 }
 
@@ -50,9 +46,8 @@ void input::add_vehicle(const vehicle_t& vehicle) {
       // vehicle creation, using current number of locations.
       current_v.start.get().set_index(_locations.size());
     }
-    auto start_index = current_v.start.get().index();
-    _all_indices.insert(start_index);
 
+    _ids.push_back(current_v.id);
     _locations.push_back(current_v.start.get());
   }
 
@@ -62,11 +57,11 @@ void input::add_vehicle(const vehicle_t& vehicle) {
       // vehicle creation, using current number of locations.
       current_v.end.get().set_index(_locations.size());
     }
-    auto end_index = current_v.end.get().index();
-    _all_indices.insert(end_index);
 
-    if (!has_start or (current_v.start.get().index() != end_index)) {
+    if (!has_start or
+        (current_v.start.get().index() != current_v.end.get().index())) {
       // Avoiding duplicate for start/end location.
+      _ids.push_back(current_v.id);
       _locations.push_back(current_v.end.get());
     }
   }
@@ -132,12 +127,6 @@ void input::set_matrix() {
   for (index_t i = 0; i < _matrix.size(); ++i) {
     _matrix[i][i] = INFINITE_COST;
   }
-}
-
-index_t input::get_job_rank_from_index(index_t index) const {
-  auto result = _index_to_job_rank.find(index);
-  assert(result != _index_to_job_rank.end());
-  return result->second;
 }
 
 PROBLEM_T input::get_problem_type() const {

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -33,7 +33,6 @@ void input::add_job(const job_t& job) {
   _index_to_job_rank.insert({current_job.index(), _jobs.size() - 1});
   _all_indices.insert(current_job.index());
 
-  _index_to_loc_rank.insert({current_job.index(), _locations.size()});
   _locations.push_back(current_job);
 }
 
@@ -54,7 +53,6 @@ void input::add_vehicle(const vehicle_t& vehicle) {
     auto start_index = current_v.start.get().index();
     _all_indices.insert(start_index);
 
-    _index_to_loc_rank.insert({start_index, _locations.size()});
     _locations.push_back(current_v.start.get());
   }
 
@@ -67,7 +65,6 @@ void input::add_vehicle(const vehicle_t& vehicle) {
     auto end_index = current_v.end.get().index();
     _all_indices.insert(end_index);
 
-    _index_to_loc_rank.insert({end_index, _locations.size()});
     _locations.push_back(current_v.end.get());
   }
 }
@@ -132,12 +129,6 @@ void input::set_matrix() {
   for (index_t i = 0; i < _matrix.size(); ++i) {
     _matrix[i][i] = INFINITE_COST;
   }
-}
-
-index_t input::get_location_rank_from_index(index_t index) const {
-  auto result = _index_to_loc_rank.find(index);
-  assert(result != _index_to_loc_rank.end());
-  return result->second;
 }
 
 index_t input::get_job_rank_from_index(index_t index) const {

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -54,8 +54,7 @@ public:
   std::vector<cost_t> _max_cost_per_line;
   std::vector<cost_t> _max_cost_per_column;
 
-  // List of locations added through add_* matching the matrix
-  // ordering.
+  // List of locations added through add_*.
   std::vector<location_t> _locations;
 
   input(std::unique_ptr<routing_io<cost_t>> routing_wrapper, bool geometry);
@@ -63,8 +62,6 @@ public:
   void add_job(const job_t& job);
 
   void add_vehicle(const vehicle_t& vehicle);
-
-  index_t get_location_rank_from_index(index_t index) const;
 
   index_t get_job_rank_from_index(index_t index) const;
 

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -44,7 +44,6 @@ private:
   void check_cost_bound();
   void set_matrix();
   std::unordered_map<index_t, index_t> _index_to_job_rank;
-  std::unordered_map<index_t, index_t> _index_to_loc_rank;
   std::set<index_t> _all_indices;
   std::unique_ptr<vrp> get_problem() const;
 

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -43,8 +43,6 @@ private:
   const bool _geometry;
   void check_cost_bound();
   void set_matrix();
-  std::unordered_map<index_t, index_t> _index_to_job_rank;
-  std::set<index_t> _all_indices;
   std::unique_ptr<vrp> get_problem() const;
 
 public:
@@ -54,7 +52,8 @@ public:
   std::vector<cost_t> _max_cost_per_line;
   std::vector<cost_t> _max_cost_per_column;
 
-  // List of locations added through add_*.
+  // List of ids and locations added through add_*.
+  std::vector<ID_t> _ids;
   std::vector<location_t> _locations;
 
   input(std::unique_ptr<routing_io<cost_t>> routing_wrapper, bool geometry);
@@ -62,8 +61,6 @@ public:
   void add_job(const job_t& job);
 
   void add_vehicle(const vehicle_t& vehicle);
-
-  index_t get_job_rank_from_index(index_t index) const;
 
   PROBLEM_T get_problem_type() const;
 

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -32,6 +32,11 @@ All rights reserved (see LICENSE).
 
 class vrp;
 
+struct type_with_id {
+  TYPE type;
+  ID_t id;
+};
+
 class input {
 private:
   std::chrono::high_resolution_clock::time_point _start_loading;
@@ -53,7 +58,7 @@ public:
   std::vector<cost_t> _max_cost_per_column;
 
   // List of ids and locations added through add_*.
-  std::vector<ID_t> _ids;
+  std::vector<type_with_id> _type_with_ids;
   std::vector<location_t> _locations;
 
   input(std::unique_ptr<routing_io<cost_t>> routing_wrapper, bool geometry);

--- a/src/structures/vroom/solution/step.h
+++ b/src/structures/vroom/solution/step.h
@@ -12,8 +12,6 @@ All rights reserved (see LICENSE).
 
 #include "../location.h"
 
-enum class TYPE { START, JOB, END };
-
 struct step {
   TYPE type;
   location_t location;


### PR DESCRIPTION
## Issue

#79 

## Tasks

 - [x] get rid of mappings in `input::_index_to_job_rank` and `input::_index_to_loc_rank`
 - [x] store indices in a `std::vector` to keep jobs with duplicate `location_index` and pass them to `tsp` for solving
 - [ ] review
