### PR TITLE
Handle fleet type

### DIFF
--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -22,6 +22,7 @@ input::input(std::unique_ptr<routing_io<cost_t>> routing_wrapper, bool geometry)
   : _start_loading(std::chrono::high_resolution_clock::now()),
     _routing_wrapper(std::move(routing_wrapper)),
     _has_TW(false),
+    _homogeneous_locations(true),
     _geometry(geometry),
     _all_locations_have_coords(true) {
 }
@@ -108,6 +109,12 @@ void input::add_vehicle(const vehicle_t& vehicle) {
     _all_locations_have_coords &= current_v.end.get().has_coordinates();
 
     _locations.push_back(current_v.end.get());
+  }
+
+  // Check for homogeneous locations among vehicles.
+  if (_vehicles.size() > 1) {
+    _homogeneous_locations &=
+      _vehicles.front().has_same_locations(_vehicles.back());
   }
 }
 

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -39,6 +39,7 @@ private:
   std::unique_ptr<routing_io<cost_t>> _routing_wrapper;
   bool _has_skills;
   bool _has_TW;
+  bool _homogeneous_locations;
   const bool _geometry;
   matrix<cost_t> _matrix;
   std::vector<location_t> _locations;

--- a/src/structures/vroom/location.cpp
+++ b/src/structures/vroom/location.cpp
@@ -47,3 +47,9 @@ coordinate_t location_t::lat() const {
 bool location_t::user_index() const {
   return _user_index;
 }
+
+bool location_t::operator==(const location_t& other) const {
+  return (_index == other.index()) or
+         (this->has_coordinates() and other.has_coordinates() and
+          (this->lon() == other.lon()) and (this->lat() == other.lat()));
+}

--- a/src/structures/vroom/location.h
+++ b/src/structures/vroom/location.h
@@ -38,6 +38,12 @@ public:
   coordinate_t lat() const;
 
   bool user_index() const;
+
+  // Locations are considered identical if they have the same
+  // user-provided index or if they both have coordinates and those
+  // are equal. The last part is required for situations with no
+  // explicit index provided in input.
+  bool operator==(const location_t& other) const;
 };
 
 #endif

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -30,3 +30,18 @@ bool vehicle_t::has_start() const {
 bool vehicle_t::has_end() const {
   return static_cast<bool>(end);
 }
+
+bool vehicle_t::has_same_locations(const vehicle_t& other) const {
+  bool same = (this->has_start() == other.has_start()) and
+              (this->has_end() == other.has_end());
+
+  if (same and this->has_start()) {
+    same &= this->start.get() == other.start.get();
+  }
+
+  if (same and this->has_end()) {
+    same &= this->end.get() == other.end.get();
+  }
+
+  return same;
+}

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -33,6 +33,8 @@ struct vehicle_t {
   bool has_start() const;
 
   bool has_end() const;
+
+  bool has_same_locations(const vehicle_t& other) const;
 };
 
 #endif


### PR DESCRIPTION
## Issue

This PR covers the scope of #151 and #152. After that, a more complete usage will involve applying different parameter tunings for homogeneous and heterogeneous fleet but this should be dealt with later with a broader look, both for CVRP and VRPTW.

## Tasks

 - [ ] Add flag to check fleet type in input
 - [ ] adjust VRPTW heuristic for the heterogeneous case
 - [ ] Update `CHANGELOG.md`
 - [ ] review
