### PR TITLE
Parse vehicle ids using GetUint64.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Parsing vehicle ids as `uint64_t` (#228)
+
 ## [v1.4.0] - 2019-03-26
 
 ### Added

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -206,7 +206,7 @@ Input parse(const CLArgs& cl_args) {
         throw Exception(ERROR::INPUT,
                         "Invalid vehicle at " + std::to_string(i) + ".");
       }
-      auto v_id = json_vehicle["id"].GetUint();
+      auto v_id = json_vehicle["id"].GetUint64();
 
       // Check if vehicle has start_index or end_index.
       bool has_start_index = json_vehicle.HasMember("start_index");
@@ -362,7 +362,7 @@ Input parse(const CLArgs& cl_args) {
         end = boost::optional<Location>(parse_coordinates(json_vehicle, "end"));
       }
 
-      Vehicle current_v(json_vehicle["id"].GetUint(),
+      Vehicle current_v(json_vehicle["id"].GetUint64(),
                         start,
                         end,
                         get_amount(json_vehicle, "capacity"),


### PR DESCRIPTION
## Issue

Fixes #228 

## Tasks

 - [x] Switch to `GetUint64` for vehicle ids parsing
 - [x] Update `CHANGELOG.md`
 - [x] review
