### PR TITLE
Refactor/includes

### DIFF
--- a/src/algorithms/kruskal.cpp
+++ b/src/algorithms/kruskal.cpp
@@ -7,6 +7,13 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+#include "../structures/typedefs.h"
+#include "../structures/abstract/edge.h"
+
 #include "./kruskal.h"
 
 template <class T>

--- a/src/algorithms/kruskal.cpp
+++ b/src/algorithms/kruskal.cpp
@@ -11,10 +11,10 @@ All rights reserved (see LICENSE).
 #include <numeric>
 #include <vector>
 
-#include "../structures/typedefs.h"
-#include "../structures/abstract/edge.h"
+#include "structures/typedefs.h"
+#include "structures/abstract/edge.h"
 
-#include "./kruskal.h"
+#include "algorithms/kruskal.h"
 
 template <class T>
 undirected_graph<T> minimum_spanning_tree(const undirected_graph<T>& graph) {

--- a/src/algorithms/kruskal.h
+++ b/src/algorithms/kruskal.h
@@ -10,7 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "../structures/abstract/undirected_graph.h"
+#include "structures/abstract/undirected_graph.h"
 
 template <class T>
 undirected_graph<T> minimum_spanning_tree(const undirected_graph<T>& graph);

--- a/src/algorithms/kruskal.h
+++ b/src/algorithms/kruskal.h
@@ -10,13 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <algorithm>
-#include <numeric>
-#include <vector>
-
-#include "../structures/abstract/edge.h"
 #include "../structures/abstract/undirected_graph.h"
-#include "../structures/typedefs.h"
 
 template <class T>
 undirected_graph<T> minimum_spanning_tree(const undirected_graph<T>& graph);

--- a/src/algorithms/munkres.cpp
+++ b/src/algorithms/munkres.cpp
@@ -7,6 +7,13 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <cassert>
+#include <limits>
+#include <list>
+#include <set>
+
+#include "../structures/abstract/edge.h"
+
 #include "./munkres.h"
 
 template <class T>

--- a/src/algorithms/munkres.cpp
+++ b/src/algorithms/munkres.cpp
@@ -12,9 +12,9 @@ All rights reserved (see LICENSE).
 #include <list>
 #include <set>
 
-#include "../structures/abstract/edge.h"
+#include "structures/abstract/edge.h"
 
-#include "./munkres.h"
+#include "algorithms/munkres.h"
 
 template <class T>
 std::unordered_map<index_t, index_t>

--- a/src/algorithms/munkres.h
+++ b/src/algorithms/munkres.h
@@ -12,8 +12,8 @@ All rights reserved (see LICENSE).
 
 #include <unordered_map>
 
-#include "../structures/typedefs.h"
-#include "../structures/abstract/matrix.h"
+#include "structures/typedefs.h"
+#include "structures/abstract/matrix.h"
 
 template <class T>
 std::unordered_map<index_t, index_t>

--- a/src/algorithms/munkres.h
+++ b/src/algorithms/munkres.h
@@ -10,13 +10,9 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <cassert>
-#include <limits>
-#include <list>
-#include <set>
 #include <unordered_map>
 
-#include "../structures/abstract/edge.h"
+#include "../structures/typedefs.h"
 #include "../structures/abstract/matrix.h"
 
 template <class T>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@ All rights reserved (see LICENSE).
 
 #include "./problems/vrp.h"
 #include "./structures/typedefs.h"
+#include "./structures/cl_args.h"
 #include "./structures/vroom/input/input.h"
 #include "./utils/input_parser.h"
 #include "./utils/output_json.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,13 +17,13 @@ All rights reserved (see LICENSE).
 #include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/log/utility/setup/console.hpp>
 
-#include "./problems/vrp.h"
-#include "./structures/typedefs.h"
-#include "./structures/cl_args.h"
-#include "./structures/vroom/input/input.h"
-#include "./utils/input_parser.h"
-#include "./utils/output_json.h"
-#include "./utils/version.h"
+#include "problems/vrp.h"
+#include "structures/typedefs.h"
+#include "structures/cl_args.h"
+#include "structures/vroom/input/input.h"
+#include "utils/input_parser.h"
+#include "utils/output_json.h"
+#include "utils/version.h"
 
 void display_usage() {
   std::string usage = "VROOM Copyright (C) 2015-2018, Julien Coupey\n";

--- a/src/makefile
+++ b/src/makefile
@@ -5,7 +5,7 @@
 
 # Variables.
 CXX ?= g++
-CXXFLAGS = -MMD -MP -std=c++14 -Wextra -Wpedantic -Wall -O3 -DBOOST_LOG_DYN_LINK
+CXXFLAGS = -MMD -MP -I. -std=c++14 -Wextra -Wpedantic -Wall -O3 -DBOOST_LOG_DYN_LINK
 LDLIBS = -lboost_system -lboost_log -lboost_log_setup -lpthread -lboost_thread
 
 # Using all cpp files in current directory.

--- a/src/problems/cvrp/cvrp.cpp
+++ b/src/problems/cvrp/cvrp.cpp
@@ -7,6 +7,13 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <mutex>
+#include <thread>
+#include <boost/log/trivial.hpp>
+
+#include "../tsp/tsp.h"
+#include "./heuristics/clustering.h"
+
 #include "cvrp.h"
 #include "../../structures/vroom/input/input.h"
 

--- a/src/problems/cvrp/cvrp.cpp
+++ b/src/problems/cvrp/cvrp.cpp
@@ -11,11 +11,11 @@ All rights reserved (see LICENSE).
 #include <thread>
 #include <boost/log/trivial.hpp>
 
-#include "../tsp/tsp.h"
-#include "./heuristics/clustering.h"
+#include "problems/tsp/tsp.h"
+#include "problems/cvrp/heuristics/clustering.h"
 
-#include "cvrp.h"
-#include "../../structures/vroom/input/input.h"
+#include "problems/cvrp/cvrp.h"
+#include "structures/vroom/input/input.h"
 
 cvrp::cvrp(const input& input) : vrp(input) {
 }

--- a/src/problems/cvrp/cvrp.h
+++ b/src/problems/cvrp/cvrp.h
@@ -10,7 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "../vrp.h"
+#include "problems/vrp.h"
 
 class cvrp : public vrp {
 private:

--- a/src/problems/cvrp/cvrp.h
+++ b/src/problems/cvrp/cvrp.h
@@ -10,12 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <mutex>
-#include <thread>
-
-#include "../tsp/tsp.h"
 #include "../vrp.h"
-#include "./heuristics/clustering.h"
 
 class cvrp : public vrp {
 private:

--- a/src/problems/cvrp/heuristics/clustering.cpp
+++ b/src/problems/cvrp/heuristics/clustering.cpp
@@ -6,6 +6,9 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <algorithm>
+#include <unordered_set>
+
 #include "clustering.h"
 #include <boost/log/trivial.hpp>
 

--- a/src/problems/cvrp/heuristics/clustering.cpp
+++ b/src/problems/cvrp/heuristics/clustering.cpp
@@ -7,6 +7,7 @@ All rights reserved (see LICENSE).
 */
 
 #include "clustering.h"
+#include <boost/log/trivial.hpp>
 
 clustering::clustering(const input& input, CLUSTERING_T t, INIT_T i, double c)
   : input_ref(input),

--- a/src/problems/cvrp/heuristics/clustering.cpp
+++ b/src/problems/cvrp/heuristics/clustering.cpp
@@ -9,7 +9,7 @@ All rights reserved (see LICENSE).
 #include <algorithm>
 #include <unordered_set>
 
-#include "clustering.h"
+#include "problems/cvrp/heuristics/clustering.h"
 #include <boost/log/trivial.hpp>
 
 clustering::clustering(const input& input, CLUSTERING_T t, INIT_T i, double c)

--- a/src/problems/cvrp/heuristics/clustering.h
+++ b/src/problems/cvrp/heuristics/clustering.h
@@ -10,8 +10,6 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <algorithm>
-#include <unordered_set>
 #include <vector>
 
 #include "../../../structures/vroom/amount.h"

--- a/src/problems/cvrp/heuristics/clustering.h
+++ b/src/problems/cvrp/heuristics/clustering.h
@@ -12,9 +12,9 @@ All rights reserved (see LICENSE).
 
 #include <vector>
 
-#include "../../../structures/vroom/amount.h"
-#include "../../../structures/vroom/input/input.h"
-#include "../../../structures/vroom/job.h"
+#include "structures/vroom/amount.h"
+#include "structures/vroom/input/input.h"
+#include "structures/vroom/job.h"
 
 // Clustering types.
 enum class CLUSTERING_T { PARALLEL, SEQUENTIAL };

--- a/src/problems/tsp/heuristics/christofides.cpp
+++ b/src/problems/tsp/heuristics/christofides.cpp
@@ -13,10 +13,10 @@ All rights reserved (see LICENSE).
 #include <set>
 
 
-#include "../../../algorithms/kruskal.h"
-#include "../../../algorithms/munkres.h"
+#include "algorithms/kruskal.h"
+#include "algorithms/munkres.h"
 
-#include "christofides.h"
+#include "problems/tsp/heuristics/christofides.h"
 
 std::list<index_t> christofides(const matrix<cost_t>& sym_matrix) {
   // The eulerian sub-graph further used is made of a minimum spanning

--- a/src/problems/tsp/heuristics/christofides.cpp
+++ b/src/problems/tsp/heuristics/christofides.cpp
@@ -7,6 +7,15 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <boost/log/trivial.hpp>
+#include <chrono>
+#include <random>
+#include <set>
+
+
+#include "../../../algorithms/kruskal.h"
+#include "../../../algorithms/munkres.h"
+
 #include "christofides.h"
 
 std::list<index_t> christofides(const matrix<cost_t>& sym_matrix) {

--- a/src/problems/tsp/heuristics/christofides.h
+++ b/src/problems/tsp/heuristics/christofides.h
@@ -11,8 +11,8 @@ All rights reserved (see LICENSE).
 */
 
 #include <list>
-#include "../../../structures/typedefs.h"
-#include "../../../structures/abstract/matrix.h"
+#include "structures/typedefs.h"
+#include "structures/abstract/matrix.h"
 
 // Implementing a variant of the Christofides heuristic.
 std::list<index_t> christofides(const matrix<cost_t>& sym_matrix);

--- a/src/problems/tsp/heuristics/christofides.h
+++ b/src/problems/tsp/heuristics/christofides.h
@@ -10,13 +10,9 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <chrono>
-#include <random>
-
-#include <boost/log/trivial.hpp>
-
-#include "../../../algorithms/kruskal.h"
-#include "../../../algorithms/munkres.h"
+#include <list>
+#include "../../../structures/typedefs.h"
+#include "../../../structures/abstract/matrix.h"
 
 // Implementing a variant of the Christofides heuristic.
 std::list<index_t> christofides(const matrix<cost_t>& sym_matrix);

--- a/src/problems/tsp/heuristics/local_search.cpp
+++ b/src/problems/tsp/heuristics/local_search.cpp
@@ -12,7 +12,7 @@ All rights reserved (see LICENSE).
 #include <thread>
 #include <boost/log/trivial.hpp>
 
-#include "local_search.h"
+#include "problems/tsp/heuristics/local_search.h"
 
 local_search::local_search(const matrix<cost_t>& matrix,
                            bool is_symmetric_matrix,

--- a/src/problems/tsp/heuristics/local_search.cpp
+++ b/src/problems/tsp/heuristics/local_search.cpp
@@ -7,6 +7,11 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <numeric>
+#include <unordered_map>
+#include <thread>
+#include <boost/log/trivial.hpp>
+
 #include "local_search.h"
 
 local_search::local_search(const matrix<cost_t>& matrix,

--- a/src/problems/tsp/heuristics/local_search.h
+++ b/src/problems/tsp/heuristics/local_search.h
@@ -13,8 +13,8 @@ All rights reserved (see LICENSE).
 #include <list>
 #include <vector>
 
-#include "../../../structures/abstract/matrix.h"
-#include "../../../structures/typedefs.h"
+#include "structures/abstract/matrix.h"
+#include "structures/typedefs.h"
 
 class local_search {
 private:

--- a/src/problems/tsp/heuristics/local_search.h
+++ b/src/problems/tsp/heuristics/local_search.h
@@ -11,12 +11,7 @@ All rights reserved (see LICENSE).
 */
 
 #include <list>
-#include <numeric>
-#include <thread>
-#include <unordered_map>
 #include <vector>
-
-#include <boost/log/trivial.hpp>
 
 #include "../../../structures/abstract/matrix.h"
 #include "../../../structures/typedefs.h"

--- a/src/problems/tsp/tsp.cpp
+++ b/src/problems/tsp/tsp.cpp
@@ -13,12 +13,12 @@ All rights reserved (see LICENSE).
 #include <boost/log/trivial.hpp>
 
 
-#include "../../structures/abstract/undirected_graph.h"
-#include "./heuristics/christofides.h"
-#include "./heuristics/local_search.h"
+#include "structures/abstract/undirected_graph.h"
+#include "problems/tsp/heuristics/christofides.h"
+#include "problems/tsp/heuristics/local_search.h"
 
 #include "tsp.h"
-#include "../../structures/vroom/input/input.h"
+#include "structures/vroom/input/input.h"
 
 tsp::tsp(const input& input,
          std::vector<index_t> job_ranks,

--- a/src/problems/tsp/tsp.cpp
+++ b/src/problems/tsp/tsp.cpp
@@ -6,6 +6,16 @@ Copyright (c) 2015-2018, Julien Coupey.
 All rights reserved (see LICENSE).
 
 */
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <boost/log/trivial.hpp>
+
+
+#include "../../structures/abstract/undirected_graph.h"
+#include "./heuristics/christofides.h"
+#include "./heuristics/local_search.h"
 
 #include "tsp.h"
 #include "../../structures/vroom/input/input.h"

--- a/src/problems/tsp/tsp.h
+++ b/src/problems/tsp/tsp.h
@@ -10,10 +10,10 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "../../structures/typedefs.h"
-#include "../../structures/abstract/matrix.h"
+#include "structures/typedefs.h"
+#include "structures/abstract/matrix.h"
 
-#include "../vrp.h"
+#include "problems/vrp.h"
 
 class tsp : public vrp {
 private:

--- a/src/problems/tsp/tsp.h
+++ b/src/problems/tsp/tsp.h
@@ -10,15 +10,10 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <fstream>
-#include <iomanip>
-#include <iostream>
-#include <string>
+#include "../../structures/typedefs.h"
+#include "../../structures/abstract/matrix.h"
 
-#include "../../structures/abstract/undirected_graph.h"
 #include "../vrp.h"
-#include "./heuristics/christofides.h"
-#include "./heuristics/local_search.h"
 
 class tsp : public vrp {
 private:

--- a/src/problems/vrp.cpp
+++ b/src/problems/vrp.cpp
@@ -7,8 +7,8 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "vrp.h"
-#include "../structures/vroom/input/input.h"
+#include "problems/vrp.h"
+#include "structures/vroom/input/input.h"
 
 vrp::vrp(const input& input) : _input(input) {
   assert(_input._vehicles.size() > 0);

--- a/src/problems/vrp.h
+++ b/src/problems/vrp.h
@@ -10,7 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "../structures/typedefs.h"
+#include "structures/typedefs.h"
 
 class input;
 

--- a/src/routing/libosrm_wrapper.cpp
+++ b/src/routing/libosrm_wrapper.cpp
@@ -7,6 +7,12 @@ All rights reserved (see LICENSE).
 
 */
 
+#include "osrm/coordinate.hpp"
+#include "osrm/json_container.hpp"
+#include "osrm/route_parameters.hpp"
+#include "osrm/status.hpp"
+#include "osrm/table_parameters.hpp"
+
 #include "./libosrm_wrapper.h"
 
 libosrm_wrapper::libosrm_wrapper(const std::string& osrm_profile)

--- a/src/routing/libosrm_wrapper.cpp
+++ b/src/routing/libosrm_wrapper.cpp
@@ -13,7 +13,7 @@ All rights reserved (see LICENSE).
 #include "osrm/status.hpp"
 #include "osrm/table_parameters.hpp"
 
-#include "./libosrm_wrapper.h"
+#include "routing/libosrm_wrapper.h"
 
 libosrm_wrapper::libosrm_wrapper(const std::string& osrm_profile)
   : osrm_wrapper(osrm_profile), _config(), _osrm(_config) {

--- a/src/routing/libosrm_wrapper.h
+++ b/src/routing/libosrm_wrapper.h
@@ -13,7 +13,7 @@ All rights reserved (see LICENSE).
 #include "osrm/osrm.hpp"
 #include "osrm/engine_config.hpp"
 
-#include "./osrm_wrapper.h"
+#include "routing/osrm_wrapper.h"
 
 class libosrm_wrapper : public osrm_wrapper {
 

--- a/src/routing/libosrm_wrapper.h
+++ b/src/routing/libosrm_wrapper.h
@@ -10,13 +10,8 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "osrm/coordinate.hpp"
-#include "osrm/engine_config.hpp"
-#include "osrm/json_container.hpp"
 #include "osrm/osrm.hpp"
-#include "osrm/route_parameters.hpp"
-#include "osrm/status.hpp"
-#include "osrm/table_parameters.hpp"
+#include "osrm/engine_config.hpp"
 
 #include "./osrm_wrapper.h"
 

--- a/src/routing/osrm_wrapper.h
+++ b/src/routing/osrm_wrapper.h
@@ -12,9 +12,9 @@ All rights reserved (see LICENSE).
 
 #include <vector>
 
-#include "../structures/abstract/matrix.h"
-#include "../utils/exceptions.h"
-#include "./routing_io.h"
+#include "structures/abstract/matrix.h"
+#include "utils/exceptions.h"
+#include "routing/routing_io.h"
 
 class osrm_wrapper : public routing_io<cost_t> {
 

--- a/src/routing/osrm_wrapper.h
+++ b/src/routing/osrm_wrapper.h
@@ -12,7 +12,6 @@ All rights reserved (see LICENSE).
 
 #include <vector>
 
-#include "../../include/rapidjson/error/en.h"
 #include "../structures/abstract/matrix.h"
 #include "../utils/exceptions.h"
 #include "./routing_io.h"

--- a/src/routing/routed_wrapper.cpp
+++ b/src/routing/routed_wrapper.cpp
@@ -9,10 +9,10 @@ All rights reserved (see LICENSE).
 #include <boost/asio.hpp>
 using boost::asio::ip::tcp;
 
-#include "../../include/rapidjson/document.h"
-#include "../../include/rapidjson/error/en.h"
+#include "../include/rapidjson/document.h"
+#include "../include/rapidjson/error/en.h"
 
-#include "./routed_wrapper.h"
+#include "routing/routed_wrapper.h"
 
 routed_wrapper::routed_wrapper(const std::string& address,
                                const std::string& port,

--- a/src/routing/routed_wrapper.cpp
+++ b/src/routing/routed_wrapper.cpp
@@ -6,6 +6,11 @@ Copyright (c) 2015-2018, Julien Coupey.
 All rights reserved (see LICENSE).
 
 */
+#include <boost/asio.hpp>
+using boost::asio::ip::tcp;
+
+#include "../../include/rapidjson/document.h"
+#include "../../include/rapidjson/error/en.h"
 
 #include "./routed_wrapper.h"
 

--- a/src/routing/routed_wrapper.h
+++ b/src/routing/routed_wrapper.h
@@ -10,11 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <boost/asio.hpp>
-
 #include "./osrm_wrapper.h"
-
-using boost::asio::ip::tcp;
 
 class routed_wrapper : public osrm_wrapper {
 

--- a/src/routing/routed_wrapper.h
+++ b/src/routing/routed_wrapper.h
@@ -10,7 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "./osrm_wrapper.h"
+#include "routing/osrm_wrapper.h"
 
 class routed_wrapper : public osrm_wrapper {
 

--- a/src/routing/routing_io.h
+++ b/src/routing/routing_io.h
@@ -10,11 +10,8 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <list>
-#include <string>
 #include <vector>
 
-#include "../../include/rapidjson/document.h"
 #include "../structures/abstract/matrix.h"
 #include "../structures/vroom/location.h"
 #include "../structures/vroom/solution/route.h"

--- a/src/routing/routing_io.h
+++ b/src/routing/routing_io.h
@@ -12,9 +12,9 @@ All rights reserved (see LICENSE).
 
 #include <vector>
 
-#include "../structures/abstract/matrix.h"
-#include "../structures/vroom/location.h"
-#include "../structures/vroom/solution/route.h"
+#include "structures/abstract/matrix.h"
+#include "structures/vroom/location.h"
+#include "structures/vroom/solution/route.h"
 
 template <class T> class routing_io {
 

--- a/src/structures/abstract/edge.cpp
+++ b/src/structures/abstract/edge.cpp
@@ -6,6 +6,7 @@ Copyright (c) 2015-2018, Julien Coupey.
 All rights reserved (see LICENSE).
 
 */
+#include <algorithm>
 
 #include "edge.h"
 

--- a/src/structures/abstract/edge.cpp
+++ b/src/structures/abstract/edge.cpp
@@ -8,7 +8,7 @@ All rights reserved (see LICENSE).
 */
 #include <algorithm>
 
-#include "edge.h"
+#include "structures/abstract/edge.h"
 
 template <class T>
 edge<T>::edge(index_t first_vertex, index_t second_vertex, T weight)

--- a/src/structures/abstract/edge.h
+++ b/src/structures/abstract/edge.h
@@ -10,7 +10,6 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <algorithm>
 
 #include "../typedefs.h"
 

--- a/src/structures/abstract/edge.h
+++ b/src/structures/abstract/edge.h
@@ -11,7 +11,7 @@ All rights reserved (see LICENSE).
 */
 
 
-#include "../typedefs.h"
+#include "structures/typedefs.h"
 
 template <class T> class edge {
 

--- a/src/structures/abstract/matrix.cpp
+++ b/src/structures/abstract/matrix.cpp
@@ -7,7 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "matrix.h"
+#include "structures/abstract/matrix.h"
 
 template <class T> line<T>::line(std::size_t n) : parent(n) {
 }

--- a/src/structures/abstract/matrix.h
+++ b/src/structures/abstract/matrix.h
@@ -13,7 +13,7 @@ All rights reserved (see LICENSE).
 #include <initializer_list>
 #include <vector>
 
-#include "../typedefs.h"
+#include "structures/typedefs.h"
 
 template <class T> class line : private std::vector<T> {
 

--- a/src/structures/abstract/undirected_graph.cpp
+++ b/src/structures/abstract/undirected_graph.cpp
@@ -8,7 +8,7 @@ All rights reserved (see LICENSE).
 */
 #include <cassert>
 
-#include "undirected_graph.h"
+#include "structures/abstract/undirected_graph.h"
 
 template <class T> undirected_graph<T>::undirected_graph() {
 }

--- a/src/structures/abstract/undirected_graph.cpp
+++ b/src/structures/abstract/undirected_graph.cpp
@@ -6,6 +6,7 @@ Copyright (c) 2015-2018, Julien Coupey.
 All rights reserved (see LICENSE).
 
 */
+#include <cassert>
 
 #include "undirected_graph.h"
 

--- a/src/structures/abstract/undirected_graph.h
+++ b/src/structures/abstract/undirected_graph.h
@@ -14,8 +14,8 @@ All rights reserved (see LICENSE).
 #include <unordered_map>
 #include <vector>
 
-#include "edge.h"
-#include "matrix.h"
+#include "structures/abstract/edge.h"
+#include "structures/abstract/matrix.h"
 
 template <class T> class undirected_graph {
 

--- a/src/structures/abstract/undirected_graph.h
+++ b/src/structures/abstract/undirected_graph.h
@@ -10,7 +10,6 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <cassert>
 #include <list>
 #include <unordered_map>
 #include <vector>

--- a/src/structures/cl_args.h
+++ b/src/structures/cl_args.h
@@ -1,0 +1,27 @@
+
+#include <string>
+#include <boost/log/trivial.hpp>
+
+struct cl_args_t {
+  // Listing command-line options.
+  std::string osrm_address;                      // -a
+  bool geometry;                                 // -g
+  std::string input_file;                        // -i
+  std::string output_file;                       // -o
+  std::string osrm_port;                         // -p
+  bool use_libosrm;                              // -l
+  boost::log::trivial::severity_level log_level; // -v
+  std::string input;                             // cl arg
+  unsigned nb_threads;                           // -t
+  std::string osrm_profile;                      // -m
+  // Default values.
+  cl_args_t()
+    : osrm_address("0.0.0.0"),
+      geometry(false),
+      osrm_port("5000"),
+      use_libosrm(false),
+      log_level(boost::log::trivial::error),
+      nb_threads(2),
+      osrm_profile("car") {
+  }
+};

--- a/src/structures/cl_args.h
+++ b/src/structures/cl_args.h
@@ -1,3 +1,14 @@
+#ifndef CLARGS_H
+#define CLARGS_H
+
+/*
+
+This file is part of VROOM.
+
+Copyright (c) 2015-2018, Julien Coupey.
+All rights reserved (see LICENSE).
+
+*/
 
 #include <string>
 #include <boost/log/trivial.hpp>
@@ -25,3 +36,5 @@ struct cl_args_t {
       osrm_profile("car") {
   }
 };
+
+#endif

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -12,11 +12,9 @@ All rights reserved (see LICENSE).
 
 #include <limits>
 #include <list>
-#include <string>
 #include <unordered_set>
 #include <vector>
 
-#include <boost/log/trivial.hpp>
 #include <boost/optional.hpp>
 
 // To easily differentiate variable types.
@@ -37,30 +35,6 @@ using raw_solution = std::vector<std::list<index_t>>;
 
 // Setting max value would cause trouble with further additions.
 constexpr cost_t INFINITE_COST = 3 * (std::numeric_limits<cost_t>::max() / 4);
-
-struct cl_args_t {
-  // Listing command-line options.
-  std::string osrm_address;                      // -a
-  bool geometry;                                 // -g
-  std::string input_file;                        // -i
-  std::string output_file;                       // -o
-  std::string osrm_port;                         // -p
-  bool use_libosrm;                              // -l
-  boost::log::trivial::severity_level log_level; // -v
-  std::string input;                             // cl arg
-  unsigned nb_threads;                           // -t
-  std::string osrm_profile;                      // -m
-  // Default values.
-  cl_args_t()
-    : osrm_address("0.0.0.0"),
-      geometry(false),
-      osrm_port("5000"),
-      use_libosrm(false),
-      log_level(boost::log::trivial::error),
-      nb_threads(2),
-      osrm_profile("car") {
-  }
-};
 
 // Available location status.
 enum class TYPE { START, JOB, END };

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -14,6 +14,7 @@ All rights reserved (see LICENSE).
 #include <list>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 #include <boost/log/trivial.hpp>
 #include <boost/optional.hpp>

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -11,6 +11,7 @@ All rights reserved (see LICENSE).
 */
 
 #include <limits>
+#include <array>
 #include <list>
 #include <unordered_set>
 #include <vector>

--- a/src/structures/vroom/amount.cpp
+++ b/src/structures/vroom/amount.cpp
@@ -7,7 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "amount.h"
+#include "structures/vroom/amount.h"
 
 amount_t::amount_t() : parent() {
 }

--- a/src/structures/vroom/amount.h
+++ b/src/structures/vroom/amount.h
@@ -12,7 +12,7 @@ All rights reserved (see LICENSE).
 
 #include <vector>
 
-#include "../typedefs.h"
+#include "structures/typedefs.h"
 
 class amount_t : private std::vector<capacity_t> {
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -6,6 +6,18 @@ Copyright (c) 2015-2018, Julien Coupey.
 All rights reserved (see LICENSE).
 
 */
+#include <array>
+
+#include <boost/optional.hpp>
+
+#include "../../../problems/cvrp/cvrp.h"
+#include "../../../problems/tsp/tsp.h"
+
+#include "../../../routing/routed_wrapper.h"
+
+#if LIBOSRM
+#include "../../../routing/libosrm_wrapper.h"
+#endif
 
 #include "./input.h"
 #include "../../../problems/vrp.h"

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -9,6 +9,8 @@ All rights reserved (see LICENSE).
 #include <array>
 
 #include <boost/optional.hpp>
+#include <boost/log/trivial.hpp>
+
 
 #include "../../../problems/cvrp/cvrp.h"
 #include "../../../problems/tsp/tsp.h"

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -12,17 +12,17 @@ All rights reserved (see LICENSE).
 #include <boost/log/trivial.hpp>
 
 
-#include "../../../problems/cvrp/cvrp.h"
-#include "../../../problems/tsp/tsp.h"
+#include "problems/cvrp/cvrp.h"
+#include "problems/tsp/tsp.h"
 
-#include "../../../routing/routed_wrapper.h"
+#include "routing/routed_wrapper.h"
 
 #if LIBOSRM
-#include "../../../routing/libosrm_wrapper.h"
+#include "routing/libosrm_wrapper.h"
 #endif
 
-#include "./input.h"
-#include "../../../problems/vrp.h"
+#include "structures/vroom/input/input.h"
+#include "problems/vrp.h"
 
 input::input(std::unique_ptr<routing_io<cost_t>> routing_wrapper, bool geometry)
   : _start_loading(std::chrono::high_resolution_clock::now()),

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -10,17 +10,12 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <array>
 #include <chrono>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <memory>
 
-#include <boost/optional.hpp>
-
-#include "../../../problems/cvrp/cvrp.h"
-#include "../../../problems/tsp/tsp.h"
-#include "../../../routing/routed_wrapper.h"
 #include "../../../routing/routing_io.h"
 #include "../../../utils/exceptions.h"
 #include "../../../utils/helpers.h"
@@ -29,9 +24,6 @@ All rights reserved (see LICENSE).
 #include "../job.h"
 #include "../solution/solution.h"
 #include "../vehicle.h"
-#if LIBOSRM
-#include "../../../routing/libosrm_wrapper.h"
-#endif
 
 class vrp;
 

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -16,14 +16,14 @@ All rights reserved (see LICENSE).
 #include <vector>
 #include <memory>
 
-#include "../../../routing/routing_io.h"
-#include "../../../utils/exceptions.h"
-#include "../../../utils/helpers.h"
-#include "../../abstract/matrix.h"
-#include "../../typedefs.h"
-#include "../job.h"
-#include "../solution/solution.h"
-#include "../vehicle.h"
+#include "routing/routing_io.h"
+#include "utils/exceptions.h"
+#include "utils/helpers.h"
+#include "structures/abstract/matrix.h"
+#include "structures/typedefs.h"
+#include "structures/vroom/job.h"
+#include "structures/vroom/solution/solution.h"
+#include "structures/vroom/vehicle.h"
 
 class vrp;
 

--- a/src/structures/vroom/job.cpp
+++ b/src/structures/vroom/job.cpp
@@ -7,7 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "job.h"
+#include "structures/vroom/job.h"
 
 job_t::job_t(ID_t id,
              const location_t& location,

--- a/src/structures/vroom/job.h
+++ b/src/structures/vroom/job.h
@@ -10,9 +10,9 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "../typedefs.h"
-#include "./amount.h"
-#include "./location.h"
+#include "structures/typedefs.h"
+#include "structures/vroom/amount.h"
+#include "structures/vroom/location.h"
 
 struct job_t {
   const ID_t id;

--- a/src/structures/vroom/location.cpp
+++ b/src/structures/vroom/location.cpp
@@ -7,7 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "location.h"
+#include "structures/vroom/location.h"
 
 location_t::location_t(index_t index)
   : _index(index), _coords(boost::none), _user_index(true) {

--- a/src/structures/vroom/location.h
+++ b/src/structures/vroom/location.h
@@ -10,7 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "../typedefs.h"
+#include "structures/typedefs.h"
 
 class location_t {
 private:

--- a/src/structures/vroom/solution/computing_times.cpp
+++ b/src/structures/vroom/solution/computing_times.cpp
@@ -7,7 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "computing_times.h"
+#include "structures/vroom/solution/computing_times.h"
 
 computing_times_t::computing_times_t() : loading(0), solving(0), routing(0) {
 }

--- a/src/structures/vroom/solution/computing_times.h
+++ b/src/structures/vroom/solution/computing_times.h
@@ -10,7 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "../../typedefs.h"
+#include "structures/typedefs.h"
 
 struct computing_times_t {
   // Computing times in milliseconds.

--- a/src/structures/vroom/solution/route.cpp
+++ b/src/structures/vroom/solution/route.cpp
@@ -7,7 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "./route.h"
+#include "structures/vroom/solution/route.h"
 
 route_t::route_t(ID_t vehicle, std::vector<step>&& steps, cost_t cost)
   : vehicle(vehicle),

--- a/src/structures/vroom/solution/route.h
+++ b/src/structures/vroom/solution/route.h
@@ -12,7 +12,7 @@ All rights reserved (see LICENSE).
 
 #include <vector>
 
-#include "./step.h"
+#include "structures/vroom/solution/step.h"
 
 struct route_t {
   const ID_t vehicle;

--- a/src/structures/vroom/solution/solution.cpp
+++ b/src/structures/vroom/solution/solution.cpp
@@ -7,7 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "solution.h"
+#include "structures/vroom/solution/solution.h"
 
 solution::solution(unsigned code, std::string error)
   : code(code), error(error), summary(0, 0) {

--- a/src/structures/vroom/solution/solution.h
+++ b/src/structures/vroom/solution/solution.h
@@ -10,9 +10,9 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "../job.h"
-#include "./route.h"
-#include "./summary.h"
+#include "structures/vroom/job.h"
+#include "structures/vroom/solution/route.h"
+#include "structures/vroom/solution/summary.h"
 
 struct solution {
   unsigned code;

--- a/src/structures/vroom/solution/step.cpp
+++ b/src/structures/vroom/solution/step.cpp
@@ -7,7 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "step.h"
+#include "structures/vroom/solution/step.h"
 
 // Dummy initialization value for unused job id.
 step::step(TYPE type, location_t location)

--- a/src/structures/vroom/solution/step.h
+++ b/src/structures/vroom/solution/step.h
@@ -10,8 +10,8 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "../job.h"
-#include "../location.h"
+#include "structures/vroom/job.h"
+#include "structures/vroom/location.h"
 
 struct step {
   const TYPE type;

--- a/src/structures/vroom/solution/summary.cpp
+++ b/src/structures/vroom/solution/summary.cpp
@@ -7,7 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "summary.h"
+#include "structures/vroom/solution/summary.h"
 
 summary_t::summary_t(cost_t cost, unsigned unassigned)
   : cost(cost), service(0), duration(0), distance(0), unassigned(unassigned) {

--- a/src/structures/vroom/solution/summary.h
+++ b/src/structures/vroom/solution/summary.h
@@ -10,7 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "./computing_times.h"
+#include "structures/vroom/solution/computing_times.h"
 
 struct summary_t {
   cost_t cost;

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -7,7 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "vehicle.h"
+#include "structures/vroom/vehicle.h"
 
 vehicle_t::vehicle_t(ID_t id,
                      const boost::optional<location_t>& start,

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -10,10 +10,10 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "../../utils/exceptions.h"
-#include "../typedefs.h"
-#include "./amount.h"
-#include "./location.h"
+#include "utils/exceptions.h"
+#include "structures/typedefs.h"
+#include "structures/vroom/amount.h"
+#include "structures/vroom/location.h"
 
 struct vehicle_t {
   const ID_t id;

--- a/src/utils/exceptions.cpp
+++ b/src/utils/exceptions.cpp
@@ -7,7 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "exceptions.h"
+#include "utils/exceptions.h"
 
 custom_exception::custom_exception(const std::string message)
   : _message(message) {

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -10,8 +10,8 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "../structures/typedefs.h"
-#include "./exceptions.h"
+#include "structures/typedefs.h"
+#include "utils/exceptions.h"
 
 inline cost_t add_without_overflow(cost_t a, cost_t b) {
   if (a > std::numeric_limits<cost_t>::max() - b) {

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -7,6 +7,17 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <array>
+#include <vector>
+
+#include "../../include/rapidjson/document.h"
+#include "../../include/rapidjson/error/en.h"
+#include "../structures/abstract/matrix.h"
+#include "../structures/vroom/amount.h"
+#include "../structures/vroom/job.h"
+#include "../structures/vroom/vehicle.h"
+#include "./exceptions.h"
+
 #include "./input_parser.h"
 
 // Helper to get optional array of coordinates.

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -10,6 +10,9 @@ All rights reserved (see LICENSE).
 #include <array>
 #include <vector>
 
+#include "../structures/cl_args.h"
+
+#include "../routing/routed_wrapper.h"
 #include "../../include/rapidjson/document.h"
 #include "../../include/rapidjson/error/en.h"
 #include "../structures/abstract/matrix.h"

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -10,18 +10,18 @@ All rights reserved (see LICENSE).
 #include <array>
 #include <vector>
 
-#include "../structures/cl_args.h"
+#include "structures/cl_args.h"
 
-#include "../routing/routed_wrapper.h"
-#include "../../include/rapidjson/document.h"
-#include "../../include/rapidjson/error/en.h"
-#include "../structures/abstract/matrix.h"
-#include "../structures/vroom/amount.h"
-#include "../structures/vroom/job.h"
-#include "../structures/vroom/vehicle.h"
-#include "./exceptions.h"
+#include "routing/routed_wrapper.h"
+#include "../include/rapidjson/document.h"
+#include "../include/rapidjson/error/en.h"
+#include "structures/abstract/matrix.h"
+#include "structures/vroom/amount.h"
+#include "structures/vroom/job.h"
+#include "structures/vroom/vehicle.h"
+#include "utils/exceptions.h"
 
-#include "./input_parser.h"
+#include "utils/input_parser.h"
 
 // Helper to get optional array of coordinates.
 inline coords_t parse_coordinates(const rapidjson::Value& object,

--- a/src/utils/input_parser.h
+++ b/src/utils/input_parser.h
@@ -10,18 +10,8 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <array>
-#include <vector>
-
-#include "../../include/rapidjson/document.h"
-#include "../../include/rapidjson/error/en.h"
-#include "../structures/abstract/matrix.h"
 #include "../structures/typedefs.h"
-#include "../structures/vroom/amount.h"
 #include "../structures/vroom/input/input.h"
-#include "../structures/vroom/job.h"
-#include "../structures/vroom/vehicle.h"
-#include "./exceptions.h"
 
 input parse(const cl_args_t& cl_args);
 

--- a/src/utils/input_parser.h
+++ b/src/utils/input_parser.h
@@ -13,6 +13,8 @@ All rights reserved (see LICENSE).
 #include "../structures/typedefs.h"
 #include "../structures/vroom/input/input.h"
 
+struct cl_args_t;
+
 input parse(const cl_args_t& cl_args);
 
 #endif

--- a/src/utils/input_parser.h
+++ b/src/utils/input_parser.h
@@ -10,8 +10,8 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "../structures/typedefs.h"
-#include "../structures/vroom/input/input.h"
+#include "structures/typedefs.h"
+#include "structures/vroom/input/input.h"
 
 struct cl_args_t;
 

--- a/src/utils/output_json.cpp
+++ b/src/utils/output_json.cpp
@@ -7,6 +7,15 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <chrono>
+#include <fstream>
+#include <iostream>
+
+#include <boost/log/trivial.hpp>
+#include "../../include/rapidjson/stringbuffer.h"
+#include "../../include/rapidjson/writer.h"
+#include "./version.h"
+
 #include "output_json.h"
 
 rapidjson::Document to_json(const solution& sol, bool geometry) {

--- a/src/utils/output_json.cpp
+++ b/src/utils/output_json.cpp
@@ -12,11 +12,11 @@ All rights reserved (see LICENSE).
 #include <iostream>
 
 #include <boost/log/trivial.hpp>
-#include "../../include/rapidjson/stringbuffer.h"
-#include "../../include/rapidjson/writer.h"
-#include "./version.h"
+#include "../include/rapidjson/stringbuffer.h"
+#include "../include/rapidjson/writer.h"
+#include "utils/version.h"
 
-#include "output_json.h"
+#include "utils/output_json.h"
 
 rapidjson::Document to_json(const solution& sol, bool geometry) {
   rapidjson::Document json_output;

--- a/src/utils/output_json.h
+++ b/src/utils/output_json.h
@@ -12,8 +12,8 @@ All rights reserved (see LICENSE).
 
 #include <string>
 
-#include "../../include/rapidjson/document.h"
-#include "../structures/vroom/solution/solution.h"
+#include "../include/rapidjson/document.h"
+#include "structures/vroom/solution/solution.h"
 
 rapidjson::Document to_json(const solution& sol, bool geometry);
 

--- a/src/utils/output_json.h
+++ b/src/utils/output_json.h
@@ -10,18 +10,10 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <chrono>
-#include <fstream>
-#include <iostream>
 #include <string>
 
-#include <boost/log/trivial.hpp>
-
 #include "../../include/rapidjson/document.h"
-#include "../../include/rapidjson/stringbuffer.h"
-#include "../../include/rapidjson/writer.h"
 #include "../structures/vroom/solution/solution.h"
-#include "./version.h"
 
 rapidjson::Document to_json(const solution& sol, bool geometry);
 

--- a/src/utils/version.cpp
+++ b/src/utils/version.cpp
@@ -7,7 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "version.h"
+#include "utils/version.h"
 
 std::string get_version() {
   std::string version = std::to_string(MAJOR) + "." + std::to_string(MINOR) +


### PR DESCRIPTION
## Issue

#108

## Tasks

 - [x] Check that the project still builds with all important gcc/clang versions
 - [x] Try the other steps mentioned in #108 
 - [ ] review


## Results of this PR

Measured with `time make -j1`
Baseline:
`make -j1  60.08s user 4.69s system 99% cpu 1:05.09 total`

Move includes in util/:
`make -j1  60.45s user 4.60s system 99% cpu 1:05.33 total`

Move includes in routing/:
`make -j1  48.56s user 4.15s system 99% cpu 52.934 total`

Move includes in structures/: 
`make -j1  47.44s user 4.09s system 99% cpu 51.747 total`

Split typedefs.h:
 `make -j1  34.08s user 2.76s system 99% cpu 37.034 total`

Move includes in problems/ and algorithms/: 
`make -j1  33.08s user 2.39s system 99% cpu 35.608 total`

Before: `make -j4  90.05s user 6.39s system 358% cpu 26.922 total`
After: `make -j4  57.71s user 3.79s system 362% cpu 16.982 total`

That's a noticeable improvement compared to the current master. Note that the big gains come from keeping the rapidjson and osrm headers from being included everywhere.
