### PR TITLE
Fix segfaults

### DIFF
--- a/src/problems/cvrp/heuristics/clustering.cpp
+++ b/src/problems/cvrp/heuristics/clustering.cpp
@@ -166,7 +166,7 @@ void clustering::parallel_clustering() {
   // Initialize cluster with the job that has higher amount (and is
   // the further away in case of amount tie).
   auto higher_amount_init_lambda = [&](auto v) {
-    return [&](index_t lhs, index_t rhs) {
+    return [&, v](index_t lhs, index_t rhs) {
       return jobs[lhs].amount < jobs[rhs].amount or
              (jobs[lhs].amount == jobs[rhs].amount and
               costs[v][lhs] < costs[v][rhs]);
@@ -410,7 +410,7 @@ void clustering::sequential_clustering() {
   // Initialize cluster with the job that has higher amount (and is
   // the further away in case of amount tie).
   auto higher_amount_init_lambda = [&](auto v) {
-    return [&](index_t lhs, index_t rhs) {
+    return [&, v](index_t lhs, index_t rhs) {
       return jobs[lhs].amount < jobs[rhs].amount or
              (jobs[lhs].amount == jobs[rhs].amount and
               vehicles_to_job_costs[v][lhs] < vehicles_to_job_costs[v][rhs]);


### PR DESCRIPTION
This changes the captures of v to copy, like it is already the case in the nearest_init lambda. On my machine this fixes the segfaults described in #126.

Regarding the optimization level: I'm guessing that the compiler replaces the reference to v with a copy of it in the inner lambda, since it is a read-only variable and the scope of it is limited and known.

## Issue

#126

## Tasks

 - [x] fix segfaults

