### PR TITLE
Adds missing "#include <string>" directives

### DIFF
--- a/src/structures/vroom/solution/route.h
+++ b/src/structures/vroom/solution/route.h
@@ -10,6 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <string>
 #include <vector>
 
 #include "structures/vroom/solution/step.h"

--- a/src/structures/vroom/solution/solution.h
+++ b/src/structures/vroom/solution/solution.h
@@ -10,6 +10,8 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <string>
+
 #include "structures/vroom/job.h"
 #include "structures/vroom/solution/route.h"
 #include "structures/vroom/solution/summary.h"


### PR DESCRIPTION
## Issue

Proposed fix for #160 -- adds missing explicit "#include <string>" in headers where needed.

## Tasks

 - [ ] ...
 - [ ] review
