### PR TITLE
Profile selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,20 @@
 
 ### Added
 
+- Optional `profile` key for vehicles to allow picking routing profile at query-time (#196)
+- `-r` command-line flag for explicit routing engine choice (#196)
+- Support for multiple named datasets when using `libosrm` (#181)
 - Generic `vroom` namespace and several other specializations (#135)
 
 ### Changed
 
 - Refactor to remove duplicate code for heuristic and local search (#176)
 - Refactor to enforce naming conventions that are now explicitly stated in `CONTRIBUTING.md` (#135)
+- Options `-a` and `-p` can be used to define profile-dependant servers (#196)
+
+### Removed
+
+- `-l` and `-m` command-line flags (#196)
 
 ## [v1.3.0]
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -60,6 +60,7 @@ A `vehicle` object has the following properties:
 | Key         | Description |
 | ----------- | ----------- |
 | `id` | an integer used as unique identifier |
+| [`profile`] | routing profile (defaults to `car`) |
 | [`start`] | coordinates array |
 | [`start_index`] | index of relevant row and column in custom matrix |
 | [`end`] | coordinates array |

--- a/libvroom_examples/libvroom.cpp
+++ b/libvroom_examples/libvroom.cpp
@@ -71,20 +71,16 @@ void log_solution(const vroom::Solution& sol, bool geometry) {
 void run_example_with_osrm() {
   bool GEOMETRY = true;
 
-  vroom::routing::Servers servers;
-  servers.emplace("car",                     // Profile
-                  vroom::Server("localhost", // OSRM server
-                                "5000")      // OSRM port
-  );
+  // Set OSRM host and port.
   auto routing_wrapper =
-    std::make_unique<vroom::routing::RoutedWrapper>(servers);
+    std::make_unique<vroom::routing::RoutedWrapper>("car",
+                                                    vroom::Server("localhost",
+                                                                  "5000"));
 
-  // // Pick profile if more than one is described in servers.
-  // routing_wrapper->set_profile("bike");
-
-  vroom::Input problem_instance(std::move(routing_wrapper),
-                                GEOMETRY); // Query for route geometry after
-                                           // solving.
+  vroom::Input problem_instance;
+  problem_instance.set_routing(std::move(routing_wrapper));
+  problem_instance.set_geometry(GEOMETRY); // Query for route geometry
+                                           // after solving.
 
   // Create one-dimension capacity restrictions to model the situation
   // where one vehicle can handle 4 jobs.

--- a/libvroom_examples/libvroom.cpp
+++ b/libvroom_examples/libvroom.cpp
@@ -68,19 +68,21 @@ void log_solution(const vroom::Solution& sol, bool geometry) {
   }
 }
 
-std::unique_ptr<vroom::routing::RoutedWrapper> routing_wrapper() {
-  // Create a wrapper for OSRM queries.
-  return std::make_unique<vroom::routing::RoutedWrapper>("localhost", // OSRM
-                                                                      // server
-                                                         "5000", // OSRM port
-                                                         "car"   // Profile
-  );
-}
-
 void run_example_with_osrm() {
   bool GEOMETRY = true;
 
-  vroom::Input problem_instance(routing_wrapper(),
+  vroom::routing::Servers servers;
+  servers.emplace("car",                     // Profile
+                  vroom::Server("localhost", // OSRM server
+                                "5000")      // OSRM port
+  );
+  auto routing_wrapper =
+    std::make_unique<vroom::routing::RoutedWrapper>(servers);
+
+  // // Pick profile if more than one is described in servers.
+  // routing_wrapper->set_profile("bike");
+
+  vroom::Input problem_instance(std::move(routing_wrapper),
                                 GEOMETRY); // Query for route geometry after
                                            // solving.
 
@@ -172,9 +174,7 @@ void run_example_with_osrm() {
 void run_example_with_custom_matrix() {
   bool GEOMETRY = false;
 
-  vroom::Input problem_instance(routing_wrapper(),
-                                GEOMETRY); // Query for route geometry after
-                                           // solving.
+  vroom::Input problem_instance;
 
   // Define custom matrix and bypass OSRM call.
   vroom::Matrix<vroom::Cost> matrix_input(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,6 +113,11 @@ int main(int argc, char** argv) {
     exit(1);
   }
 
+  // Add default server if none provided in input.
+  if (cl_args.servers.empty()) {
+    cl_args.servers.emplace(vroom::DEFAULT_PROFILE, vroom::Server());
+  }
+
   if (cl_args.input_file.empty()) {
     // Getting input from command-line.
     if (argc == optind) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,15 +27,8 @@ void display_usage() {
   usage += "Usage:\n\tvroom [OPTION]... \"INPUT\"";
   usage += "\n\tvroom [OPTION]... -i FILE\n";
   usage += "Options:\n";
-  usage += "\t-a ADDRESS (=\"0.0.0.0\")\t OSRM server address\n";
+  usage += "\t-a HOST (=\"0.0.0.0\")\t OSRM server\n";
   usage += "\t-p PORT (=5000),\t OSRM listening port\n";
-  // usage += "\t-m MODE,\t\t OSRM profile name (car)\n";
-
-  // The -m flag is only present as the profile name is part of the
-  // OSRM v5 API. It is undocumented as OSRM doesn't implement
-  // query-time profile selection (yet) so setting it will have no
-  // effect for now.
-
   usage += "\t-g,\t\t\t add detailed route geometry and indicators\n";
   usage += "\t-i FILE,\t\t read input from FILE rather than from stdin\n";
   usage += "\t-l,\t\t\t use libosrm rather than osrm-routed\n";
@@ -73,9 +66,6 @@ int main(int argc, char** argv) {
       break;
     case 'l':
       cl_args.use_libosrm = true;
-      break;
-    case 'm':
-      cl_args.osrm_profile = optarg;
       break;
     case 'o':
       cl_args.output_file = optarg;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,15 +32,15 @@ void display_usage() {
   usage += "\n\tvroom [OPTION]... -i FILE\n";
   usage += "Options:\n";
   usage += "\t-a PROFILE:HOST (=" + vroom::DEFAULT_PROFILE +
-           ":0.0.0.0)\t Routing server\n";
+           ":0.0.0.0)\t routing server\n";
   usage += "\t-p PROFILE:PORT (=" + vroom::DEFAULT_PROFILE +
-           ":5000),\t Routing server port\n";
-  usage += "\t-g,\t\t\t add detailed route geometry and indicators\n";
-  usage += "\t-i FILE,\t\t read input from FILE rather than from stdin\n";
-  usage += "\t-o OUTPUT,\t\t output file name\n";
-  usage += "\t-r ROUTER (=osrm),\t osrm or libosrm\n";
-  usage += "\t-t THREADS (=4),\t number of threads to use\n";
-  usage += "\t-x EXPLORE (=5),\t exploration level to use (0..5)";
+           ":5000),\t routing server port\n";
+  usage += "\t-g,\t\t\t\t add detailed route geometry and indicators\n";
+  usage += "\t-i FILE,\t\t\t read input from FILE rather than from stdin\n";
+  usage += "\t-o OUTPUT,\t\t\t output file name\n";
+  usage += "\t-r ROUTER (=osrm),\t\t osrm or libosrm\n";
+  usage += "\t-t THREADS (=4),\t\t number of threads to use\n";
+  usage += "\t-x EXPLORE (=5),\t\t exploration level to use (0..5)";
   std::cout << usage << std::endl;
   exit(0);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,8 +27,8 @@ void display_usage() {
   usage += "Usage:\n\tvroom [OPTION]... \"INPUT\"";
   usage += "\n\tvroom [OPTION]... -i FILE\n";
   usage += "Options:\n";
-  usage += "\t-a HOST (=\"0.0.0.0\")\t OSRM server\n";
-  usage += "\t-p PORT (=5000),\t OSRM listening port\n";
+  usage += "\t-a PROFILE:HOST (=car:0.0.0.0)\t Routing server\n";
+  usage += "\t-p PROFILE:PORT (=car:5000),\t Routing server port\n";
   usage += "\t-g,\t\t\t add detailed route geometry and indicators\n";
   usage += "\t-i FILE,\t\t read input from FILE rather than from stdin\n";
   usage += "\t-o OUTPUT,\t\t output file name\n";
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
   while (opt != -1) {
     switch (opt) {
     case 'a':
-      cl_args.server.address = optarg;
+      vroom::io::update_host(cl_args.servers, optarg);
       break;
     case 'g':
       cl_args.geometry = true;
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
       cl_args.output_file = optarg;
       break;
     case 'p':
-      cl_args.server.port = optarg;
+      vroom::io::update_port(cl_args.servers, optarg);
       break;
     case 'r':
       router_arg = optarg;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
   while (opt != -1) {
     switch (opt) {
     case 'a':
-      cl_args.osrm_address = optarg;
+      cl_args.server.address = optarg;
       break;
     case 'g':
       cl_args.geometry = true;
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
       cl_args.output_file = optarg;
       break;
     case 'p':
-      cl_args.osrm_port = optarg;
+      cl_args.server.port = optarg;
       break;
     case 'r':
       router_arg = optarg;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,8 +27,10 @@ void display_usage() {
   usage += "Usage:\n\tvroom [OPTION]... \"INPUT\"";
   usage += "\n\tvroom [OPTION]... -i FILE\n";
   usage += "Options:\n";
-  usage += "\t-a PROFILE:HOST (=car:0.0.0.0)\t Routing server\n";
-  usage += "\t-p PROFILE:PORT (=car:5000),\t Routing server port\n";
+  usage += "\t-a PROFILE:HOST (=" + vroom::DEFAULT_PROFILE +
+           ":0.0.0.0)\t Routing server\n";
+  usage += "\t-p PROFILE:PORT (=" + vroom::DEFAULT_PROFILE +
+           ":5000),\t Routing server port\n";
   usage += "\t-g,\t\t\t add detailed route geometry and indicators\n";
   usage += "\t-i FILE,\t\t read input from FILE rather than from stdin\n";
   usage += "\t-o OUTPUT,\t\t output file name\n";

--- a/src/makefile
+++ b/src/makefile
@@ -28,7 +28,7 @@ SRC = $(wildcard *.cpp)\
 # Checking for libosrm
 ifeq ($(shell pkg-config --exists libosrm && echo 1),1)
 LDLIBS += $(shell pkg-config --libs libosrm) -lboost_filesystem -lboost_iostreams -lboost_thread -lrt -ltbb
-CXXFLAGS += $(shell pkg-config --cflags libosrm) -D LIBOSRM=true
+CXXFLAGS += $(shell pkg-config --cflags libosrm) -D USE_LIBOSRM=true
 else
 	SRC := $(filter-out ./routing/libosrm_wrapper.cpp, $(SRC))
 endif

--- a/src/routing/libosrm_wrapper.cpp
+++ b/src/routing/libosrm_wrapper.cpp
@@ -19,7 +19,23 @@ namespace vroom {
 namespace routing {
 
 LibosrmWrapper::LibosrmWrapper(const std::string& profile)
-  : OSRMWrapper(profile), _config(), _osrm(_config) {
+  : OSRMWrapper(profile),
+    _config({
+      {},     // storare_config
+      -1,     // max_locations_trip
+      -1,     // max_locations_viaroute
+      -1,     // max_locations_distance_table
+      -1,     // max_locations_map_matching
+      -1.0,   // max_radius_map_matching
+      -1,     // max_results_nearest
+      1,      // max_alternatives
+      true,   // use_shared_memory
+      {},     // memory_file
+      {},     // algorithm
+      {},     // verbosity
+      profile // dataset_name
+    }),
+    _osrm(_config) {
 }
 
 Matrix<Cost>

--- a/src/routing/libosrm_wrapper.cpp
+++ b/src/routing/libosrm_wrapper.cpp
@@ -18,8 +18,7 @@ All rights reserved (see LICENSE).
 namespace vroom {
 namespace routing {
 
-LibosrmWrapper::LibosrmWrapper(const std::string& osrm_profile)
-  : OSRMWrapper(osrm_profile), _config(), _osrm(_config) {
+LibosrmWrapper::LibosrmWrapper() : _config(), _osrm(_config) {
 }
 
 Matrix<Cost>

--- a/src/routing/libosrm_wrapper.cpp
+++ b/src/routing/libosrm_wrapper.cpp
@@ -49,12 +49,7 @@ LibosrmWrapper::get_matrix(const std::vector<Location>& locs) const {
   }
 
   osrm::json::Object result;
-  osrm::Status status;
-  try {
-    status = _osrm.Table(params, result);
-  } catch (const std::exception& e) {
-    throw Exception(e.what());
-  }
+  osrm::Status status = _osrm.Table(params, result);
 
   if (status == osrm::Status::Error) {
     throw Exception(
@@ -117,12 +112,7 @@ void LibosrmWrapper::add_route_info(Route& route) const {
   }
 
   osrm::json::Object result;
-  osrm::Status status;
-  try {
-    status = _osrm.Route(params, result);
-  } catch (const std::exception& e) {
-    throw Exception(e.what());
-  }
+  osrm::Status status = _osrm.Route(params, result);
 
   if (status == osrm::Status::Error) {
     throw Exception(

--- a/src/routing/libosrm_wrapper.cpp
+++ b/src/routing/libosrm_wrapper.cpp
@@ -18,7 +18,8 @@ All rights reserved (see LICENSE).
 namespace vroom {
 namespace routing {
 
-LibosrmWrapper::LibosrmWrapper() : _config(), _osrm(_config) {
+LibosrmWrapper::LibosrmWrapper(const std::string& profile)
+  : OSRMWrapper(profile), _config(), _osrm(_config) {
 }
 
 Matrix<Cost>

--- a/src/routing/libosrm_wrapper.h
+++ b/src/routing/libosrm_wrapper.h
@@ -25,7 +25,7 @@ private:
   const osrm::OSRM _osrm;
 
 public:
-  LibosrmWrapper(const std::string& osrm_profile);
+  LibosrmWrapper();
 
   virtual Matrix<Cost>
   get_matrix(const std::vector<Location>& locs) const override;

--- a/src/routing/libosrm_wrapper.h
+++ b/src/routing/libosrm_wrapper.h
@@ -25,7 +25,7 @@ private:
   const osrm::OSRM _osrm;
 
 public:
-  LibosrmWrapper();
+  LibosrmWrapper(const std::string& profile);
 
   virtual Matrix<Cost>
   get_matrix(const std::vector<Location>& locs) const override;

--- a/src/routing/osrm_wrapper.h
+++ b/src/routing/osrm_wrapper.h
@@ -22,6 +22,9 @@ namespace routing {
 class OSRMWrapper : public Wrapper<Cost> {
 
 protected:
+  OSRMWrapper(const std::string& profile) : Wrapper(profile) {
+  }
+
   static Cost round_cost(double value) {
     return static_cast<Cost>(value + 0.5);
   }

--- a/src/routing/osrm_wrapper.h
+++ b/src/routing/osrm_wrapper.h
@@ -22,11 +22,11 @@ namespace routing {
 class OSRMWrapper : public Wrapper<Cost> {
 
 protected:
-  OSRMWrapper(const std::string& profile) : Wrapper(profile) {
-  }
-
   static Cost round_cost(double value) {
     return static_cast<Cost>(value + 0.5);
+  }
+
+  OSRMWrapper(const std::string& profile) : Wrapper(profile) {
   }
 
   inline void

--- a/src/routing/osrm_wrapper.h
+++ b/src/routing/osrm_wrapper.h
@@ -22,13 +22,8 @@ namespace routing {
 class OSRMWrapper : public Wrapper<Cost> {
 
 protected:
-  const std::string _osrm_profile; // OSRM profile name
-
   static Cost round_cost(double value) {
     return static_cast<Cost>(value + 0.5);
-  }
-
-  OSRMWrapper(const std::string& osrm_profile) : _osrm_profile(osrm_profile) {
   }
 
   inline void
@@ -44,12 +39,12 @@ protected:
       if (nb_unfound_from_loc[i] > max_unfound_routes_for_a_loc) {
         max_unfound_routes_for_a_loc = nb_unfound_from_loc[i];
         error_loc = i;
-        error_direction = "from";
+        error_direction = "from ";
       }
       if (nb_unfound_to_loc[i] > max_unfound_routes_for_a_loc) {
         max_unfound_routes_for_a_loc = nb_unfound_to_loc[i];
         error_loc = i;
-        error_direction = "to";
+        error_direction = "to ";
       }
     }
     if (max_unfound_routes_for_a_loc > 0) {

--- a/src/routing/routed_wrapper.cpp
+++ b/src/routing/routed_wrapper.cpp
@@ -20,9 +20,8 @@ namespace vroom {
 namespace routing {
 
 RoutedWrapper::RoutedWrapper(const std::string& address,
-                             const std::string& port,
-                             const std::string& osrm_profile)
-  : OSRMWrapper(osrm_profile), _address(address), _port(port) {
+                             const std::string& port)
+  : _address(address), _port(port) {
 }
 
 std::string RoutedWrapper::build_query(const std::vector<Location>& locations,
@@ -31,7 +30,7 @@ std::string RoutedWrapper::build_query(const std::vector<Location>& locations,
   // Building query for osrm-routed
   std::string query = "GET /" + service;
 
-  query += "/v1/" + _osrm_profile + "/";
+  query += "/v1/" + _profile + "/";
 
   // Adding locations.
   for (auto const& location : locations) {

--- a/src/routing/routed_wrapper.cpp
+++ b/src/routing/routed_wrapper.cpp
@@ -19,7 +19,21 @@ using boost::asio::ip::tcp;
 namespace vroom {
 namespace routing {
 
-RoutedWrapper::RoutedWrapper(const Server& server) : _server(server) {
+RoutedWrapper::RoutedWrapper(const Servers& servers) : _servers(servers) {
+  if (_servers.size() == 1) {
+    this->set_profile(_servers.begin()->first);
+  }
+}
+
+void RoutedWrapper::update_server() {
+  auto search = _servers.find(_profile);
+  if (search == _servers.end()) {
+    throw Exception("Invalid profile:" + _profile + ".");
+  }
+
+  auto& server = search->second;
+  _host = server.host;
+  _port = server.port;
 }
 
 std::string RoutedWrapper::build_query(const std::vector<Location>& locations,
@@ -42,7 +56,7 @@ std::string RoutedWrapper::build_query(const std::vector<Location>& locations,
   }
 
   query += " HTTP/1.1\r\n";
-  query += "Host: " + _server.address + "\r\n";
+  query += "Host: " + _host + "\r\n";
   query += "Accept: */*\r\n";
   query += "Connection: close\r\n\r\n";
 
@@ -56,7 +70,8 @@ std::string RoutedWrapper::send_then_receive(std::string query) const {
     boost::asio::io_service io_service;
 
     tcp::resolver r(io_service);
-    tcp::resolver::query q(_server.address, _server.port);
+
+    tcp::resolver::query q(_host, _port);
 
     tcp::socket s(io_service);
     boost::asio::connect(s, r.resolve(q));
@@ -182,6 +197,11 @@ void RoutedWrapper::add_route_info(Route& route) const {
     current_distance += infos["routes"][0]["legs"][i]["distance"].GetDouble();
     route.steps[i + 1].distance = round_cost(current_distance);
   }
+}
+
+void RoutedWrapper::set_profile(const std::string& profile) {
+  Wrapper::set_profile(profile);
+  this->update_server();
 }
 
 } // namespace routing

--- a/src/routing/routed_wrapper.cpp
+++ b/src/routing/routed_wrapper.cpp
@@ -93,7 +93,7 @@ std::string RoutedWrapper::send_then_receive(std::string query) const {
       }
     }
   } catch (boost::system::system_error& e) {
-    throw Exception("Failure while connecting to the OSRM server.");
+    throw Exception("Failed to connect to OSRM at " + _host + ":" + _port);
   }
   return response;
 }

--- a/src/routing/routed_wrapper.cpp
+++ b/src/routing/routed_wrapper.cpp
@@ -19,9 +19,7 @@ using boost::asio::ip::tcp;
 namespace vroom {
 namespace routing {
 
-RoutedWrapper::RoutedWrapper(const std::string& address,
-                             const std::string& port)
-  : _address(address), _port(port) {
+RoutedWrapper::RoutedWrapper(const Server& server) : _server(server) {
 }
 
 std::string RoutedWrapper::build_query(const std::vector<Location>& locations,
@@ -44,7 +42,7 @@ std::string RoutedWrapper::build_query(const std::vector<Location>& locations,
   }
 
   query += " HTTP/1.1\r\n";
-  query += "Host: " + _address + "\r\n";
+  query += "Host: " + _server.address + "\r\n";
   query += "Accept: */*\r\n";
   query += "Connection: close\r\n\r\n";
 
@@ -58,7 +56,7 @@ std::string RoutedWrapper::send_then_receive(std::string query) const {
     boost::asio::io_service io_service;
 
     tcp::resolver r(io_service);
-    tcp::resolver::query q(_address, _port);
+    tcp::resolver::query q(_server.address, _server.port);
 
     tcp::socket s(io_service);
     boost::asio::connect(s, r.resolve(q));

--- a/src/routing/routed_wrapper.h
+++ b/src/routing/routed_wrapper.h
@@ -28,9 +28,7 @@ private:
   std::string send_then_receive(std::string query) const;
 
 public:
-  RoutedWrapper(const std::string& address,
-                const std::string& port,
-                const std::string& osrm_profile);
+  RoutedWrapper(const std::string& address, const std::string& port);
 
   virtual Matrix<Cost>
   get_matrix(const std::vector<Location>& locs) const override;

--- a/src/routing/routed_wrapper.h
+++ b/src/routing/routed_wrapper.h
@@ -17,14 +17,10 @@ All rights reserved (see LICENSE).
 namespace vroom {
 namespace routing {
 
-using Servers = std::unordered_map<std::string, Server>;
-
 class RoutedWrapper : public OSRMWrapper {
 
 private:
-  Servers _servers;
-  std::string _host;
-  std::string _port;
+  Server _server;
 
   void update_server();
 
@@ -35,14 +31,12 @@ private:
   std::string send_then_receive(std::string query) const;
 
 public:
-  RoutedWrapper(const Servers& servers);
+  RoutedWrapper(const std::string& profile, const Server& server);
 
   virtual Matrix<Cost>
   get_matrix(const std::vector<Location>& locs) const override;
 
   virtual void add_route_info(Route& route) const override;
-
-  virtual void set_profile(const std::string& profile) override;
 };
 
 } // namespace routing

--- a/src/routing/routed_wrapper.h
+++ b/src/routing/routed_wrapper.h
@@ -10,15 +10,23 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <unordered_map>
+
 #include "routing/osrm_wrapper.h"
 
 namespace vroom {
 namespace routing {
 
+using Servers = std::unordered_map<std::string, Server>;
+
 class RoutedWrapper : public OSRMWrapper {
 
 private:
-  Server _server;
+  Servers _servers;
+  std::string _host;
+  std::string _port;
+
+  void update_server();
 
   std::string build_query(const std::vector<Location>& locations,
                           std::string service,
@@ -27,12 +35,14 @@ private:
   std::string send_then_receive(std::string query) const;
 
 public:
-  RoutedWrapper(const Server& server);
+  RoutedWrapper(const Servers& servers);
 
   virtual Matrix<Cost>
   get_matrix(const std::vector<Location>& locs) const override;
 
   virtual void add_route_info(Route& route) const override;
+
+  virtual void set_profile(const std::string& profile) override;
 };
 
 } // namespace routing

--- a/src/routing/routed_wrapper.h
+++ b/src/routing/routed_wrapper.h
@@ -18,8 +18,7 @@ namespace routing {
 class RoutedWrapper : public OSRMWrapper {
 
 private:
-  std::string _address;
-  std::string _port;
+  Server _server;
 
   std::string build_query(const std::vector<Location>& locations,
                           std::string service,
@@ -28,7 +27,7 @@ private:
   std::string send_then_receive(std::string query) const;
 
 public:
-  RoutedWrapper(const std::string& address, const std::string& port);
+  RoutedWrapper(const Server& server);
 
   virtual Matrix<Cost>
   get_matrix(const std::vector<Location>& locs) const override;

--- a/src/routing/routed_wrapper.h
+++ b/src/routing/routed_wrapper.h
@@ -10,8 +10,6 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <unordered_map>
-
 #include "routing/osrm_wrapper.h"
 
 namespace vroom {

--- a/src/routing/wrapper.h
+++ b/src/routing/wrapper.h
@@ -28,15 +28,11 @@ public:
 
   virtual void add_route_info(Route& route) const = 0;
 
-  virtual void set_profile(const std::string& profile) {
-    _profile = profile;
-  }
-
   virtual ~Wrapper() {
   }
 
 protected:
-  Wrapper() : _profile(DEFAULT_PROFILE) {
+  Wrapper(const std::string& profile) : _profile(profile) {
   }
 };
 

--- a/src/routing/wrapper.h
+++ b/src/routing/wrapper.h
@@ -22,11 +22,15 @@ namespace routing {
 template <class T> class Wrapper {
 
 public:
-  const std::string _profile;
+  std::string _profile;
 
   virtual Matrix<T> get_matrix(const std::vector<Location>& locs) const = 0;
 
   virtual void add_route_info(Route& route) const = 0;
+
+  virtual void set_profile(const std::string& profile) {
+    _profile = profile;
+  }
 
   virtual ~Wrapper() {
   }

--- a/src/routing/wrapper.h
+++ b/src/routing/wrapper.h
@@ -36,7 +36,7 @@ public:
   }
 
 protected:
-  Wrapper() : _profile("car") {
+  Wrapper() : _profile(DEFAULT_PROFILE) {
   }
 };
 

--- a/src/routing/wrapper.h
+++ b/src/routing/wrapper.h
@@ -22,6 +22,8 @@ namespace routing {
 template <class T> class Wrapper {
 
 public:
+  const std::string _profile;
+
   virtual Matrix<T> get_matrix(const std::vector<Location>& locs) const = 0;
 
   virtual void add_route_info(Route& route) const = 0;
@@ -30,7 +32,7 @@ public:
   }
 
 protected:
-  Wrapper() {
+  Wrapper() : _profile("car") {
   }
 };
 

--- a/src/structures/cl_args.cpp
+++ b/src/structures/cl_args.cpp
@@ -21,7 +21,7 @@ CLArgs::CLArgs()
 
 void update_host(Servers& servers, const std::string& value) {
   // Determine profile and host from a "car:0.0.0.0"-like value.
-  std::string profile = "car";
+  std::string profile = DEFAULT_PROFILE;
   std::string host;
 
   auto index = value.find(':');
@@ -44,7 +44,7 @@ void update_host(Servers& servers, const std::string& value) {
 
 void update_port(Servers& servers, const std::string& value) {
   // Determine profile and port from a "car:0.0.0.0"-like value.
-  std::string profile = "car";
+  std::string profile = DEFAULT_PROFILE;
   std::string port;
 
   auto index = value.find(':');

--- a/src/structures/cl_args.cpp
+++ b/src/structures/cl_args.cpp
@@ -19,7 +19,7 @@ CLArgs::CLArgs()
   : osrm_address("0.0.0.0"),
     geometry(false),
     osrm_port("5000"),
-    use_libosrm(false),
+    router(ROUTER::OSRM),
     nb_threads(4),
     exploration_level(5) {
 }

--- a/src/structures/cl_args.cpp
+++ b/src/structures/cl_args.cpp
@@ -19,5 +19,51 @@ CLArgs::CLArgs()
   : geometry(false), router(ROUTER::OSRM), nb_threads(4), exploration_level(5) {
 }
 
+void update_host(Servers& servers, const std::string& value) {
+  // Determine profile and host from a "car:0.0.0.0"-like value.
+  std::string profile = "car";
+  std::string host;
+
+  auto index = value.find(':');
+  if (index == std::string::npos) {
+    host = value;
+  } else {
+    profile = value.substr(0, index);
+    host = value.substr(index + 1);
+  }
+
+  auto existing_profile = servers.find(profile);
+  if (existing_profile != servers.end()) {
+    existing_profile->second.host = host;
+  } else {
+    auto add_result = servers.emplace(profile, Server());
+    assert(add_result.second);
+    add_result.first->second.host = host;
+  }
+}
+
+void update_port(Servers& servers, const std::string& value) {
+  // Determine profile and port from a "car:0.0.0.0"-like value.
+  std::string profile = "car";
+  std::string port;
+
+  auto index = value.find(':');
+  if (index == std::string::npos) {
+    port = value;
+  } else {
+    profile = value.substr(0, index);
+    port = value.substr(index + 1);
+  }
+
+  auto existing_profile = servers.find(profile);
+  if (existing_profile != servers.end()) {
+    existing_profile->second.port = port;
+  } else {
+    auto add_result = servers.emplace(profile, Server());
+    assert(add_result.second);
+    add_result.first->second.port = port;
+  }
+}
+
 } // namespace io
 } // namespace vroom

--- a/src/structures/cl_args.cpp
+++ b/src/structures/cl_args.cpp
@@ -21,7 +21,6 @@ CLArgs::CLArgs()
     osrm_port("5000"),
     use_libosrm(false),
     nb_threads(4),
-    osrm_profile("car"),
     exploration_level(5) {
 }
 

--- a/src/structures/cl_args.cpp
+++ b/src/structures/cl_args.cpp
@@ -16,12 +16,7 @@ const unsigned CLArgs::max_exploration_level = 5;
 
 // Default values.
 CLArgs::CLArgs()
-  : osrm_address("0.0.0.0"),
-    geometry(false),
-    osrm_port("5000"),
-    router(ROUTER::OSRM),
-    nb_threads(4),
-    exploration_level(5) {
+  : geometry(false), router(ROUTER::OSRM), nb_threads(4), exploration_level(5) {
 }
 
 } // namespace io

--- a/src/structures/cl_args.h
+++ b/src/structures/cl_args.h
@@ -25,7 +25,6 @@ struct CLArgs {
   bool use_libosrm;           // -l
   std::string input;          // cl arg
   unsigned nb_threads;        // -t
-  std::string osrm_profile;   // -m
   unsigned exploration_level; // -x
 
   static const unsigned max_exploration_level;

--- a/src/structures/cl_args.h
+++ b/src/structures/cl_args.h
@@ -19,11 +19,10 @@ namespace io {
 
 struct CLArgs {
   // Listing command-line options.
-  std::string osrm_address;   // -a
+  Server server;              // -a and -p
   bool geometry;              // -g
   std::string input_file;     // -i
   std::string output_file;    // -o
-  std::string osrm_port;      // -p
   ROUTER router;              // -r
   std::string input;          // cl arg
   unsigned nb_threads;        // -t

--- a/src/structures/cl_args.h
+++ b/src/structures/cl_args.h
@@ -12,6 +12,8 @@ All rights reserved (see LICENSE).
 
 #include <string>
 
+#include "structures/typedefs.h"
+
 namespace vroom {
 namespace io {
 
@@ -22,7 +24,7 @@ struct CLArgs {
   std::string input_file;     // -i
   std::string output_file;    // -o
   std::string osrm_port;      // -p
-  bool use_libosrm;           // -l
+  ROUTER router;              // -r
   std::string input;          // cl arg
   unsigned nb_threads;        // -t
   unsigned exploration_level; // -x

--- a/src/structures/cl_args.h
+++ b/src/structures/cl_args.h
@@ -18,6 +18,7 @@ All rights reserved (see LICENSE).
 namespace vroom {
 namespace io {
 
+// Profile name used as key.
 using Servers = std::unordered_map<std::string, Server>;
 
 struct CLArgs {

--- a/src/structures/cl_args.h
+++ b/src/structures/cl_args.h
@@ -11,15 +11,18 @@ All rights reserved (see LICENSE).
 */
 
 #include <string>
+#include <unordered_map>
 
 #include "structures/typedefs.h"
 
 namespace vroom {
 namespace io {
 
+using Servers = std::unordered_map<std::string, Server>;
+
 struct CLArgs {
   // Listing command-line options.
-  Server server;              // -a and -p
+  Servers servers;            // -a and -p
   bool geometry;              // -g
   std::string input_file;     // -i
   std::string output_file;    // -o
@@ -32,6 +35,10 @@ struct CLArgs {
 
   CLArgs();
 };
+
+void update_host(Servers& servers, const std::string& value);
+
+void update_port(Servers& servers, const std::string& value);
 
 } // namespace io
 } // namespace vroom

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -42,6 +42,15 @@ constexpr Cost INFINITE_COST = 3 * (std::numeric_limits<Cost>::max() / 4);
 // Available routing engines.
 enum class ROUTER { OSRM, LIBOSRM };
 
+// Used to describe a routing server.
+struct Server {
+  std::string address;
+  std::string port;
+
+  Server() : address("0.0.0.0"), port("5000") {
+  }
+};
+
 // Available location status.
 enum class STEP_TYPE { START, JOB, END };
 

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -44,10 +44,13 @@ enum class ROUTER { OSRM, LIBOSRM };
 
 // Used to describe a routing server.
 struct Server {
-  std::string address;
+  std::string host;
   std::string port;
 
-  Server() : address("0.0.0.0"), port("5000") {
+  Server() : host("0.0.0.0"), port("5000") {
+  }
+  Server(const std::string& host, const std::string& port)
+    : host(host), port(port) {
   }
 };
 

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -51,6 +51,7 @@ struct Server {
 
   Server() : host("0.0.0.0"), port("5000") {
   }
+
   Server(const std::string& host, const std::string& port)
     : host(host), port(port) {
   }

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -39,6 +39,9 @@ using Skills = std::unordered_set<Skill>;
 // Setting max value would cause trouble with further additions.
 constexpr Cost INFINITE_COST = 3 * (std::numeric_limits<Cost>::max() / 4);
 
+// Available routing engines.
+enum class ROUTER { OSRM, LIBOSRM };
+
 // Available location status.
 enum class STEP_TYPE { START, JOB, END };
 

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -39,6 +39,8 @@ using Skills = std::unordered_set<Skill>;
 // Setting max value would cause trouble with further additions.
 constexpr Cost INFINITE_COST = 3 * (std::numeric_limits<Cost>::max() / 4);
 
+const std::string DEFAULT_PROFILE = "car";
+
 // Available routing engines.
 enum class ROUTER { OSRM, LIBOSRM };
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -20,6 +20,14 @@ All rights reserved (see LICENSE).
 
 namespace vroom {
 
+Input::Input()
+  : _start_loading(std::chrono::high_resolution_clock::now()),
+    _has_TW(false),
+    _homogeneous_locations(true),
+    _geometry(false),
+    _all_locations_have_coords(true) {
+}
+
 Input::Input(std::unique_ptr<routing::Wrapper<Cost>> routing_wrapper,
              bool geometry)
   : _start_loading(std::chrono::high_resolution_clock::now()),

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -28,14 +28,13 @@ Input::Input()
     _all_locations_have_coords(true) {
 }
 
-Input::Input(std::unique_ptr<routing::Wrapper<Cost>> routing_wrapper,
-             bool geometry)
-  : _start_loading(std::chrono::high_resolution_clock::now()),
-    _routing_wrapper(std::move(routing_wrapper)),
-    _has_TW(false),
-    _homogeneous_locations(true),
-    _geometry(geometry),
-    _all_locations_have_coords(true) {
+void Input::set_geometry(bool geometry) {
+  _geometry = geometry;
+}
+
+void Input::set_routing(
+  std::unique_ptr<routing::Wrapper<Cost>> routing_wrapper) {
+  _routing_wrapper = std::move(routing_wrapper);
 }
 
 void Input::add_job(const Job& job) {
@@ -319,10 +318,6 @@ Solution Input::solve(unsigned exploration_level, unsigned nb_thread) {
   }
 
   return sol;
-}
-
-void Input::set_profile(const std::string& profile) {
-  _routing_wrapper->set_profile(profile);
 }
 
 } // namespace vroom

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -321,4 +321,8 @@ Solution Input::solve(unsigned exploration_level, unsigned nb_thread) {
   return sol;
 }
 
+void Input::set_profile(const std::string& profile) {
+  _routing_wrapper->set_profile(profile);
+}
+
 } // namespace vroom

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -37,7 +37,7 @@ private:
   bool _has_skills;
   bool _has_TW;
   bool _homogeneous_locations;
-  const bool _geometry;
+  bool _geometry;
   Matrix<Cost> _matrix;
   std::vector<Location> _locations;
   unsigned _amount_size;
@@ -62,7 +62,9 @@ public:
 
   Input();
 
-  Input(std::unique_ptr<routing::Wrapper<Cost>> routing_wrapper, bool geometry);
+  void set_geometry(bool geometry);
+
+  void set_routing(std::unique_ptr<routing::Wrapper<Cost>> routing_wrapper);
 
   void add_job(const Job& job);
 
@@ -85,8 +87,6 @@ public:
   Matrix<Cost> get_sub_matrix(const std::vector<Index>& indices) const;
 
   Solution solve(unsigned exploration_level, unsigned nb_thread);
-
-  void set_profile(const std::string& profile);
 };
 
 } // namespace vroom

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -60,6 +60,8 @@ public:
   std::vector<Job> jobs;
   std::vector<Vehicle> vehicles;
 
+  Input();
+
   Input(std::unique_ptr<routing::Wrapper<Cost>> routing_wrapper, bool geometry);
 
   void add_job(const Job& job);

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -85,6 +85,8 @@ public:
   Matrix<Cost> get_sub_matrix(const std::vector<Index>& indices) const;
 
   Solution solve(unsigned exploration_level, unsigned nb_thread);
+
+  void set_profile(const std::string& profile);
 };
 
 } // namespace vroom

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -10,6 +10,10 @@ All rights reserved (see LICENSE).
 #include <array>
 #include <vector>
 
+#if USE_LIBOSRM
+#include "osrm/exception.hpp"
+#endif
+
 #include "../include/rapidjson/document.h"
 #include "../include/rapidjson/error/en.h"
 
@@ -370,8 +374,12 @@ Input parse(const CLArgs& cl_args) {
     case ROUTER::LIBOSRM:
 #if USE_LIBOSRM
       // Use libosrm.
-      routing_wrapper =
-        std::make_unique<routing::LibosrmWrapper>(common_profile);
+      try {
+        routing_wrapper =
+          std::make_unique<routing::LibosrmWrapper>(common_profile);
+      } catch (const osrm::exception& e) {
+        throw Exception("Invalid shared memory region: " + common_profile);
+      }
 #else
       // Attempt to use libosrm while compiling without it.
       throw Exception("VROOM compiled without libosrm installed.");

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -135,16 +135,11 @@ Input parse(const CLArgs& cl_args) {
     // Use osrm-routed.
     routing_wrapper =
       std::make_unique<routing::RoutedWrapper>(cl_args.osrm_address,
-                                               cl_args.osrm_port,
-                                               cl_args.osrm_profile);
+                                               cl_args.osrm_port);
   } else {
 #if LIBOSRM
     // Use libosrm.
-    if (cl_args.osrm_profile.empty()) {
-      throw Exception("-l flag requires -m.");
-    }
-    routing_wrapper =
-      std::make_unique<routing::LibosrmWrapper>(cl_args.osrm_profile);
+    routing_wrapper = std::make_unique<routing::LibosrmWrapper>();
 #else
     throw Exception("libosrm must be installed to use -l.");
 #endif

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -134,9 +134,7 @@ Input parse(const CLArgs& cl_args) {
   switch (cl_args.router) {
   case ROUTER::OSRM:
     // Use osrm-routed.
-    routing_wrapper =
-      std::make_unique<routing::RoutedWrapper>(cl_args.osrm_address,
-                                               cl_args.osrm_port);
+    routing_wrapper = std::make_unique<routing::RoutedWrapper>(cl_args.server);
     break;
   case ROUTER::LIBOSRM:
 #if USE_LIBOSRM

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -148,7 +148,7 @@ Input parse(const CLArgs& cl_args) {
   }
 
   // TODO set this in Input after parsing vehicles.
-  routing_wrapper->set_profile("car");
+  routing_wrapper->set_profile(vroom::DEFAULT_PROFILE);
 
   // Custom input object embedding jobs, vehicles and matrix.
   Input input_data(std::move(routing_wrapper), cl_args.geometry);

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -321,6 +321,7 @@ Input parse(const CLArgs& cl_args) {
 
     // All vehicles.
     std::string common_profile;
+    bool has_input_profile = false;
     for (rapidjson::SizeType i = 0; i < json_input["vehicles"].Size(); ++i) {
       auto& json_vehicle = json_input["vehicles"][i];
       if (!valid_vehicle(json_vehicle)) {
@@ -355,6 +356,7 @@ Input parse(const CLArgs& cl_args) {
       input.add_vehicle(current_v);
 
       bool has_profile = json_vehicle.HasMember("profile");
+      has_input_profile |= has_profile;
       std::string current_profile =
         (has_profile) ? get_string(json_vehicle, "profile") : DEFAULT_PROFILE;
 
@@ -369,7 +371,9 @@ Input parse(const CLArgs& cl_args) {
       }
     }
 
-    input.set_profile(common_profile);
+    if (has_input_profile) {
+      input.set_profile(common_profile);
+    }
 
     // Getting jobs.
     for (rapidjson::SizeType i = 0; i < json_input["jobs"].Size(); ++i) {

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -134,7 +134,7 @@ Input parse(const CLArgs& cl_args) {
   switch (cl_args.router) {
   case ROUTER::OSRM:
     // Use osrm-routed.
-    routing_wrapper = std::make_unique<routing::RoutedWrapper>(cl_args.server);
+    routing_wrapper = std::make_unique<routing::RoutedWrapper>(cl_args.servers);
     break;
   case ROUTER::LIBOSRM:
 #if USE_LIBOSRM
@@ -146,6 +146,9 @@ Input parse(const CLArgs& cl_args) {
 #endif
     break;
   }
+
+  // TODO set this in Input after parsing vehicles.
+  routing_wrapper->set_profile("car");
 
   // Custom input object embedding jobs, vehicles and matrix.
   Input input_data(std::move(routing_wrapper), cl_args.geometry);


### PR DESCRIPTION
## Issue

This PR aims at adding a way to decide routing profile at query time (see #187). When using `libosrm`, this will be implemented via #181.

## Tasks

 - [x] Remove `-m` flag
 - [x] Add `-r` flag to decide on routing engine and remove `-l`
 - [x] Adjust `-a` and `-p` input parsing to make them profile-dependant
 - [x] Parse `profile` key for vehicles in input and check for consistency
 - [x] Set routing profile based on input
 - [x] Handle `libosrm` use-case with named shared memory datasets
 - [x] Update `docs/API.md`
 - [x] Update `CHANGELOG.md`
 - [x] review
