### PR TITLE
Refactor/tsp speedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Improve performance of the TSP heuristic by ~35% on all TSPLIB instances (#142)
+
 ## [v1.2.0]
 
 ### Added

--- a/src/algorithms/munkres.cpp
+++ b/src/algorithms/munkres.cpp
@@ -43,6 +43,7 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
     // Step 1.
 
     alternating_tree.clear();
+    std::vector<index_t> S_list;
     std::unordered_set<index_t> S;
     std::unordered_set<index_t> T_set;
 
@@ -52,6 +53,7 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
       ++unmatched_x;
     }
     S.insert(unmatched_x);
+    S_list.push_back(unmatched_x);
 
     // Saving relevant neighbors in equality graph in alternating_tree
     // and initializing slacks.
@@ -86,7 +88,7 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
         }
 
         // Update labelings
-        for (auto const& x : S) {
+        for (auto const& x : S_list) {
           labeling_x[x] = labeling_x[x] + alpha;
         }
         for (auto const& y : T_set) {
@@ -100,7 +102,7 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
             slack[y] = slack[y] - alpha;
 
             if (alternating_tree.find(y) == alternating_tree.end()) {
-              for (auto const& x : S) {
+              for (auto const& x : S_list) {
                 if (labeling_x[x] + labeling_y[y] == m[x][y]) {
                     alternating_tree.emplace(y, x);
                 }
@@ -129,7 +131,10 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
         // proceed to step 2.
         index_t matched_x = matching_y->second;
 
-        S.insert(matched_x);
+        auto p = S.insert(matched_x);
+        if (p.second) {
+          S_list.push_back(matched_x);
+        }
         T_set.insert(chosen_y);
 
         // Updating slacks.

--- a/src/algorithms/munkres.cpp
+++ b/src/algorithms/munkres.cpp
@@ -104,7 +104,8 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
             if (alternating_tree.find(y) == alternating_tree.end()) {
               for (auto const& x : S_list) {
                 if (labeling_x[x] + labeling_y[y] == m[x][y]) {
-                    alternating_tree.emplace(y, x);
+                  alternating_tree.emplace(y, x);
+                  break;
                 }
               }
             }

--- a/src/algorithms/munkres.cpp
+++ b/src/algorithms/munkres.cpp
@@ -20,7 +20,7 @@ std::unordered_map<index_t, index_t>
 minimum_weight_perfect_matching(const matrix<T>& m) {
 
   // Trivial initial labeling.
-  std::unordered_map<index_t, T> labeling_x;
+  std::vector<T> labeling_x(m.size(), 0);
   std::vector<T> labeling_y(m.size(), 0);
   for (index_t i = 0; i < m.size(); ++i) {
     T min_weight = std::numeric_limits<T>::max();
@@ -29,7 +29,7 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
         min_weight = m[i][j];
       }
     }
-    labeling_x.emplace(i, min_weight);
+    labeling_x[i] = min_weight;
   }
 
   // Initial empty matching.
@@ -58,10 +58,10 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
     std::vector<T> slack;
     slack.resize(m.size());
     for (index_t y = 0; y < m.size(); ++y) {
-      if (labeling_x.at(unmatched_x) + labeling_y[y] == m[unmatched_x][y]) {
+      if (labeling_x[unmatched_x] + labeling_y[y] == m[unmatched_x][y]) {
         alternating_tree.emplace(y, unmatched_x);
       }
-      slack[y] = m[unmatched_x][y] - labeling_x.at(unmatched_x) -
+      slack[y] = m[unmatched_x][y] - labeling_x[unmatched_x] -
                       labeling_y[y];
     }
 
@@ -87,7 +87,7 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
 
         // Update labelings
         for (auto const& x : S) {
-          labeling_x.at(x) = labeling_x.at(x) + alpha;
+          labeling_x[x] = labeling_x[x] + alpha;
         }
         for (auto const& y : T_set) {
           labeling_y[y] = labeling_y[y] - alpha;
@@ -101,7 +101,7 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
 
             if (alternating_tree.find(y) == alternating_tree.end()) {
               for (auto const& x : S) {
-                if (labeling_x.at(x) + labeling_y[y] == m[x][y]) {
+                if (labeling_x[x] + labeling_y[y] == m[x][y]) {
                     alternating_tree.emplace(y, x);
                 }
               }
@@ -136,7 +136,7 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
         for (index_t y = 0; y < m.size(); ++y) {
           T current_value = slack[y];
           T new_value =
-            m[matched_x][y] - labeling_x.at(matched_x) - labeling_y[y];
+            m[matched_x][y] - labeling_x[matched_x] - labeling_y[y];
           if (new_value < current_value) {
             slack[y] = new_value;
           }

--- a/src/algorithms/munkres.cpp
+++ b/src/algorithms/munkres.cpp
@@ -63,8 +63,7 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
       if (labeling_x[unmatched_x] + labeling_y[y] == m[unmatched_x][y]) {
         alternating_tree.emplace(y, unmatched_x);
       }
-      slack[y] = m[unmatched_x][y] - labeling_x[unmatched_x] -
-                      labeling_y[y];
+      slack[y] = m[unmatched_x][y] - labeling_x[unmatched_x] - labeling_y[y];
     }
 
     bool augmented_path = false;
@@ -141,8 +140,7 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
         // Updating slacks.
         for (index_t y = 0; y < m.size(); ++y) {
           T current_value = slack[y];
-          T new_value =
-            m[matched_x][y] - labeling_x[matched_x] - labeling_y[y];
+          T new_value = m[matched_x][y] - labeling_x[matched_x] - labeling_y[y];
           if (new_value < current_value) {
             slack[y] = new_value;
           }

--- a/src/algorithms/munkres.cpp
+++ b/src/algorithms/munkres.cpp
@@ -44,8 +44,8 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
     // Step 1.
 
     alternating_tree.clear();
-    std::set<index_t> S;
-    std::set<index_t> T_set;
+    std::unordered_set<index_t> S;
+    std::unordered_set<index_t> T_set;
 
     // Finding any unmatched x.
     index_t unmatched_x = 0;

--- a/src/algorithms/munkres.cpp
+++ b/src/algorithms/munkres.cpp
@@ -56,14 +56,14 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
 
     // Saving relevant neighbors in equality graph in alternating_tree
     // and initializing slacks.
-    std::unordered_map<index_t, T> slack;
+    std::vector<T> slack;
+    slack.resize(m.size());
     for (index_t y = 0; y < m.size(); ++y) {
       if (labeling_x.at(unmatched_x) + labeling_y.at(y) == m[unmatched_x][y]) {
         alternating_tree.emplace(y, unmatched_x);
       }
-      slack.emplace(y,
-                    m[unmatched_x][y] - labeling_x.at(unmatched_x) -
-                      labeling_y.at(y));
+      slack[y] = m[unmatched_x][y] - labeling_x.at(unmatched_x) -
+                      labeling_y.at(y);
     }
 
     bool augmented_path = false;
@@ -79,7 +79,7 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
           // Computing alpha, the minimum of slack values over
           // complement of T_set.
           if (T_set.find(y) == T_set.end()) {
-            T current_slack = slack.at(y);
+            T current_slack = slack[y];
             if (current_slack < alpha) {
               alpha = current_slack;
             }
@@ -98,12 +98,12 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
         // updating slacks.
         for (index_t y = 0; y < m.size(); ++y) {
           if (T_set.find(y) == T_set.end()) {
-            slack.at(y) = slack.at(y) - alpha;
+            slack[y] = slack[y] - alpha;
 
-            for (auto const& x : S) {
-              if (labeling_x.at(x) + labeling_y.at(y) == m[x][y]) {
-                if (alternating_tree.find(y) == alternating_tree.end()) {
-                  alternating_tree.emplace(y, x);
+            if (alternating_tree.find(y) == alternating_tree.end()) {
+              for (auto const& x : S) {
+                if (labeling_x.at(x) + labeling_y.at(y) == m[x][y]) {
+                    alternating_tree.emplace(y, x);
                 }
               }
             }
@@ -135,11 +135,11 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
 
         // Updating slacks.
         for (index_t y = 0; y < m.size(); ++y) {
-          T current_value = slack.at(y);
+          T current_value = slack[y];
           T new_value =
             m[matched_x][y] - labeling_x.at(matched_x) - labeling_y.at(y);
           if (new_value < current_value) {
-            slack.at(y) = new_value;
+            slack[y] = new_value;
           }
         }
       } else {

--- a/src/algorithms/munkres.cpp
+++ b/src/algorithms/munkres.cpp
@@ -195,8 +195,6 @@ greedy_symmetric_approx_mwpm(const matrix<T>& m) {
 
   while (remaining_indices.size() > 0) {
     T min_weight = std::numeric_limits<T>::max();
-    index_t first_chosen_index;
-    index_t second_chosen_index;
     std::set<index_t>::iterator chosen_i;
     std::set<index_t>::iterator chosen_j;
     for (auto i = remaining_indices.begin(); i != remaining_indices.end();
@@ -207,14 +205,12 @@ greedy_symmetric_approx_mwpm(const matrix<T>& m) {
         T current_weight = m[*i][*j];
         if (current_weight < min_weight) {
           min_weight = current_weight;
-          first_chosen_index = *i;
-          second_chosen_index = *j;
           chosen_i = i;
           chosen_j = j;
         }
       }
     }
-    matching.emplace(first_chosen_index, second_chosen_index);
+    matching.emplace(*chosen_i, *chosen_j);
     remaining_indices.erase(chosen_j);
     remaining_indices.erase(chosen_i);
   }

--- a/src/algorithms/munkres.cpp
+++ b/src/algorithms/munkres.cpp
@@ -21,9 +21,8 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
 
   // Trivial initial labeling.
   std::unordered_map<index_t, T> labeling_x;
-  std::unordered_map<index_t, T> labeling_y;
+  std::vector<T> labeling_y(m.size(), 0);
   for (index_t i = 0; i < m.size(); ++i) {
-    labeling_y.emplace(i, 0);
     T min_weight = std::numeric_limits<T>::max();
     for (index_t j = 0; j < m.size(); ++j) {
       if (m[i][j] < min_weight) {
@@ -59,11 +58,11 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
     std::vector<T> slack;
     slack.resize(m.size());
     for (index_t y = 0; y < m.size(); ++y) {
-      if (labeling_x.at(unmatched_x) + labeling_y.at(y) == m[unmatched_x][y]) {
+      if (labeling_x.at(unmatched_x) + labeling_y[y] == m[unmatched_x][y]) {
         alternating_tree.emplace(y, unmatched_x);
       }
       slack[y] = m[unmatched_x][y] - labeling_x.at(unmatched_x) -
-                      labeling_y.at(y);
+                      labeling_y[y];
     }
 
     bool augmented_path = false;
@@ -91,7 +90,7 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
           labeling_x.at(x) = labeling_x.at(x) + alpha;
         }
         for (auto const& y : T_set) {
-          labeling_y.at(y) = labeling_y.at(y) - alpha;
+          labeling_y[y] = labeling_y[y] - alpha;
         }
 
         // Updating relevant neighbors in new equality graph and
@@ -102,7 +101,7 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
 
             if (alternating_tree.find(y) == alternating_tree.end()) {
               for (auto const& x : S) {
-                if (labeling_x.at(x) + labeling_y.at(y) == m[x][y]) {
+                if (labeling_x.at(x) + labeling_y[y] == m[x][y]) {
                     alternating_tree.emplace(y, x);
                 }
               }
@@ -137,7 +136,7 @@ minimum_weight_perfect_matching(const matrix<T>& m) {
         for (index_t y = 0; y < m.size(); ++y) {
           T current_value = slack[y];
           T new_value =
-            m[matched_x][y] - labeling_x.at(matched_x) - labeling_y.at(y);
+            m[matched_x][y] - labeling_x.at(matched_x) - labeling_y[y];
           if (new_value < current_value) {
             slack[y] = new_value;
           }

--- a/src/problems/tsp/heuristics/local_search.cpp
+++ b/src/problems/tsp/heuristics/local_search.cpp
@@ -31,11 +31,11 @@ tsp_local_search::tsp_local_search(
   ++location;
   while (location != tour.cend()) {
     current_index = *location;
-    _edges.at(last_index) = current_index;
+    _edges[last_index] = current_index;
     last_index = current_index;
     ++location;
   }
-  _edges.at(last_index) = first_index;
+  _edges[last_index] = first_index;
 
   // Build a vector of bounds that easily split the [0, _edges.size()]
   // look-up range 'evenly' between threads for relocate and or-opt
@@ -194,12 +194,12 @@ cost_t tsp_local_search::relocate_step() {
 
   if (best_gain > 0) {
     // Performing best possible exchange.
-    index_t best_edge_1_end = _edges.at(best_edge_1_start);
-    index_t best_edge_2_end = _edges.at(best_edge_2_start);
+    index_t best_edge_1_end = _edges[best_edge_1_start];
+    index_t best_edge_2_end = _edges[best_edge_2_start];
 
-    _edges.at(best_edge_1_start) = _edges.at(best_edge_1_end);
-    _edges.at(best_edge_1_end) = best_edge_2_end;
-    _edges.at(best_edge_2_start) = best_edge_1_end;
+    _edges[best_edge_1_start] = _edges[best_edge_1_end];
+    _edges[best_edge_1_end] = best_edge_2_end;
+    _edges[best_edge_2_start] = best_edge_1_end;
   }
 
   return best_gain;
@@ -239,7 +239,7 @@ cost_t tsp_local_search::avoid_loop_step() {
 
   // Going through all candidate nodes for relocation.
   index_t previous_candidate = 0;
-  index_t candidate = _edges.at(previous_candidate);
+  index_t candidate = _edges[previous_candidate];
 
   // Remember previous steps for each node, required for step 3.
   std::vector<index_t> previous(_matrix.size());
@@ -254,13 +254,13 @@ cost_t tsp_local_search::avoid_loop_step() {
   std::unordered_map<index_t, index_t> possible_position;
 
   do {
-    index_t current = _edges.at(candidate);
+    index_t current = _edges[candidate];
 
     bool candidate_relocatable = false;
     if (!_avoid_start_relocate.first or
         candidate != _avoid_start_relocate.second) {
       while ((current != previous_candidate) and !candidate_relocatable) {
-        index_t next = _edges.at(current);
+        index_t next = _edges[current];
         if ((_matrix[current][candidate] + _matrix[candidate][next] <=
              _matrix[current][next]) and
             (_matrix[current][candidate] > 0) and
@@ -283,7 +283,7 @@ cost_t tsp_local_search::avoid_loop_step() {
       current_relocatable_chain.clear();
     }
     previous_candidate = candidate;
-    candidate = _edges.at(candidate);
+    candidate = _edges[candidate];
     previous.at(candidate) = previous_candidate;
   } while (candidate != 0);
 
@@ -385,7 +385,7 @@ cost_t tsp_local_search::two_opt_step() {
                      index_t& best_edge_1_start,
                      index_t& best_edge_2_start) {
     for (index_t edge_1_start = start; edge_1_start < end; ++edge_1_start) {
-      index_t edge_1_end = _edges.at(edge_1_start);
+      index_t edge_1_end = _edges[edge_1_start];
       for (index_t edge_2_start = edge_1_start + 1;
            edge_2_start < _edges.size();
            ++edge_2_start) {
@@ -400,7 +400,7 @@ cost_t tsp_local_search::two_opt_step() {
         // is the same as with (e_1, e_2), so assuming edge_1_start <
         // edge_2_start avoids testing pairs in both orders.
 
-        index_t edge_2_end = _edges.at(edge_2_start);
+        index_t edge_2_end = _edges[edge_2_start];
         if ((edge_2_start == edge_1_end) or (edge_2_end == edge_1_start)) {
           // Operator doesn't make sense.
           continue;
@@ -459,22 +459,22 @@ cost_t tsp_local_search::two_opt_step() {
   index_t best_edge_2_start = best_edge_2_starts[best_rank];
 
   if (best_gain > 0) {
-    index_t best_edge_1_end = _edges.at(best_edge_1_start);
-    index_t best_edge_2_end = _edges.at(best_edge_2_start);
+    index_t best_edge_1_end = _edges[best_edge_1_start];
+    index_t best_edge_2_end = _edges[best_edge_2_start];
     // Storing part of the tour that needs to be reversed.
     std::vector<index_t> to_reverse;
     for (index_t current = best_edge_1_end; current != best_edge_2_start;
-         current = _edges.at(current)) {
+         current = _edges[current]) {
       to_reverse.push_back(current);
     }
     // Performing exchange.
     index_t current = best_edge_2_start;
-    _edges.at(best_edge_1_start) = current;
+    _edges[best_edge_1_start] = current;
     for (auto next = to_reverse.rbegin(); next != to_reverse.rend(); ++next) {
-      _edges.at(current) = *next;
+      _edges[current] = *next;
       current = *next;
     }
-    _edges.at(current) = best_edge_2_end;
+    _edges[current] = best_edge_2_end;
   }
 
   return best_gain;
@@ -489,7 +489,7 @@ cost_t tsp_local_search::asym_two_opt_step() {
   // The initial node for the first edge is arbitrary but it is handy
   // to keep in mind the previous one for stopping conditions.
   index_t previous_init = _edges.front();
-  index_t init = _edges.at(previous_init);
+  index_t init = _edges[previous_init];
 
   // Lambda function to search for the best move in a range of
   // elements from _edges.
@@ -502,9 +502,9 @@ cost_t tsp_local_search::asym_two_opt_step() {
 
     do {
       // Going through the edges in the order of the current tour.
-      index_t edge_1_end = _edges.at(edge_1_start);
-      index_t edge_2_start = _edges.at(edge_1_end);
-      index_t edge_2_end = _edges.at(edge_2_start);
+      index_t edge_1_end = _edges[edge_1_start];
+      index_t edge_2_start = _edges[edge_1_end];
+      index_t edge_2_end = _edges[edge_2_start];
       // Trying to improve two "crossing edges".
       //
       // Namely edge_1_start --> edge_1_end and edge_2_start -->
@@ -544,9 +544,9 @@ cost_t tsp_local_search::asym_two_opt_step() {
         // Go for next possible second edge.
         previous = edge_2_start;
         edge_2_start = edge_2_end;
-        edge_2_end = _edges.at(edge_2_start);
+        edge_2_end = _edges[edge_2_start];
       }
-      edge_1_start = _edges.at(edge_1_start);
+      edge_1_start = _edges[edge_1_start];
     } while (edge_1_start != end);
   };
 
@@ -562,7 +562,7 @@ cost_t tsp_local_search::asym_two_opt_step() {
   index_t node = init;
   for (std::size_t i = 0; i < _nb_threads - 1; ++i) {
     // Finding nodes that separate current tour in _nb_threads ranges.
-    for (std::size_t j = 0; j < thread_range; ++j, node = _edges.at(node)) {
+    for (std::size_t j = 0; j < thread_range; ++j, node = _edges[node]) {
     }
     limit_nodes.push_back(node);
   }
@@ -599,22 +599,22 @@ cost_t tsp_local_search::asym_two_opt_step() {
   index_t best_edge_2_start = best_edge_2_starts[best_rank];
 
   if (best_gain > 0) {
-    index_t best_edge_1_end = _edges.at(best_edge_1_start);
-    index_t best_edge_2_end = _edges.at(best_edge_2_start);
+    index_t best_edge_1_end = _edges[best_edge_1_start];
+    index_t best_edge_2_end = _edges[best_edge_2_start];
     // Storing part of the tour that needs to be reversed.
     std::vector<index_t> to_reverse;
     for (index_t current = best_edge_1_end; current != best_edge_2_start;
-         current = _edges.at(current)) {
+         current = _edges[current]) {
       to_reverse.push_back(current);
     }
     // Performing exchange.
     index_t current = best_edge_2_start;
-    _edges.at(best_edge_1_start) = current;
+    _edges[best_edge_1_start] = current;
     for (auto next = to_reverse.rbegin(); next != to_reverse.rend(); ++next) {
-      _edges.at(current) = *next;
+      _edges[current] = *next;
       current = *next;
     }
-    _edges.at(current) = best_edge_2_end;
+    _edges[current] = best_edge_2_end;
   }
 
   return best_gain;
@@ -666,9 +666,9 @@ cost_t tsp_local_search::or_opt_step() {
                      index_t& best_edge_1_start,
                      index_t& best_edge_2_start) {
     for (index_t edge_1_start = start; edge_1_start < end; ++edge_1_start) {
-      index_t edge_1_end = _edges.at(edge_1_start);
-      index_t next = _edges.at(edge_1_end);
-      index_t next_2 = _edges.at(next);
+      index_t edge_1_end = _edges[edge_1_start];
+      index_t next = _edges[edge_1_end];
+      index_t next_2 = _edges[next];
       index_t edge_2_start = next_2;
       // Going through the tour while checking the move of edge after
       // edge_1_end in place of another edge (edge_2_*).
@@ -684,7 +684,7 @@ cost_t tsp_local_search::or_opt_step() {
       cost_t next_next_2_weight = _matrix[next][next_2];
 
       while (edge_2_start != edge_1_start) {
-        index_t edge_2_end = _edges.at(edge_2_start);
+        index_t edge_2_end = _edges[edge_2_start];
         cost_t before_cost = edge_1_weight + next_next_2_weight +
                              _matrix[edge_2_start][edge_2_end];
         cost_t after_cost = first_potential_add +
@@ -740,13 +740,13 @@ cost_t tsp_local_search::or_opt_step() {
   index_t best_edge_2_start = best_edge_2_starts[best_rank];
 
   if (best_gain > 0) {
-    index_t best_edge_1_end = _edges.at(best_edge_1_start);
-    index_t next = _edges.at(best_edge_1_end);
+    index_t best_edge_1_end = _edges[best_edge_1_start];
+    index_t next = _edges[best_edge_1_end];
 
     // Performing exchange.
-    _edges.at(best_edge_1_start) = _edges.at(next);
-    _edges.at(next) = _edges.at(best_edge_2_start);
-    _edges.at(best_edge_2_start) = best_edge_1_end;
+    _edges[best_edge_1_start] = _edges[next];
+    _edges[next] = _edges[best_edge_2_start];
+    _edges[best_edge_2_start] = best_edge_1_end;
   }
   return best_gain;
 }
@@ -769,10 +769,10 @@ cost_t tsp_local_search::perform_all_or_opt_steps() {
 std::list<index_t> tsp_local_search::get_tour(index_t first_index) const {
   std::list<index_t> tour;
   tour.push_back(first_index);
-  index_t next_index = _edges.at(first_index);
+  index_t next_index = _edges[first_index];
   while (next_index != first_index) {
     tour.push_back(next_index);
-    next_index = _edges.at(next_index);
+    next_index = _edges[next_index];
   }
   return tour;
 }

--- a/src/problems/tsp/heuristics/local_search.cpp
+++ b/src/problems/tsp/heuristics/local_search.cpp
@@ -110,14 +110,14 @@ cost_t tsp_local_search::relocate_step() {
                      index_t& best_edge_1_start,
                      index_t& best_edge_2_start) {
     for (index_t edge_1_start = start; edge_1_start < end; ++edge_1_start) {
-      index_t edge_1_end = _edges.at(edge_1_start);
+      index_t edge_1_end = _edges[edge_1_start];
       // Going through the tour while checking for insertion of
       // edge_1_end between two other nodes (edge_2_*).
       //
       // Namely edge_1_start --> edge_1_end --> next is replaced by
       // edge_1_start --> next while edge_2_start --> edge_2_end is
       // replaced by edge_2_start --> edge_1_end --> edge_2_end.
-      index_t next = _edges.at(edge_1_end);
+      index_t next = _edges[edge_1_end];
 
       // Precomputing weights not depending on edge_2_*.
       cost_t first_potential_add = _matrix[edge_1_start][next];
@@ -126,7 +126,7 @@ cost_t tsp_local_search::relocate_step() {
 
       index_t edge_2_start = next;
       while (edge_2_start != edge_1_start) {
-        index_t edge_2_end = _edges.at(edge_2_start);
+        index_t edge_2_end = _edges[edge_2_start];
         cost_t before_cost = edge_1_weight + edge_1_end_next_weight +
                              _matrix[edge_2_start][edge_2_end];
         cost_t after_cost = first_potential_add +

--- a/src/problems/tsp/heuristics/local_search.cpp
+++ b/src/problems/tsp/heuristics/local_search.cpp
@@ -124,14 +124,16 @@ cost_t tsp_local_search::relocate_step() {
       cost_t edge_1_weight = _matrix[edge_1_start][edge_1_end];
       cost_t edge_1_end_next_weight = _matrix[edge_1_end][next];
 
-      if (edge_1_weight + edge_1_end_next_weight - first_potential_add < best_gain) {
-          //if edge_2_start --> edge_2_end is shorter than
-          //edge_2_start --> edge_1_end --> edge_2_end (which it should be)
-          //than the gain can't be larger than the improvement between
-          //edge_1_start --> edge_1_end --> next  and
-          //edge_1_start --> next
-          //Note: No harm is done if this underflows due to triangle inequality violations
-          continue;
+      if (edge_1_weight + edge_1_end_next_weight - first_potential_add <
+          best_gain) {
+        // if edge_2_start --> edge_2_end is shorter than
+        // edge_2_start --> edge_1_end --> edge_2_end (which it should be)
+        // than the gain can't be larger than the improvement between
+        // edge_1_start --> edge_1_end --> next  and
+        // edge_1_start --> next
+        // Note: No harm is done if this underflows due to triangle inequality
+        // violations
+        continue;
       }
 
       index_t edge_2_start = next;

--- a/src/problems/tsp/heuristics/local_search.cpp
+++ b/src/problems/tsp/heuristics/local_search.cpp
@@ -124,6 +124,16 @@ cost_t tsp_local_search::relocate_step() {
       cost_t edge_1_weight = _matrix[edge_1_start][edge_1_end];
       cost_t edge_1_end_next_weight = _matrix[edge_1_end][next];
 
+      if (edge_1_weight + edge_1_end_next_weight - first_potential_add < best_gain) {
+          //if edge_2_start --> edge_2_end is shorter than
+          //edge_2_start --> edge_1_end --> edge_2_end (which it should be)
+          //than the gain can't be larger than the improvement between
+          //edge_1_start --> edge_1_end --> next  and
+          //edge_1_start --> next
+          //Note: No harm is done if this underflows due to triangle inequality violations
+          continue;
+      }
+
       index_t edge_2_start = next;
       while (edge_2_start != edge_1_start) {
         index_t edge_2_end = _edges[edge_2_start];

--- a/src/structures/abstract/edge.cpp
+++ b/src/structures/abstract/edge.cpp
@@ -17,14 +17,6 @@ edge<T>::edge(index_t first_vertex, index_t second_vertex, T weight)
     _weight(weight) {
 }
 
-template <class T> index_t edge<T>::get_first_vertex() const {
-  return _first_vertex;
-}
-
-template <class T> index_t edge<T>::get_second_vertex() const {
-  return _second_vertex;
-}
-
 template <class T> bool edge<T>::operator<(const edge& rhs) const {
   return (this->_first_vertex < rhs._first_vertex) or
          ((this->_first_vertex == rhs._first_vertex) and
@@ -34,10 +26,6 @@ template <class T> bool edge<T>::operator<(const edge& rhs) const {
 template <class T> bool edge<T>::operator==(const edge& rhs) const {
   return (this->_first_vertex == rhs._first_vertex) and
          (this->_second_vertex == rhs._second_vertex);
-}
-
-template <class T> T edge<T>::get_weight() const {
-  return _weight;
 }
 
 template class edge<cost_t>;

--- a/src/structures/abstract/edge.h
+++ b/src/structures/abstract/edge.h
@@ -22,15 +22,15 @@ private:
 public:
   edge(index_t first_vertex, index_t second_vertex, T weight);
 
-  index_t get_first_vertex() const;
+  index_t get_first_vertex() const { return _first_vertex;};
 
-  index_t get_second_vertex() const;
+  index_t get_second_vertex() const { return _second_vertex;};
 
   bool operator<(const edge& rhs) const;
 
   bool operator==(const edge& rhs) const;
 
-  T get_weight() const;
+  T get_weight() const { return _weight;};
 };
 
 #endif

--- a/src/structures/abstract/edge.h
+++ b/src/structures/abstract/edge.h
@@ -22,15 +22,21 @@ private:
 public:
   edge(index_t first_vertex, index_t second_vertex, T weight);
 
-  index_t get_first_vertex() const { return _first_vertex;};
+  index_t get_first_vertex() const {
+    return _first_vertex;
+  };
 
-  index_t get_second_vertex() const { return _second_vertex;};
+  index_t get_second_vertex() const {
+    return _second_vertex;
+  };
 
   bool operator<(const edge& rhs) const;
 
   bool operator==(const edge& rhs) const;
 
-  T get_weight() const { return _weight;};
+  T get_weight() const {
+    return _weight;
+  };
 };
 
 #endif

--- a/src/structures/abstract/undirected_graph.cpp
+++ b/src/structures/abstract/undirected_graph.cpp
@@ -19,7 +19,7 @@ undirected_graph<T>::undirected_graph(const matrix<T>& m) : _size(m.size()) {
   _edges.reserve(_size * _size);
   _adjacency_list.reserve(_size);
   for (index_t i = 0; i < _size; ++i) {
-      _adjacency_list[i].reserve(_size);
+    _adjacency_list[i].reserve(_size);
   }
   for (index_t i = 0; i < _size; ++i) {
     matrix_ok &= (m[i][i] == INFINITE_COST);
@@ -59,7 +59,9 @@ std::unordered_map<index_t, std::list<index_t>>
 undirected_graph<T>::get_adjacency_list() const {
   std::unordered_map<index_t, std::list<index_t>> result;
   for (const auto& pair : _adjacency_list) {
-    std::copy(pair.second.begin(), pair.second.end(), std::back_inserter(result[pair.first]));
+    std::copy(pair.second.begin(),
+              pair.second.end(),
+              std::back_inserter(result[pair.first]));
   }
   return result;
 }

--- a/src/structures/abstract/undirected_graph.cpp
+++ b/src/structures/abstract/undirected_graph.cpp
@@ -16,6 +16,11 @@ template <class T> undirected_graph<T>::undirected_graph() {
 template <class T>
 undirected_graph<T>::undirected_graph(const matrix<T>& m) : _size(m.size()) {
   bool matrix_ok = true;
+  _edges.reserve(_size * _size);
+  _adjacency_list.reserve(_size);
+  for (index_t i = 0; i < _size; ++i) {
+      _adjacency_list[i].reserve(_size);
+  }
   for (index_t i = 0; i < _size; ++i) {
     matrix_ok &= (m[i][i] == INFINITE_COST);
     for (index_t j = i + 1; j < _size; ++j) {
@@ -52,7 +57,11 @@ template <class T> std::vector<edge<T>> undirected_graph<T>::get_edges() const {
 template <class T>
 std::unordered_map<index_t, std::list<index_t>>
 undirected_graph<T>::get_adjacency_list() const {
-  return _adjacency_list;
+  std::unordered_map<index_t, std::list<index_t>> result;
+  for (const auto& pair : _adjacency_list) {
+    std::copy(pair.second.begin(), pair.second.end(), std::back_inserter(result[pair.first]));
+  }
+  return result;
 }
 
 template class undirected_graph<cost_t>;

--- a/src/structures/abstract/undirected_graph.h
+++ b/src/structures/abstract/undirected_graph.h
@@ -24,7 +24,7 @@ private:
   // Embedding two representations for different uses depending on
   // context.
   std::vector<edge<T>> _edges;
-  std::unordered_map<index_t, std::list<index_t>> _adjacency_list;
+  std::unordered_map<index_t, std::vector<index_t>> _adjacency_list;
 
 public:
   undirected_graph();

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -149,12 +149,13 @@ input parse(const cl_args_t& cl_args) {
         throw custom_exception("Invalid matrix line " + std::to_string(i) +
                                ".");
       }
+      rapidjson::Document::Array mi = json_input["matrix"][i].GetArray();
       for (rapidjson::SizeType j = 0; j < matrix_size; ++j) {
-        if (!json_input["matrix"][i][j].IsUint()) {
+        if (!mi[j].IsUint()) {
           throw custom_exception("Invalid matrix entry (" + std::to_string(i) +
                                  "," + std::to_string(j) + ").");
         }
-        cost_t cost = json_input["matrix"][i][j].GetUint();
+        cost_t cost = mi[j].GetUint();
         matrix_input[i][j] = cost;
       }
     }


### PR DESCRIPTION
## Issue

Closes #141 

## Tasks

 - [x] Review algorithm changes
 - [x] Update `CHANGELOG.md` (remove if irrelevant)
 - [x] review

## Description

This PR is a series of patches that improve the performance of the TSP heuristic via some microoptimisations. The patches can be applied and reviewed individually, they do not build upon each other. I think the impact on code quality and maintainability is very small and the performance gains are worth including them.

origin/master:
```
../bin/vroom -i ../bin/d1291.json -t 1  1.93s user 0.12s system 99% cpu 2.051 total
{"cost":53459,"unassigned":0,"computing_times":{"loading":142,"solving":1799}}
```

Improve undirected_graph 003cb5883733ecb51ddcf16a247ea48451c134b5:
```
../bin/vroom -i ../bin/d1291.json -t 1  1.57s user 0.10s system 98% cpu 1.691 total
{"cost":53364,"unassigned":0,"computing_times":{"loading":153,"solving":1430}}
```
The getter copied the `std::list`s anyway, so we avoid their creation cost in the constructor.


Inline edge getters f687ed4:
```
../bin/vroom -i ../bin/d1291.json -t 1  1.53s user 0.10s system 98% cpu 1.658 total
{"cost":53364,"unassigned":0,"computing_times":{"loading":149,"solving":1389}}
```

`get_weight()` showed up in some profiles since it is used to sort the edges by weight for Kruskal's algorithm.

Remove bounds checks in relocate 0ae260b:
```
../bin/vroom -i ../bin/d1291.json -t 1  1.46s user 0.09s system 99% cpu 1.560 total
{"cost":53364,"unassigned":0,"computing_times":{"loading":150,"solving":1329}}
```

Adding shortcut to relocate 696aa4b:
```
../bin/vroom -i ../bin/d1291.json -t 1  1.38s user 0.09s system 99% cpu 1.476 total
{"cost":53364,"unassigned":0,"computing_times":{"loading":139,"solving":1254}}
```

I think this change does not change how the relocate-operator works as long as the triangle inequality holds in the matrix. (However, since I am quite aware that it does not hold on e.g. data that OSRM returns, I have not touched the code below to assume that).

Improve datastructures in munkres c545796 :
```
../bin/vroom -i ../bin/d1291.json -t 1  1.37s user 0.08s system 99% cpu 1.454 total
{"cost":53364,"unassigned":0,"computing_times":{"loading":151,"solving":1223}}
```

The implementation of Munkres' Algorithm does work on all indices of a dense matrix. Thus we don't really need sets and maps and could use vector everywhere.

Replace ordered with unordered set 9154fda :
```
../bin/vroom -i ../bin/d1291.json -t 1  1.33s user 0.08s system 99% cpu 1.412 total
{"cost":53362,"unassigned":0,"computing_times":{"loading":159,"solving":1171}}
```

The tree operations were showing up in profiles.
Note: this commit changes the found solutions since munkres relies on the ordering sometimes

Replace labeling_y with vector b3f25d2: 
```
../bin/vroom -i ../bin/d1291.json -t 1  1.20s user 0.09s system 99% cpu 1.292 total
{"cost":53362,"unassigned":0,"computing_times":{"loading":153,"solving":1056}}
```

Replace labeling_x with vector 0674bde :
```
../bin/vroom -i ../bin/d1291.json -t 1  1.13s user 0.07s system 99% cpu 1.203 total
{"cost":53362,"unassigned":0,"computing_times":{"loading":153,"solving":969}}
```

Improve matrix loading time a bit d98a912:
```
../bin/vroom -i ../bin/d1291.json -t 1  1.05s user 0.09s system 99% cpu 1.143 total
{"cost":53362,"unassigned":0,"computing_times":{"loading":107,"solving":958}}
```
Not really related to the TSP heuristic, but eh well, it showed up in profiles.

## Result

I ran the TSP benchmark script with most of the problems from TSPLIB (I didn't yet run it on the larger ones).

`origin/master`:
```
,Gaps,Computing times
Min,0.09,7
First decile,1.2,11
Lower quartile,1.97,18
Median,2.96,70
Upper quartile,3.56,1419
Ninth decile,4.54,4905
Max,7.56,161364
```

This PR:
```
,Gaps,Computing times
Min,0.0,5
First decile,1.01,13
Lower quartile,1.97,19
Median,2.73,35
Upper quartile,3.59,837
Ninth decile,4.34,3362
Max,6.33,110023
```
