### PR TITLE
Use incompatibilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - `-r` command-line flag for explicit routing engine choice (#196)
 - Support for multiple named datasets when using `libosrm` (#181)
 - Generic `vroom` namespace and several other specializations (#135)
+- Spot more job/vehicle incompatibilities derived from constraints (#201)
+- Filter out irrelevant local search neighbourhoods for vehicles with disjoint job candidates (#202)
 
 ### Changed
 

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -265,11 +265,14 @@ void LocalSearch<Route,
     best_ops[v] = std::vector<std::unique_ptr<Operator>>(_nb_vehicles);
   }
 
-  // List of source/target pairs we need to test (all at first).
+  // List of source/target pairs we need to test (all related vehicles
+  // at first).
   std::vector<std::pair<Index, Index>> s_t_pairs;
   for (unsigned s_v = 0; s_v < _nb_vehicles; ++s_v) {
     for (unsigned t_v = 0; t_v < _nb_vehicles; ++t_v) {
-      s_t_pairs.emplace_back(s_v, t_v);
+      if (_input.vehicle_ok_with_vehicle(s_v, t_v)) {
+        s_t_pairs.emplace_back(s_v, t_v);
+      }
     }
   }
 
@@ -704,10 +707,12 @@ void LocalSearch<Route,
 
       for (unsigned v = 0; v < _nb_vehicles; ++v) {
         for (auto v_rank : update_candidates) {
-          best_gains[v][v_rank] = 0;
-          s_t_pairs.emplace_back(v, v_rank);
-          if (v != v_rank) {
-            s_t_pairs.emplace_back(v_rank, v);
+          if (_input.vehicle_ok_with_vehicle(v, v_rank)) {
+            best_gains[v][v_rank] = 0;
+            s_t_pairs.emplace_back(v, v_rank);
+            if (v != v_rank) {
+              s_t_pairs.emplace_back(v_rank, v);
+            }
           }
         }
       }

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -177,6 +177,10 @@ bool Input::vehicle_ok_with_job(Index v_index, Index j_index) const {
   return _vehicle_to_job_compatibility[v_index][j_index];
 }
 
+bool Input::vehicle_ok_with_vehicle(Index v1_index, Index v2_index) const {
+  return _vehicle_to_vehicle_compatibility[v1_index][v2_index];
+}
+
 const Matrix<Cost>& Input::get_matrix() const {
   return _matrix;
 }

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -83,6 +83,9 @@ public:
 
   bool vehicle_ok_with_job(Index v_index, Index j_index) const;
 
+  // Returns true iff both vehicles have common job candidates.
+  bool vehicle_ok_with_vehicle(Index v1_index, Index v2_index) const;
+
   const Matrix<Cost>& get_matrix() const;
 
   Matrix<Cost> get_sub_matrix(const std::vector<Index>& indices) const;

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -43,6 +43,7 @@ private:
   unsigned _amount_size;
   Amount _amount_lower_bound;
   std::vector<std::vector<bool>> _vehicle_to_job_compatibility;
+  std::vector<std::vector<bool>> _vehicle_to_vehicle_compatibility;
   std::unordered_set<Index> _matrix_used_index;
   bool _all_locations_have_coords;
 
@@ -52,7 +53,7 @@ private:
 
   void check_cost_bound() const;
 
-  void set_vehicle_to_job_compatibility();
+  void set_compatibility();
 
   void store_amount_lower_bound(const Amount& amount);
 


### PR DESCRIPTION
## Issue

Covers #201 and #202 to speed-up local search by removing irrelevant neighbourhoods and tests.

## Tasks

 - [x] Add additional job/vehicle incompatibilities derived from constraints
 - [x] Don't include vehicle pairs for local search neighbourhoods if they don't share some job candidates
 - [x] Ensure the overhead is negligible using unaffected instances
 - [x] Evaluate the gain on affected instances
 - [x] Update `CHANGELOG.md`
 - [ ] review
