### PR TITLE
Add local search operators operating on a single route

### DIFF
--- a/src/problems/cvrp/local_search/2_opt.cpp
+++ b/src/problems/cvrp/local_search/2_opt.cpp
@@ -113,3 +113,7 @@ void cvrp_two_opt::apply() const {
 std::vector<index_t> cvrp_two_opt::addition_candidates() const {
   return {s_vehicle, t_vehicle};
 }
+
+std::vector<index_t> cvrp_two_opt::update_candidates() const {
+  return {s_vehicle, t_vehicle};
+}

--- a/src/problems/cvrp/local_search/cross_exchange.cpp
+++ b/src/problems/cvrp/local_search/cross_exchange.cpp
@@ -189,3 +189,7 @@ void cvrp_cross_exchange::apply() const {
 std::vector<index_t> cvrp_cross_exchange::addition_candidates() const {
   return {s_vehicle, t_vehicle};
 }
+
+std::vector<index_t> cvrp_cross_exchange::update_candidates() const {
+  return {s_vehicle, t_vehicle};
+}

--- a/src/problems/cvrp/local_search/cross_exchange.h
+++ b/src/problems/cvrp/local_search/cross_exchange.h
@@ -39,6 +39,8 @@ public:
   virtual void apply() const override;
 
   virtual std::vector<index_t> addition_candidates() const override;
+
+  virtual std::vector<index_t> update_candidates() const override;
 };
 
 #endif

--- a/src/problems/cvrp/local_search/exchange.cpp
+++ b/src/problems/cvrp/local_search/exchange.cpp
@@ -132,3 +132,7 @@ void cvrp_exchange::apply() const {
 std::vector<index_t> cvrp_exchange::addition_candidates() const {
   return {s_vehicle, t_vehicle};
 }
+
+std::vector<index_t> cvrp_exchange::update_candidates() const {
+  return {s_vehicle, t_vehicle};
+}

--- a/src/problems/cvrp/local_search/exchange.h
+++ b/src/problems/cvrp/local_search/exchange.h
@@ -31,6 +31,8 @@ public:
   virtual void apply() const override;
 
   virtual std::vector<index_t> addition_candidates() const override;
+
+  virtual std::vector<index_t> update_candidates() const override;
 };
 
 #endif

--- a/src/problems/cvrp/local_search/inner_relocate.cpp
+++ b/src/problems/cvrp/local_search/inner_relocate.cpp
@@ -1,0 +1,69 @@
+/*
+
+This file is part of VROOM.
+
+Copyright (c) 2015-2018, Julien Coupey.
+All rights reserved (see LICENSE).
+
+*/
+
+#include "problems/cvrp/local_search/inner_relocate.h"
+#include "utils/helpers.h"
+
+cvrp_inner_relocate::cvrp_inner_relocate(const input& input,
+                                         const solution_state& sol_state,
+                                         std::vector<index_t>& s_route,
+                                         index_t s_vehicle,
+                                         index_t s_rank,
+                                         index_t t_rank)
+  : ls_operator(input,
+                sol_state,
+                s_route,
+                s_vehicle,
+                s_rank,
+                s_route,
+                s_vehicle,
+                t_rank) {
+  assert(s_route.size() >= 2);
+  assert(s_rank < s_route.size());
+  assert(t_rank <= s_route.size() - 1);
+  assert(s_rank != t_rank);
+}
+
+void cvrp_inner_relocate::compute_gain() {
+  const auto& m = _input.get_matrix();
+  const auto& v_target = _input._vehicles[t_vehicle];
+
+  // For removal, we consider the cost of removing job at rank s_rank,
+  // already stored in _sol_state.node_gains[s_vehicle][s_rank].
+
+  // For addition, consider the cost of adding source job at new rank
+  // *after* removal.
+  auto new_rank = t_rank;
+  if (s_rank < t_rank) {
+    ++new_rank;
+  }
+  gain_t t_gain =
+    -addition_cost(_input, m, s_route[s_rank], v_target, t_route, new_rank);
+
+  stored_gain = _sol_state.node_gains[s_vehicle][s_rank] + t_gain;
+  gain_computed = true;
+}
+
+bool cvrp_inner_relocate::is_valid() const {
+  return true;
+}
+
+void cvrp_inner_relocate::apply() const {
+  auto relocate_job_rank = s_route[s_rank];
+  s_route.erase(s_route.begin() + s_rank);
+  t_route.insert(t_route.begin() + t_rank, relocate_job_rank);
+}
+
+std::vector<index_t> cvrp_inner_relocate::addition_candidates() const {
+  return {};
+}
+
+std::vector<index_t> cvrp_inner_relocate::update_candidates() const {
+  return {s_vehicle};
+}

--- a/src/problems/cvrp/local_search/inner_relocate.h
+++ b/src/problems/cvrp/local_search/inner_relocate.h
@@ -1,5 +1,5 @@
-#ifndef CVRP_TWO_OPT_H
-#define CVRP_TWO_OPT_H
+#ifndef CVRP_INNER_RELOCATE_H
+#define CVRP_INNER_RELOCATE_H
 
 /*
 
@@ -12,19 +12,17 @@ All rights reserved (see LICENSE).
 
 #include "problems/ls_operator.h"
 
-class cvrp_two_opt : public ls_operator {
+class cvrp_inner_relocate : public ls_operator {
 protected:
   virtual void compute_gain() override;
 
 public:
-  cvrp_two_opt(const input& input,
-               const solution_state& sol_state,
-               std::vector<index_t>& s_route,
-               index_t s_vehicle,
-               index_t s_rank,
-               std::vector<index_t>& t_route,
-               index_t t_vehicle,
-               index_t t_rank);
+  cvrp_inner_relocate(const input& input,
+                      const solution_state& sol_state,
+                      std::vector<index_t>& s_route,
+                      index_t s_vehicle,
+                      index_t s_rank,
+                      index_t t_rank); // relocate rank *after* removal.
 
   virtual bool is_valid() const override;
 

--- a/src/problems/cvrp/local_search/local_search.cpp
+++ b/src/problems/cvrp/local_search/local_search.cpp
@@ -7,10 +7,13 @@ All rights reserved (see LICENSE).
 
 */
 
-#include "problems/cvrp/local_search/local_search.h"
+#include <numeric>
+
 #include "problems/cvrp/local_search/2_opt.h"
 #include "problems/cvrp/local_search/cross_exchange.h"
 #include "problems/cvrp/local_search/exchange.h"
+#include "problems/cvrp/local_search/inner_relocate.h"
+#include "problems/cvrp/local_search/local_search.h"
 #include "problems/cvrp/local_search/mixed_exchange.h"
 #include "problems/cvrp/local_search/or_opt.h"
 #include "problems/cvrp/local_search/relocate.h"
@@ -147,9 +150,6 @@ void cvrp_local_search::run_ls_step() {
   std::vector<std::pair<index_t, index_t>> s_t_pairs;
   for (unsigned s_v = 0; s_v < V; ++s_v) {
     for (unsigned t_v = 0; t_v < V; ++t_v) {
-      if (s_v == t_v) {
-        continue;
-      }
       s_t_pairs.emplace_back(s_v, t_v);
     }
   }
@@ -214,7 +214,8 @@ void cvrp_local_search::run_ls_step() {
 
     // Mixed-exchange stuff
     for (const auto& s_t : s_t_pairs) {
-      if (_sol[s_t.first].size() == 0 or _sol[s_t.second].size() < 2) {
+      if (s_t.first == s_t.second or _sol[s_t.first].size() == 0 or
+          _sol[s_t.second].size() < 2) {
         continue;
       }
 
@@ -269,6 +270,9 @@ void cvrp_local_search::run_ls_step() {
 
     // Reverse 2-opt* stuff
     for (const auto& s_t : s_t_pairs) {
+      if (s_t.first == s_t.second) {
+        continue;
+      }
       for (unsigned s_rank = 0; s_rank < _sol[s_t.first].size(); ++s_rank) {
         auto s_free_amount = _input._vehicles[s_t.first].capacity;
         s_free_amount -= _sol_state.fwd_amounts[s_t.first][s_rank];
@@ -295,7 +299,7 @@ void cvrp_local_search::run_ls_step() {
 
     // Relocate stuff
     for (const auto& s_t : s_t_pairs) {
-      if (_sol[s_t.first].size() == 0 or
+      if (s_t.first == s_t.second or _sol[s_t.first].size() == 0 or
           !(_sol_state.total_amount(s_t.second) + _amount_lower_bound <=
             _input._vehicles[s_t.second].capacity)) {
         // Don't try to put things in a full vehicle or from an empty
@@ -329,7 +333,7 @@ void cvrp_local_search::run_ls_step() {
 
     // Or-opt stuff
     for (const auto& s_t : s_t_pairs) {
-      if (_sol[s_t.first].size() < 2 or
+      if (s_t.first == s_t.second or _sol[s_t.first].size() < 2 or
           !(_sol_state.total_amount(s_t.second) + _double_amount_lower_bound <=
             _input._vehicles[s_t.second].capacity)) {
         // Don't try to put things in a full vehicle or from a
@@ -360,6 +364,39 @@ void cvrp_local_search::run_ls_step() {
       }
     }
 
+    // Inner relocate stuff, only applied on a single route.
+    for (const auto& s_t : s_t_pairs) {
+      if (s_t.first != s_t.second or _sol[s_t.first].size() < 2) {
+        continue;
+      }
+      for (unsigned s_rank = 0; s_rank < _sol[s_t.first].size(); ++s_rank) {
+        if (_sol_state.node_gains[s_t.first][s_rank] <=
+            best_gains[s_t.first][s_t.first]) {
+          // Except if addition cost in route is negative (!!),
+          // overall gain can't exceed current known best gain.
+          continue;
+        }
+        for (unsigned t_rank = 0; t_rank <= _sol[s_t.first].size() - 1;
+             ++t_rank) {
+          if (t_rank == s_rank) {
+            continue;
+          }
+          cvrp_inner_relocate r(_input,
+                                _sol_state,
+                                _sol[s_t.first],
+                                s_t.first,
+                                s_rank,
+                                t_rank);
+          // This move is always valid.
+          if (r.gain() > best_gains[s_t.first][s_t.first]) {
+            best_gains[s_t.first][s_t.first] = r.gain();
+            best_ops[s_t.first][s_t.first] =
+              std::make_unique<cvrp_inner_relocate>(r);
+          }
+        }
+      }
+    }
+
     // Find best overall gain.
     best_gain = 0;
     index_t best_source = 0;
@@ -367,9 +404,6 @@ void cvrp_local_search::run_ls_step() {
 
     for (unsigned s_v = 0; s_v < V; ++s_v) {
       for (unsigned t_v = 0; t_v < V; ++t_v) {
-        if (s_v == t_v) {
-          continue;
-        }
         if (best_gains[s_v][t_v] > best_gain) {
           best_gain = best_gains[s_v][t_v];
           best_source = s_v;
@@ -384,64 +418,75 @@ void cvrp_local_search::run_ls_step() {
 
       best_ops[best_source][best_target]->apply();
 
+      auto update_candidates =
+        best_ops[best_source][best_target]->update_candidates();
+
       // Update route costs.
-      auto previous_cost = _sol_state.route_costs[best_source] +
-                           _sol_state.route_costs[best_target];
-      _sol_state.update_route_cost(_sol[best_source], best_source);
-      _sol_state.update_route_cost(_sol[best_target], best_target);
-      auto new_cost = _sol_state.route_costs[best_source] +
-                      _sol_state.route_costs[best_target];
+      auto previous_cost =
+        std::accumulate(update_candidates.begin(),
+                        update_candidates.end(),
+                        0,
+                        [&](auto sum, auto c) {
+                          return sum + _sol_state.route_costs[c];
+                        });
+      for (auto v_rank : update_candidates) {
+        _sol_state.update_route_cost(_sol[v_rank], v_rank);
+      }
+      auto new_cost = std::accumulate(update_candidates.begin(),
+                                      update_candidates.end(),
+                                      0,
+                                      [&](auto sum, auto c) {
+                                        return sum + _sol_state.route_costs[c];
+                                      });
+
       assert(new_cost + best_gain == previous_cost);
 
-      run_tsp(best_source);
-      run_tsp(best_target);
+      for (auto v_rank : update_candidates) {
+        run_tsp(v_rank);
+      }
 
       // We need to run update_amounts before try_job_additions to
       // correctly evaluate amounts. No need to run it again after
       // since try_before_additions will subsequently fix amounts upon
       // each addition.
-      _sol_state.update_amounts(_sol[best_source], best_source);
-      _sol_state.update_amounts(_sol[best_target], best_target);
+      for (auto v_rank : update_candidates) {
+        _sol_state.update_amounts(_sol[v_rank], v_rank);
+      }
 
       try_job_additions(best_ops[best_source][best_target]
                           ->addition_candidates(),
                         0);
 
       // Running update_costs only after try_job_additions is fine.
-      _sol_state.update_costs(_sol[best_source], best_source);
-      _sol_state.update_costs(_sol[best_target], best_target);
+      for (auto v_rank : update_candidates) {
+        _sol_state.update_costs(_sol[v_rank], v_rank);
+      }
 
-      _sol_state.update_skills(_sol[best_source], best_source);
-      _sol_state.update_skills(_sol[best_target], best_target);
+      for (auto v_rank : update_candidates) {
+        _sol_state.update_skills(_sol[v_rank], v_rank);
+      }
 
       // Update candidates.
-      _sol_state.set_node_gains(_sol[best_source], best_source);
-      _sol_state.set_node_gains(_sol[best_target], best_target);
-      _sol_state.set_edge_gains(_sol[best_source], best_source);
-      _sol_state.set_edge_gains(_sol[best_target], best_target);
+      for (auto v_rank : update_candidates) {
+        _sol_state.set_node_gains(_sol[v_rank], v_rank);
+        _sol_state.set_edge_gains(_sol[v_rank], v_rank);
+      }
 
       // Set gains to zero for what needs to be recomputed in the next
-      // round.
+      // round and set route pairs accordingly.
       s_t_pairs.clear();
-      best_gains[best_source] = std::vector<gain_t>(V, 0);
-      best_gains[best_target] = std::vector<gain_t>(V, 0);
-
-      s_t_pairs.emplace_back(best_source, best_target);
-      s_t_pairs.emplace_back(best_target, best_source);
+      for (auto v_rank : update_candidates) {
+        best_gains[v_rank] = std::vector<gain_t>(V, 0);
+      }
 
       for (unsigned v = 0; v < V; ++v) {
-        if (v == best_source or v == best_target) {
-          continue;
+        for (auto v_rank : update_candidates) {
+          best_gains[v][v_rank] = 0;
+          s_t_pairs.emplace_back(v, v_rank);
+          if (v != v_rank) {
+            s_t_pairs.emplace_back(v_rank, v);
+          }
         }
-        s_t_pairs.emplace_back(best_source, v);
-        s_t_pairs.emplace_back(v, best_source);
-        best_gains[v][best_source] = 0;
-        best_gains[best_source][v] = 0;
-
-        s_t_pairs.emplace_back(best_target, v);
-        s_t_pairs.emplace_back(v, best_target);
-        best_gains[v][best_target] = 0;
-        best_gains[best_target][v] = 0;
       }
     }
   }

--- a/src/problems/cvrp/local_search/mixed_exchange.cpp
+++ b/src/problems/cvrp/local_search/mixed_exchange.cpp
@@ -164,3 +164,7 @@ void cvrp_mixed_exchange::apply() const {
 std::vector<index_t> cvrp_mixed_exchange::addition_candidates() const {
   return {s_vehicle, t_vehicle};
 }
+
+std::vector<index_t> cvrp_mixed_exchange::update_candidates() const {
+  return {s_vehicle, t_vehicle};
+}

--- a/src/problems/cvrp/local_search/mixed_exchange.h
+++ b/src/problems/cvrp/local_search/mixed_exchange.h
@@ -37,6 +37,8 @@ public:
   virtual void apply() const override;
 
   virtual std::vector<index_t> addition_candidates() const override;
+
+  virtual std::vector<index_t> update_candidates() const override;
 };
 
 #endif

--- a/src/problems/cvrp/local_search/or_opt.cpp
+++ b/src/problems/cvrp/local_search/or_opt.cpp
@@ -154,3 +154,7 @@ void cvrp_or_opt::apply() const {
 std::vector<index_t> cvrp_or_opt::addition_candidates() const {
   return {s_vehicle};
 }
+
+std::vector<index_t> cvrp_or_opt::update_candidates() const {
+  return {s_vehicle, t_vehicle};
+}

--- a/src/problems/cvrp/local_search/or_opt.h
+++ b/src/problems/cvrp/local_search/or_opt.h
@@ -36,6 +36,8 @@ public:
   virtual void apply() const override;
 
   virtual std::vector<index_t> addition_candidates() const override;
+
+  virtual std::vector<index_t> update_candidates() const override;
 };
 
 #endif

--- a/src/problems/cvrp/local_search/relocate.cpp
+++ b/src/problems/cvrp/local_search/relocate.cpp
@@ -75,3 +75,7 @@ void cvrp_relocate::apply() const {
 std::vector<index_t> cvrp_relocate::addition_candidates() const {
   return {s_vehicle};
 }
+
+std::vector<index_t> cvrp_relocate::update_candidates() const {
+  return {s_vehicle, t_vehicle};
+}

--- a/src/problems/cvrp/local_search/relocate.h
+++ b/src/problems/cvrp/local_search/relocate.h
@@ -31,6 +31,8 @@ public:
   virtual void apply() const override;
 
   virtual std::vector<index_t> addition_candidates() const override;
+
+  virtual std::vector<index_t> update_candidates() const override;
 };
 
 #endif

--- a/src/problems/cvrp/local_search/reverse_2_opt.cpp
+++ b/src/problems/cvrp/local_search/reverse_2_opt.cpp
@@ -155,3 +155,7 @@ void cvrp_reverse_two_opt::apply() const {
 std::vector<index_t> cvrp_reverse_two_opt::addition_candidates() const {
   return {s_vehicle, t_vehicle};
 }
+
+std::vector<index_t> cvrp_reverse_two_opt::update_candidates() const {
+  return {s_vehicle, t_vehicle};
+}

--- a/src/problems/cvrp/local_search/reverse_2_opt.h
+++ b/src/problems/cvrp/local_search/reverse_2_opt.h
@@ -31,6 +31,8 @@ public:
   virtual void apply() const override;
 
   virtual std::vector<index_t> addition_candidates() const override;
+
+  virtual std::vector<index_t> update_candidates() const override;
 };
 
 #endif

--- a/src/problems/ls_operator.h
+++ b/src/problems/ls_operator.h
@@ -51,6 +51,8 @@ public:
 
   virtual std::vector<index_t> addition_candidates() const = 0;
 
+  virtual std::vector<index_t> update_candidates() const = 0;
+
   virtual ~ls_operator() {
   }
 };

--- a/src/problems/vrptw/local_search/inner_relocate.cpp
+++ b/src/problems/vrptw/local_search/inner_relocate.cpp
@@ -1,0 +1,63 @@
+/*
+
+This file is part of VROOM.
+
+Copyright (c) 2015-2018, Julien Coupey.
+All rights reserved (see LICENSE).
+
+*/
+
+#include "problems/vrptw/local_search/inner_relocate.h"
+
+vrptw_inner_relocate::vrptw_inner_relocate(const input& input,
+                                           const solution_state& sol_state,
+                                           tw_solution& tw_sol,
+                                           index_t s_vehicle,
+                                           index_t s_rank,
+                                           index_t t_rank)
+  : cvrp_inner_relocate(input,
+                        sol_state,
+                        tw_sol[s_vehicle].route,
+                        s_vehicle,
+                        s_rank,
+                        t_rank),
+    _tw_sol(tw_sol),
+    _rank_distance((s_rank < t_rank) ? t_rank - s_rank : s_rank - t_rank) {
+}
+
+bool vrptw_inner_relocate::is_valid() const {
+  std::vector<index_t> job_ranks(_rank_distance + 1);
+  index_t first_rank;
+  index_t last_rank;
+
+  if (t_rank < s_rank) {
+    job_ranks[0] = s_route[s_rank];
+    std::copy(s_route.begin() + t_rank,
+              s_route.begin() + s_rank,
+              job_ranks.begin() + 1);
+
+    first_rank = t_rank;
+    last_rank = s_rank + 1;
+  } else {
+    std::copy(s_route.begin() + s_rank + 1,
+              s_route.begin() + t_rank + 1,
+              job_ranks.begin());
+    job_ranks.back() = s_route[s_rank];
+
+    first_rank = s_rank;
+    last_rank = t_rank + 1;
+  }
+
+  return _tw_sol[s_vehicle].is_valid_addition_for_tw(_input,
+                                                     job_ranks.begin(),
+                                                     job_ranks.end(),
+                                                     first_rank,
+                                                     last_rank);
+}
+
+void vrptw_inner_relocate::apply() const {
+  auto relocate_job_rank = s_route[s_rank];
+
+  _tw_sol[s_vehicle].remove(_input, s_rank, 1);
+  _tw_sol[t_vehicle].add(_input, relocate_job_rank, t_rank);
+}

--- a/src/problems/vrptw/local_search/inner_relocate.h
+++ b/src/problems/vrptw/local_search/inner_relocate.h
@@ -1,0 +1,37 @@
+#ifndef VRPTW_INNER_RELOCATE_H
+#define VRPTW_INNER_RELOCATE_H
+
+/*
+
+This file is part of VROOM.
+
+Copyright (c) 2015-2018, Julien Coupey.
+All rights reserved (see LICENSE).
+
+*/
+
+#include "problems/cvrp/local_search/inner_relocate.h"
+#include "structures/vroom/tw_route.h"
+
+using tw_solution = std::vector<tw_route>;
+
+class vrptw_inner_relocate : public cvrp_inner_relocate {
+private:
+  tw_solution& _tw_sol;
+
+  const unsigned _rank_distance;
+
+public:
+  vrptw_inner_relocate(const input& input,
+                       const solution_state& sol_state,
+                       tw_solution& tw_sol,
+                       index_t s_vehicle,
+                       index_t s_rank,
+                       index_t t_rank); // relocate rank *after* removal.
+
+  virtual bool is_valid() const override;
+
+  virtual void apply() const override;
+};
+
+#endif

--- a/src/problems/vrptw/local_search/local_search.cpp
+++ b/src/problems/vrptw/local_search/local_search.cpp
@@ -292,7 +292,7 @@ void vrptw_local_search::run_ls_step() {
                           s_rank,
                           s_t.second,
                           t_rank);
-          if (r.is_valid() and r.gain() > best_gains[s_t.first][s_t.second]) {
+          if (r.gain() > best_gains[s_t.first][s_t.second] and r.is_valid()) {
             best_gains[s_t.first][s_t.second] = r.gain();
             best_ops[s_t.first][s_t.second] =
               std::make_unique<vrptw_two_opt>(r);
@@ -322,7 +322,7 @@ void vrptw_local_search::run_ls_step() {
                                   s_rank,
                                   s_t.second,
                                   t_rank);
-          if (r.is_valid() and r.gain() > best_gains[s_t.first][s_t.second]) {
+          if (r.gain() > best_gains[s_t.first][s_t.second] and r.is_valid()) {
             best_gains[s_t.first][s_t.second] = r.gain();
             best_ops[s_t.first][s_t.second] =
               std::make_unique<vrptw_reverse_two_opt>(r);
@@ -424,7 +424,7 @@ void vrptw_local_search::run_ls_step() {
                                  s_t.first,
                                  s_rank,
                                  t_rank);
-          if (r.is_valid() and r.gain() > best_gains[s_t.first][s_t.first]) {
+          if (r.gain() > best_gains[s_t.first][s_t.first] and r.is_valid()) {
             best_gains[s_t.first][s_t.first] = r.gain();
             best_ops[s_t.first][s_t.first] =
               std::make_unique<vrptw_inner_relocate>(r);

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -24,7 +24,7 @@ inline cost_t add_without_overflow(cost_t a, cost_t b) {
   return a + b;
 }
 
-// Compute cost of adding job with index job_index in given route at
+// Compute cost of adding job with rank job_rank in given route at
 // given rank for vehicle v.
 inline gain_t addition_cost(const input& input,
                             const matrix<cost_t>& m,


### PR DESCRIPTION
## Issue

This PR implements #170 in order to improve solutions, especially for the VRPTW use-case. Fixes #169.

## Tasks

 - [ ] Adjust local search process to include operations on a single route
 - [ ] Implement and evaluate for relocate
 - [ ] Implement and evaluate for or-opt
 - [ ] Implement and evaluate for exchange
 - [ ] Implement and evaluate for cross-exchange
 - [ ] Implement and evaluate for mixed_exchange
 - [ ] Update `CHANGELOG.md`
 - [ ] review
