### PR TITLE
Use default capacities

### DIFF
--- a/examples/libvroom.cpp
+++ b/examples/libvroom.cpp
@@ -93,14 +93,15 @@ void run_example_with_osrm() {
                {2, 14});         // skills
   problem_instance.add_vehicle(v2);
 
-  // Set jobs id, amount, required skills and location.
+  // Set jobs id, location, amount and required skills. Last two can
+  // be omitted if no constraints are required.
   std::vector<job_t> jobs;
-  jobs.push_back(job_t(1, job_amount, {1}, coords_t({1.98935, 48.701})));
-  jobs.push_back(job_t(2, job_amount, {1}, coords_t({2.03655, 48.61128})));
-  jobs.push_back(job_t(3, job_amount, {2}, coords_t({2.39719, 49.07611})));
-  jobs.push_back(job_t(4, job_amount, {2}, coords_t({2.41808, 49.22619})));
-  jobs.push_back(job_t(5, job_amount, {14}, coords_t({2.28325, 48.5958})));
-  jobs.push_back(job_t(6, job_amount, {14}, coords_t({2.89357, 48.90736})));
+  jobs.push_back(job_t(1, coords_t({1.98935, 48.701}), job_amount, {1}));
+  jobs.push_back(job_t(2, coords_t({2.03655, 48.61128}), job_amount, {1}));
+  jobs.push_back(job_t(3, coords_t({2.39719, 49.07611}), job_amount, {2}));
+  jobs.push_back(job_t(4, coords_t({2.41808, 49.22619}), job_amount, {2}));
+  jobs.push_back(job_t(5, coords_t({2.28325, 48.5958}), job_amount, {14}));
+  jobs.push_back(job_t(6, coords_t({2.89357, 48.90736}), job_amount, {14}));
 
   for (const auto& j : jobs) {
     problem_instance.add_job(j);
@@ -159,15 +160,16 @@ void run_example_with_custom_matrix() {
                {2, 14});         // skills
   problem_instance.add_vehicle(v2);
 
-  // Set jobs id, amount, required skills and index of location in the
-  // matrix (coordinates are optional).
+  // Set jobs id, index of location in the matrix (coordinates are
+  // optional), amount and required skills. Last two can be omitted if
+  // no constraints are required.
   std::vector<job_t> jobs;
-  jobs.push_back(job_t(1, job_amount, {1}, 1));
-  jobs.push_back(job_t(2, job_amount, {1}, 2));
-  jobs.push_back(job_t(3, job_amount, {2}, 3));
-  jobs.push_back(job_t(4, job_amount, {2}, 4));
-  jobs.push_back(job_t(5, job_amount, {14}, 5));
-  jobs.push_back(job_t(6, job_amount, {14}, 6));
+  jobs.push_back(job_t(1, 1, job_amount, {1}));
+  jobs.push_back(job_t(2, 2, job_amount, {1}));
+  jobs.push_back(job_t(3, 3, job_amount, {2}));
+  jobs.push_back(job_t(4, 4, job_amount, {2}));
+  jobs.push_back(job_t(5, 5, job_amount, {14}));
+  jobs.push_back(job_t(6, 6, job_amount, {14}));
 
   for (const auto& j : jobs) {
     problem_instance.add_job(j);

--- a/src/problems/cvrp/cvrp.cpp
+++ b/src/problems/cvrp/cvrp.cpp
@@ -73,15 +73,7 @@ solution cvrp::solve(unsigned nb_threads) const {
     t.join();
   }
 
-  auto best_c =
-    std::min_element(clusterings.begin(),
-                     clusterings.end(),
-                     [](auto& lhs, auto& rhs) {
-                       return lhs.unassigned.size() < rhs.unassigned.size() or
-                              (lhs.unassigned.size() ==
-                                 rhs.unassigned.size() and
-                               lhs.edges_cost < rhs.edges_cost);
-                     });
+  auto best_c = std::min_element(clusterings.begin(), clusterings.end());
 
   std::string strategy =
     (best_c->type == CLUSTERING_T::PARALLEL) ? "parallel" : "sequential";

--- a/src/problems/cvrp/cvrp.cpp
+++ b/src/problems/cvrp/cvrp.cpp
@@ -99,6 +99,7 @@ solution cvrp::solve(unsigned nb_threads) const {
   }
   BOOST_LOG_TRIVIAL(trace) << "Best clustering:" << strategy << ";" << init_str
                            << ";" << best_c->regret_coeff << ";"
+                           << best_c->clusters.size() << ";"
                            << best_c->unassigned.size() << ";"
                            << best_c->edges_cost;
 
@@ -114,14 +115,7 @@ solution cvrp::solve(unsigned nb_threads) const {
 
   BOOST_LOG_TRIVIAL(info) << "[CVRP] Launching TSPs ";
 
-  // Determine non-empty clusters and number of TSP to launch.
-  std::vector<std::size_t> non_empty_cluster_ranks;
-  for (std::size_t i = 0; i < best_c->clusters.size(); ++i) {
-    if (!best_c->clusters[i].empty()) {
-      non_empty_cluster_ranks.push_back(i);
-    }
-  }
-  auto nb_tsp = non_empty_cluster_ranks.size();
+  auto nb_tsp = best_c->clusters.size();
 
   // Create vector of TSP solutions with dummy init.
   std::vector<solution> tsp_sols(nb_tsp, solution(0, ""));
@@ -131,8 +125,7 @@ solution cvrp::solve(unsigned nb_threads) const {
   auto run_tsp = [&](const std::vector<unsigned>& cluster_ranks,
                      unsigned tsp_threads) {
     for (auto cl_rank : cluster_ranks) {
-      auto vehicle_rank = non_empty_cluster_ranks[cl_rank];
-      tsp p(_input, best_c->clusters[vehicle_rank], vehicle_rank);
+      tsp p(_input, best_c->clusters[cl_rank], cl_rank);
 
       tsp_sols[cl_rank] = p.solve(tsp_threads);
     }

--- a/src/problems/cvrp/cvrp.cpp
+++ b/src/problems/cvrp/cvrp.cpp
@@ -11,17 +11,6 @@ All rights reserved (see LICENSE).
 #include "../../structures/vroom/input/input.h"
 
 cvrp::cvrp(const input& input) : vrp(input) {
-  for (const auto& v : _input._vehicles) {
-    if (!v.has_capacity()) {
-      throw custom_exception("Missing capacity for vehicle " +
-                             std::to_string(v.id));
-    }
-  }
-  for (const auto& j : _input._jobs) {
-    if (!j.has_amount()) {
-      throw custom_exception("Missing amount for job " + std::to_string(j.id));
-    }
-  }
 }
 
 solution cvrp::solve(unsigned nb_threads) const {

--- a/src/problems/cvrp/heuristics/clustering.cpp
+++ b/src/problems/cvrp/heuristics/clustering.cpp
@@ -150,8 +150,9 @@ void clustering::parallel_clustering() {
   };
   // Initialize cluster with the nearest job.
   auto nearest_init_lambda = [&](auto v) {
-    return
-      [&](index_t lhs, index_t rhs) { return costs[v][lhs] < costs[v][rhs]; };
+    return [&, v](index_t lhs, index_t rhs) {
+      return costs[v][lhs] < costs[v][rhs];
+    };
   };
 
   if (init != INIT_T::NONE) {
@@ -216,7 +217,7 @@ void clustering::parallel_clustering() {
   }
 
   auto eval_lambda = [&](auto v) {
-    return [&](auto i, auto j) {
+    return [&, v](auto i, auto j) {
       return regret_coeff * static_cast<double>(regrets[v][i]) -
                static_cast<double>(costs[v][i]) <
              regret_coeff * static_cast<double>(regrets[v][j]) -
@@ -398,7 +399,7 @@ void clustering::sequential_clustering() {
   };
   // Initialize cluster with the nearest job.
   auto nearest_init_lambda = [&](auto v) {
-    return [&](index_t lhs, index_t rhs) {
+    return [&, v](index_t lhs, index_t rhs) {
       return vehicles_to_job_costs[v][lhs] < vehicles_to_job_costs[v][rhs];
     };
   };

--- a/src/problems/cvrp/heuristics/clustering.cpp
+++ b/src/problems/cvrp/heuristics/clustering.cpp
@@ -43,8 +43,16 @@ clustering::clustering(const input& input, CLUSTERING_T t, INIT_T i, double c)
     init_str = "nearest";
     break;
   }
+
+  // Filter out empty clusters.
+  clusters.erase(std::remove_if(clusters.begin(),
+                                clusters.end(),
+                                [](auto& c) { return c.empty(); }),
+                 clusters.end());
+
   BOOST_LOG_TRIVIAL(trace) << "Clustering:" << strategy << ";" << init_str
                            << ";" << this->regret_coeff << ";"
+                           << this->clusters.size() << ";"
                            << this->unassigned.size() << ";"
                            << this->edges_cost;
 }

--- a/src/problems/cvrp/heuristics/clustering.cpp
+++ b/src/problems/cvrp/heuristics/clustering.cpp
@@ -57,6 +57,22 @@ clustering::clustering(const input& input, CLUSTERING_T t, INIT_T i, double c)
                            << this->edges_cost;
 }
 
+bool operator<(const clustering& lhs, const clustering& rhs) {
+  if (lhs.unassigned.size() < rhs.unassigned.size()) {
+    return true;
+  }
+  if (lhs.unassigned.size() == rhs.unassigned.size()) {
+    if (lhs.edges_cost < rhs.edges_cost) {
+      return true;
+    }
+    if (lhs.edges_cost == rhs.edges_cost and
+        lhs.clusters.size() < rhs.clusters.size()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 inline void update_cost(index_t from_index,
                         std::vector<cost_t>& costs,
                         std::vector<index_t>& parents,

--- a/src/problems/cvrp/heuristics/clustering.cpp
+++ b/src/problems/cvrp/heuristics/clustering.cpp
@@ -114,7 +114,7 @@ void clustering::parallel_clustering() {
   // Remember current capacity left in clusters.
   std::vector<amount_t> capacities;
   for (std::size_t v = 0; v < V; ++v) {
-    capacities.emplace_back(vehicles[v].capacity.get());
+    capacities.emplace_back(vehicles[v].capacity);
   }
 
   // Regrets[v][j] is the min cost of reaching jobs[j] from another
@@ -143,8 +143,8 @@ void clustering::parallel_clustering() {
   // the further away in case of amount tie).
   auto higher_amount_init_lambda = [&](auto v) {
     return [&](index_t lhs, index_t rhs) {
-      return jobs[lhs].amount.get() < jobs[rhs].amount.get() or
-             (jobs[lhs].amount.get() == jobs[rhs].amount.get() and
+      return jobs[lhs].amount < jobs[rhs].amount or
+             (jobs[lhs].amount == jobs[rhs].amount and
               costs[v][lhs] < costs[v][rhs]);
     };
   };
@@ -173,7 +173,7 @@ void clustering::parallel_clustering() {
         clusters[v].push_back(job_rank);
         unassigned.erase(job_rank);
         edges_cost += costs[v][job_rank];
-        capacities[v] -= jobs[job_rank].amount.get();
+        capacities[v] -= jobs[job_rank].amount;
         candidates[v].erase(init_job);
 
         BOOST_LOG_TRIVIAL(trace) << vehicles[v].id << ";"
@@ -244,7 +244,7 @@ void clustering::parallel_clustering() {
                      eval_lambda(v));
 
       auto current_j = candidates[v].front();
-      if (jobs[current_j].amount.get() <= capacities[v] and
+      if (jobs[current_j].amount <= capacities[v] and
           (costs[v][current_j] < best_cost or
            (costs[v][current_j] == best_cost and
             capacities[best_v] < capacities[v]))) {
@@ -289,7 +289,7 @@ void clustering::parallel_clustering() {
     BOOST_LOG_TRIVIAL(trace) << vehicles[best_v].id << ";"
                              << parents[best_v][best_j] << "->"
                              << jobs[best_j].index();
-    capacities[best_v] -= jobs[best_j].amount.get();
+    capacities[best_v] -= jobs[best_j].amount;
 
     std::pop_heap(candidates[best_v].begin(),
                   candidates[best_v].end(),
@@ -391,8 +391,8 @@ void clustering::sequential_clustering() {
   // the further away in case of amount tie).
   auto higher_amount_init_lambda = [&](auto v) {
     return [&](index_t lhs, index_t rhs) {
-      return jobs[lhs].amount.get() < jobs[rhs].amount.get() or
-             (jobs[lhs].amount.get() == jobs[rhs].amount.get() and
+      return jobs[lhs].amount < jobs[rhs].amount or
+             (jobs[lhs].amount == jobs[rhs].amount and
               vehicles_to_job_costs[v][lhs] < vehicles_to_job_costs[v][rhs]);
     };
   };
@@ -409,7 +409,7 @@ void clustering::sequential_clustering() {
     std::vector<index_t> candidates;
     for (auto i : candidates_set) {
       if (input_ref._vehicle_to_job_compatibility[v][i] and
-          jobs[i].amount.get() <= input_ref._vehicles[v].capacity.get()) {
+          jobs[i].amount <= input_ref._vehicles[v].capacity) {
         candidates.push_back(i);
       }
     }
@@ -438,7 +438,7 @@ void clustering::sequential_clustering() {
     }
 
     // Remember current capacity left in cluster.
-    auto capacity = vehicles[v].capacity.get();
+    auto capacity = vehicles[v].capacity;
 
     // Strategy for cluster initialization.
     if (init != INIT_T::NONE) {
@@ -459,7 +459,7 @@ void clustering::sequential_clustering() {
         clusters[v].push_back(job_rank);
         unassigned.erase(job_rank);
         edges_cost += vehicles_to_job_costs[v][job_rank];
-        capacity -= jobs[job_rank].amount.get();
+        capacity -= jobs[job_rank].amount;
         candidates_set.erase(job_rank);
         candidates.erase(init_job);
 
@@ -487,13 +487,13 @@ void clustering::sequential_clustering() {
 
       auto current_j = candidates.front();
 
-      if (jobs[current_j].amount.get() <= capacity) {
+      if (jobs[current_j].amount <= capacity) {
         clusters[v].push_back(current_j);
         unassigned.erase(current_j);
         edges_cost += costs[current_j];
         BOOST_LOG_TRIVIAL(trace) << vehicles[v].id << ";" << parents[current_j]
                                  << "->" << jobs[current_j].index();
-        capacity -= jobs[current_j].amount.get();
+        capacity -= jobs[current_j].amount;
         candidates_set.erase(current_j);
 
         update_cost(jobs[current_j].index(),

--- a/src/problems/cvrp/heuristics/clustering.h
+++ b/src/problems/cvrp/heuristics/clustering.h
@@ -40,6 +40,8 @@ public:
   std::unordered_set<unsigned> unassigned;
 
   clustering(const input& input, CLUSTERING_T t, INIT_T i, double c);
+
+  friend bool operator<(const clustering& lhs, const clustering& rhs);
 };
 
 #endif

--- a/src/problems/tsp/tsp.cpp
+++ b/src/problems/tsp/tsp.cpp
@@ -25,7 +25,9 @@ tsp::tsp(const input& input,
   std::transform(_job_ranks.cbegin(),
                  _job_ranks.cend(),
                  std::back_inserter(matrix_ranks),
-                 [&](const auto& r) { return _input._jobs[r].index(); });
+                 [&](const auto& r) {
+                   return _input._jobs[r].location.index();
+                 });
 
   if (_has_start) {
     // Add start and remember rank in _matrix.
@@ -326,7 +328,7 @@ solution tsp::solve(unsigned nb_threads) const {
   for (auto job = job_start; job != job_end; ++job) {
     auto current_rank = _job_ranks[*job];
     steps.emplace_back(TYPE::JOB,
-                       _input._jobs[current_rank],
+                       _input._jobs[current_rank].location,
                        _input._jobs[current_rank].id);
   }
   // Handle end.

--- a/src/problems/tsp/tsp.cpp
+++ b/src/problems/tsp/tsp.cpp
@@ -25,9 +25,7 @@ tsp::tsp(const input& input,
   std::transform(_job_ranks.cbegin(),
                  _job_ranks.cend(),
                  std::back_inserter(matrix_ranks),
-                 [&](const auto& r) {
-                   return _input._jobs[r].location.index();
-                 });
+                 [&](const auto& r) { return _input._jobs[r].index(); });
 
   if (_has_start) {
     // Add start and remember rank in _matrix.

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -12,6 +12,7 @@ All rights reserved (see LICENSE).
 
 #include <limits>
 #include <string>
+#include <unordered_set>
 
 #include <boost/log/trivial.hpp>
 #include <boost/optional.hpp>
@@ -29,6 +30,7 @@ using skill_t = uint32_t;
 // Type helpers.
 using coords_t = std::array<coordinate_t, 2>;
 using optional_coords_t = boost::optional<coords_t>;
+using skills_t = std::unordered_set<skill_t>;
 
 // Setting max value would cause trouble with further additions.
 constexpr cost_t INFINITE_COST = 3 * (std::numeric_limits<cost_t>::max() / 4);

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -57,9 +57,6 @@ struct cl_args_t {
   }
 };
 
-// Problem types.
-enum class PROBLEM_T { TSP, CVRP };
-
 // Available location status.
 enum class TYPE { START, JOB, END };
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -33,13 +33,13 @@ void input::add_job(const job_t& job) {
     }
   }
 
-  if (!current_job.user_index()) {
+  if (!current_job.location.user_index()) {
     // Index of this job in the matrix was not specified upon job
     // creation, using current number of locations.
-    current_job.set_index(_locations.size());
+    current_job.location.set_index(_locations.size());
   }
 
-  _locations.push_back(current_job);
+  _locations.push_back(current_job.location);
 }
 
 void input::add_vehicle(const vehicle_t& vehicle) {

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -68,8 +68,9 @@ void input::add_vehicle(const vehicle_t& vehicle) {
       // vehicle creation, using current number of locations.
       assert(current_v.start.get().has_coordinates());
       current_v.start.get().set_index(_locations.size());
-      _locations.push_back(current_v.start.get());
     }
+
+    _locations.push_back(current_v.start.get());
   }
 
   if (has_end) {
@@ -77,17 +78,10 @@ void input::add_vehicle(const vehicle_t& vehicle) {
       // Index of this end in the matrix was not specified upon
       // vehicle creation, using current number of locations.
       assert(current_v.end.get().has_coordinates());
-
-      if (has_start and !current_v.start.get().user_index() and
-          current_v.start.get().lon() == current_v.end.get().lon() and
-          current_v.start.get().lat() == current_v.end.get().lat()) {
-        // Avoiding duplicate for start/end identical locations.
-        current_v.end.get().set_index(_locations.size() - 1);
-      } else {
-        current_v.end.get().set_index(_locations.size());
-        _locations.push_back(current_v.end.get());
-      }
+      current_v.end.get().set_index(_locations.size());
     }
+
+    _locations.push_back(current_v.end.get());
   }
 }
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -13,7 +13,6 @@ All rights reserved (see LICENSE).
 input::input(std::unique_ptr<routing_io<cost_t>> routing_wrapper, bool geometry)
   : _start_loading(std::chrono::high_resolution_clock::now()),
     _routing_wrapper(std::move(routing_wrapper)),
-    _has_capacity(false),
     _geometry(geometry) {
 }
 
@@ -96,7 +95,6 @@ void input::check_amount_size(unsigned size) {
   if (_locations.empty()) {
     // Updating real value on first call.
     _amount_size = size;
-    _has_capacity = true;
   } else {
     // Checking consistency for amount/capacity input lengths.
     if (size != _amount_size) {
@@ -193,25 +191,8 @@ void input::set_vehicle_to_job_compatibility() {
   }
 }
 
-PROBLEM_T input::get_problem_type() const {
-  PROBLEM_T problem_type = PROBLEM_T::TSP;
-  if (_has_capacity) {
-    problem_type = PROBLEM_T::CVRP;
-  }
-  return problem_type;
-}
-
 std::unique_ptr<vrp> input::get_problem() const {
-  auto problem_type = this->get_problem_type();
-
-  if (problem_type == PROBLEM_T::CVRP) {
-    return std::make_unique<cvrp>(*this);
-  } else {
-    std::vector<index_t> job_ranks(_jobs.size());
-    std::iota(job_ranks.begin(), job_ranks.end(), 0);
-
-    return std::make_unique<tsp>(*this, job_ranks, 0);
-  }
+  return std::make_unique<cvrp>(*this);
 }
 
 solution input::solve(unsigned nb_thread) {

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -22,6 +22,9 @@ void input::add_job(const job_t& job) {
 
   auto& current_job = _jobs.back();
 
+  // Ensure amount size consistency.
+  this->check_amount_size(current_job.amount.size());
+
   // Ensure that skills are either always or never provided.
   if (_locations.empty()) {
     _has_skills = !current_job.skills.empty();
@@ -38,16 +41,15 @@ void input::add_job(const job_t& job) {
   }
 
   _locations.push_back(current_job);
-
-  if (current_job.has_amount()) {
-    this->check_amount_size(current_job.amount.get().size());
-  }
 }
 
 void input::add_vehicle(const vehicle_t& vehicle) {
   _vehicles.push_back(vehicle);
 
   auto& current_v = _vehicles.back();
+
+  // Ensure amount size consistency.
+  this->check_amount_size(current_v.capacity.size());
 
   // Ensure that skills are either always or never provided.
   if (_locations.empty()) {
@@ -88,24 +90,20 @@ void input::add_vehicle(const vehicle_t& vehicle) {
       }
     }
   }
-
-  if (current_v.has_capacity()) {
-    this->check_amount_size(current_v.capacity.get().size());
-  }
 }
 
 void input::check_amount_size(unsigned size) {
-  if (_amount_size) {
+  if (_locations.empty()) {
+    // Updating real value on first call.
+    _amount_size = size;
+    _has_capacity = true;
+  } else {
     // Checking consistency for amount/capacity input lengths.
-    if (size != _amount_size.get()) {
+    if (size != _amount_size) {
       throw custom_exception("Inconsistent amount/capacity lengths: " +
                              std::to_string(size) + " and " +
-                             std::to_string(_amount_size.get()) + '.');
+                             std::to_string(_amount_size) + '.');
     }
-  } else {
-    // Updating real value on first call.
-    _amount_size = boost::make_optional(size);
-    _has_capacity = true;
   }
 }
 

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -50,7 +50,7 @@ private:
   const bool _geometry;
   matrix<cost_t> _matrix;
   std::vector<location_t> _locations;
-  boost::optional<unsigned> _amount_size;
+  unsigned _amount_size;
   std::vector<std::vector<bool>> _vehicle_to_job_compatibility;
   void check_amount_size(unsigned size);
   std::unique_ptr<vrp> get_problem() const;

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -45,7 +45,6 @@ private:
   std::chrono::high_resolution_clock::time_point _end_solving;
   std::chrono::high_resolution_clock::time_point _end_routing;
   std::unique_ptr<routing_io<cost_t>> _routing_wrapper;
-  bool _has_capacity;
   bool _has_skills;
   const bool _geometry;
   matrix<cost_t> _matrix;
@@ -72,8 +71,6 @@ public:
   const matrix<cost_t>& get_matrix() const;
 
   matrix<cost_t> get_sub_matrix(const std::vector<index_t>& indices) const;
-
-  PROBLEM_T get_problem_type() const;
 
   solution solve(unsigned nb_thread);
 

--- a/src/structures/vroom/job.cpp
+++ b/src/structures/vroom/job.cpp
@@ -10,17 +10,13 @@ All rights reserved (see LICENSE).
 #include "job.h"
 
 job_t::job_t(ID_t id, index_t index)
-  : job_t(id, boost::none, std::unordered_set<skill_t>(), index) {
+  : job_t(id, amount_t(0), std::unordered_set<skill_t>(), index) {
 }
 
 job_t::job_t(ID_t id, index_t index, const coords_t& coords)
-  : job_t(id, boost::none, std::unordered_set<skill_t>(), index, coords) {
+  : job_t(id, amount_t(0), std::unordered_set<skill_t>(), index, coords) {
 }
 
 job_t::job_t(ID_t id, const coords_t& coords)
-  : job_t(id, boost::none, std::unordered_set<skill_t>(), coords) {
-}
-
-bool job_t::has_amount() const {
-  return amount != boost::none;
+  : job_t(id, amount_t(0), std::unordered_set<skill_t>(), coords) {
 }

--- a/src/structures/vroom/job.cpp
+++ b/src/structures/vroom/job.cpp
@@ -10,7 +10,7 @@ All rights reserved (see LICENSE).
 #include "job.h"
 
 job_t::job_t(ID_t id,
-             location_t location,
+             const location_t& location,
              const amount_t& amount,
              const std::unordered_set<skill_t>& skills)
   : id(id), location(location), amount(amount), skills(skills) {

--- a/src/structures/vroom/job.cpp
+++ b/src/structures/vroom/job.cpp
@@ -9,14 +9,13 @@ All rights reserved (see LICENSE).
 
 #include "job.h"
 
-job_t::job_t(ID_t id, index_t index)
-  : job_t(id, amount_t(0), std::unordered_set<skill_t>(), index) {
+job_t::job_t(ID_t id,
+             location_t location,
+             const amount_t& amount,
+             const std::unordered_set<skill_t>& skills)
+  : id(id), location(location), amount(amount), skills(skills) {
 }
 
-job_t::job_t(ID_t id, index_t index, const coords_t& coords)
-  : job_t(id, amount_t(0), std::unordered_set<skill_t>(), index, coords) {
-}
-
-job_t::job_t(ID_t id, const coords_t& coords)
-  : job_t(id, amount_t(0), std::unordered_set<skill_t>(), coords) {
+index_t job_t::index() const {
+  return location.index();
 }

--- a/src/structures/vroom/job.h
+++ b/src/structures/vroom/job.h
@@ -18,7 +18,7 @@ All rights reserved (see LICENSE).
 
 struct job_t : public location_t {
   const ID_t id;
-  boost::optional<amount_t> amount;
+  amount_t amount;
   std::unordered_set<skill_t> skills;
 
   job_t(ID_t id, index_t index);
@@ -29,7 +29,7 @@ struct job_t : public location_t {
 
   template <typename... Args>
   job_t(ID_t id,
-        const boost::optional<amount_t>& amount,
+        const amount_t& amount,
         const std::unordered_set<skill_t>& skills,
         Args&&... args)
     : location_t(std::forward<Args>(args)...),
@@ -37,8 +37,6 @@ struct job_t : public location_t {
       amount(amount),
       skills(skills) {
   }
-
-  bool has_amount() const;
 };
 
 #endif

--- a/src/structures/vroom/job.h
+++ b/src/structures/vroom/job.h
@@ -10,8 +10,6 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <unordered_set>
-
 #include "../typedefs.h"
 #include "./amount.h"
 #include "./location.h"
@@ -19,13 +17,13 @@ All rights reserved (see LICENSE).
 struct job_t {
   const ID_t id;
   location_t location;
-  amount_t amount;
-  std::unordered_set<skill_t> skills;
+  const amount_t amount;
+  const skills_t skills;
 
   job_t(ID_t id,
         location_t location,
-        const amount_t& amount,
-        const std::unordered_set<skill_t>& skills);
+        const amount_t& amount = amount_t(0),
+        const skills_t& skills = skills_t());
 
   index_t index() const;
 };

--- a/src/structures/vroom/job.h
+++ b/src/structures/vroom/job.h
@@ -21,7 +21,7 @@ struct job_t {
   const skills_t skills;
 
   job_t(ID_t id,
-        location_t location,
+        const location_t& location,
         const amount_t& amount = amount_t(0),
         const skills_t& skills = skills_t());
 

--- a/src/structures/vroom/job.h
+++ b/src/structures/vroom/job.h
@@ -16,27 +16,18 @@ All rights reserved (see LICENSE).
 #include "./amount.h"
 #include "./location.h"
 
-struct job_t : public location_t {
+struct job_t {
   const ID_t id;
+  location_t location;
   amount_t amount;
   std::unordered_set<skill_t> skills;
 
-  job_t(ID_t id, index_t index);
-
-  job_t(ID_t id, index_t index, const coords_t& coords);
-
-  job_t(ID_t id, const coords_t& coords);
-
-  template <typename... Args>
   job_t(ID_t id,
+        location_t location,
         const amount_t& amount,
-        const std::unordered_set<skill_t>& skills,
-        Args&&... args)
-    : location_t(std::forward<Args>(args)...),
-      id(id),
-      amount(amount),
-      skills(skills) {
-  }
+        const std::unordered_set<skill_t>& skills);
+
+  index_t index() const;
 };
 
 #endif

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -11,12 +11,6 @@ All rights reserved (see LICENSE).
 
 vehicle_t::vehicle_t(ID_t id,
                      const boost::optional<location_t>& start,
-                     const boost::optional<location_t>& end)
-  : vehicle_t(id, start, end, amount_t(0), std::unordered_set<skill_t>()) {
-}
-
-vehicle_t::vehicle_t(ID_t id,
-                     const boost::optional<location_t>& start,
                      const boost::optional<location_t>& end,
                      const amount_t& capacity,
                      const std::unordered_set<skill_t>& skills)

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -12,13 +12,13 @@ All rights reserved (see LICENSE).
 vehicle_t::vehicle_t(ID_t id,
                      const boost::optional<location_t>& start,
                      const boost::optional<location_t>& end)
-  : vehicle_t(id, start, end, boost::none, std::unordered_set<skill_t>()) {
+  : vehicle_t(id, start, end, amount_t(0), std::unordered_set<skill_t>()) {
 }
 
 vehicle_t::vehicle_t(ID_t id,
                      const boost::optional<location_t>& start,
                      const boost::optional<location_t>& end,
-                     const boost::optional<amount_t>& capacity,
+                     const amount_t& capacity,
                      const std::unordered_set<skill_t>& skills)
   : id(id), start(start), end(end), capacity(capacity), skills(skills) {
   if (!static_cast<bool>(start) and !static_cast<bool>(end)) {
@@ -33,8 +33,4 @@ bool vehicle_t::has_start() const {
 
 bool vehicle_t::has_end() const {
   return static_cast<bool>(end);
-}
-
-bool vehicle_t::has_capacity() const {
-  return static_cast<bool>(capacity);
 }

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -10,8 +10,6 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <unordered_set>
-
 #include "../../utils/exceptions.h"
 #include "../typedefs.h"
 #include "./amount.h"
@@ -21,18 +19,14 @@ struct vehicle_t {
   const ID_t id;
   boost::optional<location_t> start;
   boost::optional<location_t> end;
-  amount_t capacity;
-  std::unordered_set<skill_t> skills;
-
-  vehicle_t(ID_t id,
-            const boost::optional<location_t>& start,
-            const boost::optional<location_t>& end);
+  const amount_t capacity;
+  const skills_t skills;
 
   vehicle_t(ID_t id,
             const boost::optional<location_t>& start,
             const boost::optional<location_t>& end,
-            const amount_t& capacity,
-            const std::unordered_set<skill_t>& skills);
+            const amount_t& capacity = amount_t(0),
+            const skills_t& skills = skills_t());
 
   bool has_start() const;
 

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -21,7 +21,7 @@ struct vehicle_t {
   const ID_t id;
   boost::optional<location_t> start;
   boost::optional<location_t> end;
-  boost::optional<amount_t> capacity;
+  amount_t capacity;
   std::unordered_set<skill_t> skills;
 
   vehicle_t(ID_t id,
@@ -31,14 +31,12 @@ struct vehicle_t {
   vehicle_t(ID_t id,
             const boost::optional<location_t>& start,
             const boost::optional<location_t>& end,
-            const boost::optional<amount_t>& capacity,
+            const amount_t& capacity,
             const std::unordered_set<skill_t>& skills);
 
   bool has_start() const;
 
   bool has_end() const;
-
-  bool has_capacity() const;
 };
 
 #endif

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -23,19 +23,17 @@ inline amount_t get_amount(const rapidjson::Value& object, const char* key) {
   // Default to empty amount.
   amount_t amount(0);
 
-  if (!object.HasMember(key)) {
-    return amount;
-  }
-
-  if (!object[key].IsArray()) {
-    throw custom_exception("Invalid " + std::string(key) + " array.");
-  }
-
-  for (rapidjson::SizeType i = 0; i < object[key].Size(); ++i) {
-    if (!object[key][i].IsInt64()) {
-      throw custom_exception("Invalid " + std::string(key) + " value.");
+  if (object.HasMember(key)) {
+    if (!object[key].IsArray()) {
+      throw custom_exception("Invalid " + std::string(key) + " array.");
     }
-    amount.push_back(object[key][i].GetInt64());
+
+    for (rapidjson::SizeType i = 0; i < object[key].Size(); ++i) {
+      if (!object[key][i].IsInt64()) {
+        throw custom_exception("Invalid " + std::string(key) + " value.");
+      }
+      amount.push_back(object[key][i].GetInt64());
+    }
   }
 
   return amount;

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -19,16 +19,18 @@ parse_coordinates(const rapidjson::Value& object, const char* key) {
   return {object[key][0].GetDouble(), object[key][1].GetDouble()};
 }
 
-inline boost::optional<amount_t> get_amount(const rapidjson::Value& object,
-                                            const char* key) {
+inline amount_t get_amount(const rapidjson::Value& object, const char* key) {
+  // Default to empty amount.
+  amount_t amount(0);
+
   if (!object.HasMember(key)) {
-    return boost::none;
+    return amount;
   }
 
   if (!object[key].IsArray()) {
     throw custom_exception("Invalid " + std::string(key) + " array.");
   }
-  amount_t amount;
+
   for (rapidjson::SizeType i = 0; i < object[key].Size(); ++i) {
     if (!object[key][i].IsInt64()) {
       throw custom_exception("Invalid " + std::string(key) + " value.");

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -231,19 +231,19 @@ input parse(const cl_args_t& cl_args) {
                                std::to_string(j_id) + ".");
       }
 
+      auto job_loc_index = json_job["location_index"].GetUint();
+      location_t job_loc(job_loc_index);
+
       if (json_job.HasMember("location")) {
-        job_t current_job(j_id,
-                          parse_coordinates(json_job, "location"),
-                          get_amount(json_job, "amount"),
-                          get_skills(json_job));
-        input_data.add_job(current_job);
-      } else {
-        job_t current_job(json_job["id"].GetUint64(),
-                          json_job["location_index"].GetUint(),
-                          get_amount(json_job, "amount"),
-                          get_skills(json_job));
-        input_data.add_job(current_job);
+        job_loc =
+          location_t(job_loc_index, parse_coordinates(json_job, "location"));
       }
+
+      job_t current_job(j_id,
+                        job_loc,
+                        get_amount(json_job, "amount"),
+                        get_skills(json_job));
+      input_data.add_job(current_job);
     }
   } else {
     // Adding vehicles and jobs only, matrix will be computed using

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -10,8 +10,8 @@ All rights reserved (see LICENSE).
 #include "./input_parser.h"
 
 // Helper to get optional array of coordinates.
-inline std::array<coordinate_t, 2>
-parse_coordinates(const rapidjson::Value& object, const char* key) {
+inline coords_t parse_coordinates(const rapidjson::Value& object,
+                                  const char* key) {
   if (!object[key].IsArray() or (object[key].Size() < 2) or
       !object[key][0].IsNumber() or !object[key][1].IsNumber()) {
     throw custom_exception("Invalid " + std::string(key) + " array.");
@@ -233,16 +233,15 @@ input parse(const cl_args_t& cl_args) {
 
       if (json_job.HasMember("location")) {
         job_t current_job(j_id,
+                          parse_coordinates(json_job, "location"),
                           get_amount(json_job, "amount"),
-                          get_skills(json_job),
-                          json_job["location_index"].GetUint(),
-                          parse_coordinates(json_job, "location"));
+                          get_skills(json_job));
         input_data.add_job(current_job);
       } else {
         job_t current_job(json_job["id"].GetUint64(),
+                          json_job["location_index"].GetUint(),
                           get_amount(json_job, "amount"),
-                          get_skills(json_job),
-                          json_job["location_index"].GetUint());
+                          get_skills(json_job));
         input_data.add_job(current_job);
       }
     }
@@ -302,9 +301,9 @@ input parse(const cl_args_t& cl_args) {
       }
 
       job_t current_job(j_id,
+                        parse_coordinates(json_job, "location"),
                         get_amount(json_job, "amount"),
-                        get_skills(json_job),
-                        parse_coordinates(json_job, "location"));
+                        get_skills(json_job));
 
       input_data.add_job(current_job);
     }

--- a/src/utils/output_json.cpp
+++ b/src/utils/output_json.cpp
@@ -27,8 +27,10 @@ rapidjson::Document to_json(const solution& sol, bool geometry) {
     for (const auto& job : sol.unassigned) {
       rapidjson::Value json_job(rapidjson::kObjectType);
       json_job.AddMember("id", job.id, allocator);
-      if (job.has_coordinates()) {
-        json_job.AddMember("location", to_json(job, allocator), allocator);
+      if (job.location.has_coordinates()) {
+        json_job.AddMember("location",
+                           to_json(job.location, allocator),
+                           allocator);
       }
       json_unassigned.PushBack(json_job, allocator);
     }


### PR DESCRIPTION
## Issue

#97 

## Tasks

 - [x] Handle default values for `capacity` and `amount`
 - [x] ~~Make `capacity` and `amount` non-optional for jobs and vehicles~~ Add default values in `job`/`vehicle` ctor
 - [x] default to using the CVRP approach, even with a single vehicle
 - [x] consider number of non-empty clusters when picking the best clustering
 - [x] review
