### PR TITLE
Refactor/micro opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `HttpWrapper` class to factor code previously duplicated across routing wrappers (#224)
 
+### Changed
+
+- Speed up solving by 25% for CVRP and up to 30% for VRPTW benchmark instances (#255)
+
 ### Fixed
 
 - Implicit instantiation of undefined template error for macos g++ compiler (#231)

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -121,6 +121,8 @@ void LocalSearch<Route,
                                                   routes,
                                                 double regret_coeff) {
   bool job_added;
+  std::vector<Gain> best_costs;
+  std::vector<Index> best_ranks;
 
   do {
     double best_cost = std::numeric_limits<double>::max();
@@ -130,10 +132,9 @@ void LocalSearch<Route,
 
     for (const auto j : _sol_state.unassigned) {
       auto& current_amount = _input.jobs[j].amount;
-      std::vector<Gain> best_costs(routes.size(),
-                                   std::numeric_limits<Gain>::max());
-      std::vector<Index> best_ranks(routes.size());
 
+      best_costs.assign(routes.size(), std::numeric_limits<Gain>::max());
+      best_ranks.assign(routes.size(), 0);
       for (std::size_t i = 0; i < routes.size(); ++i) {
         auto v = routes[i];
         const auto& v_target = _input.vehicles[v];

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -371,7 +371,8 @@ void LocalSearch<Route,
         continue;
       }
       for (unsigned s_rank = 0; s_rank < _sol[s_t.first].size(); ++s_rank) {
-        auto s_free_amount = _input.vehicles[s_t.first].capacity - _sol_state.fwd_amounts[s_t.first][s_rank];
+        auto s_free_amount = _input.vehicles[s_t.first].capacity -
+                             _sol_state.fwd_amounts[s_t.first][s_rank];
         for (int t_rank = _sol[s_t.second].size() - 1; t_rank >= 0; --t_rank) {
           if (!(_sol_state.bwd_amounts[s_t.second][t_rank] <= s_free_amount)) {
             break;
@@ -398,7 +399,8 @@ void LocalSearch<Route,
         continue;
       }
       for (unsigned s_rank = 0; s_rank < _sol[s_t.first].size(); ++s_rank) {
-        auto s_free_amount = _input.vehicles[s_t.first].capacity - _sol_state.fwd_amounts[s_t.first][s_rank];
+        auto s_free_amount = _input.vehicles[s_t.first].capacity -
+                             _sol_state.fwd_amounts[s_t.first][s_rank];
         for (unsigned t_rank = 0; t_rank < _sol[s_t.second].size(); ++t_rank) {
           if (!(_sol_state.fwd_amounts[s_t.second][t_rank] <= s_free_amount)) {
             break;

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -371,8 +371,7 @@ void LocalSearch<Route,
         continue;
       }
       for (unsigned s_rank = 0; s_rank < _sol[s_t.first].size(); ++s_rank) {
-        auto s_free_amount = _input.vehicles[s_t.first].capacity;
-        s_free_amount -= _sol_state.fwd_amounts[s_t.first][s_rank];
+        auto s_free_amount = _input.vehicles[s_t.first].capacity - _sol_state.fwd_amounts[s_t.first][s_rank];
         for (int t_rank = _sol[s_t.second].size() - 1; t_rank >= 0; --t_rank) {
           if (!(_sol_state.bwd_amounts[s_t.second][t_rank] <= s_free_amount)) {
             break;
@@ -399,8 +398,7 @@ void LocalSearch<Route,
         continue;
       }
       for (unsigned s_rank = 0; s_rank < _sol[s_t.first].size(); ++s_rank) {
-        auto s_free_amount = _input.vehicles[s_t.first].capacity;
-        s_free_amount -= _sol_state.fwd_amounts[s_t.first][s_rank];
+        auto s_free_amount = _input.vehicles[s_t.first].capacity - _sol_state.fwd_amounts[s_t.first][s_rank];
         for (unsigned t_rank = 0; t_rank < _sol[s_t.second].size(); ++t_rank) {
           if (!(_sol_state.fwd_amounts[s_t.second][t_rank] <= s_free_amount)) {
             break;
@@ -703,7 +701,7 @@ void LocalSearch<Route,
       // round and set route pairs accordingly.
       s_t_pairs.clear();
       for (auto v_rank : update_candidates) {
-        best_gains[v_rank] = std::vector<Gain>(_nb_vehicles, 0);
+        best_gains[v_rank].assign(_nb_vehicles, 0);
       }
 
       for (unsigned v = 0; v < _nb_vehicles; ++v) {

--- a/src/algorithms/local_search/operator.cpp
+++ b/src/algorithms/local_search/operator.cpp
@@ -12,25 +12,6 @@ All rights reserved (see LICENSE).
 namespace vroom {
 namespace ls {
 
-Operator::Operator(const Input& input,
-                   const utils::SolutionState& sol_state,
-                   RawRoute& s_raw_route,
-                   Index s_vehicle,
-                   Index s_rank,
-                   RawRoute& t_raw_route,
-                   Index t_vehicle,
-                   Index t_rank)
-  : _input(input),
-    _sol_state(sol_state),
-    s_route(s_raw_route.route),
-    s_vehicle(s_vehicle),
-    s_rank(s_rank),
-    t_route(t_raw_route.route),
-    t_vehicle(t_vehicle),
-    t_rank(t_rank),
-    gain_computed(false) {
-}
-
 Gain Operator::gain() {
   if (!gain_computed) {
     this->compute_gain();

--- a/src/algorithms/local_search/operator.h
+++ b/src/algorithms/local_search/operator.h
@@ -39,13 +39,13 @@ protected:
 
 public:
   Operator(const Input& input,
-          const utils::SolutionState& sol_state,
-          RawRoute& s_raw_route,
-          Index s_vehicle,
-          Index s_rank,
-          RawRoute& t_raw_route,
-          Index t_vehicle,
-          Index t_rank)
+           const utils::SolutionState& sol_state,
+           RawRoute& s_raw_route,
+           Index s_vehicle,
+           Index s_rank,
+           RawRoute& t_raw_route,
+           Index t_vehicle,
+           Index t_rank)
     : _input(input),
       _sol_state(sol_state),
       s_route(s_raw_route.route),

--- a/src/algorithms/local_search/operator.h
+++ b/src/algorithms/local_search/operator.h
@@ -39,13 +39,23 @@ protected:
 
 public:
   Operator(const Input& input,
-           const utils::SolutionState& sol_state,
-           RawRoute& s_route,
-           Index s_vehicle,
-           Index s_rank,
-           RawRoute& t_route,
-           Index t_vehicle,
-           Index t_rank);
+          const utils::SolutionState& sol_state,
+          RawRoute& s_raw_route,
+          Index s_vehicle,
+          Index s_rank,
+          RawRoute& t_raw_route,
+          Index t_vehicle,
+          Index t_rank)
+    : _input(input),
+      _sol_state(sol_state),
+      s_route(s_raw_route.route),
+      s_vehicle(s_vehicle),
+      s_rank(s_rank),
+      t_route(t_raw_route.route),
+      t_vehicle(t_vehicle),
+      t_rank(t_rank),
+      gain_computed(false) {
+  }
 
   virtual Gain gain();
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -206,10 +206,6 @@ bool Input::has_homogeneous_locations() const {
   return _homogeneous_locations;
 }
 
-bool Input::vehicle_ok_with_job(Index v_index, Index j_index) const {
-  return _vehicle_to_job_compatibility[v_index][j_index];
-}
-
 bool Input::vehicle_ok_with_vehicle(Index v1_index, Index v2_index) const {
   return _vehicle_to_vehicle_compatibility[v1_index][v2_index];
 }
@@ -271,8 +267,8 @@ void Input::check_cost_bound() const {
 void Input::set_compatibility() {
   // Default to no restriction when no skills are provided.
   _vehicle_to_job_compatibility =
-    std::vector<std::vector<bool>>(vehicles.size(),
-                                   std::vector<bool>(jobs.size(), true));
+    std::vector<std::vector<unsigned char>>(vehicles.size(),
+                std::vector<unsigned char>(jobs.size(), true));
   if (_has_skills) {
     for (std::size_t v = 0; v < vehicles.size(); ++v) {
       const auto& v_skills = vehicles[v].skills;

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -210,9 +210,6 @@ bool Input::vehicle_ok_with_vehicle(Index v1_index, Index v2_index) const {
   return _vehicle_to_vehicle_compatibility[v1_index][v2_index];
 }
 
-const Matrix<Cost>& Input::get_matrix() const {
-  return _matrix;
-}
 
 Matrix<Cost> Input::get_sub_matrix(const std::vector<Index>& indices) const {
   return _matrix.get_sub_matrix(indices);

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -210,7 +210,6 @@ bool Input::vehicle_ok_with_vehicle(Index v1_index, Index v2_index) const {
   return _vehicle_to_vehicle_compatibility[v1_index][v2_index];
 }
 
-
 Matrix<Cost> Input::get_sub_matrix(const std::vector<Index>& indices) const {
   return _matrix.get_sub_matrix(indices);
 }
@@ -263,9 +262,9 @@ void Input::check_cost_bound() const {
 
 void Input::set_compatibility() {
   // Default to no restriction when no skills are provided.
-  _vehicle_to_job_compatibility =
-    std::vector<std::vector<unsigned char>>(vehicles.size(),
-                std::vector<unsigned char>(jobs.size(), true));
+  _vehicle_to_job_compatibility = std::vector<
+    std::vector<unsigned char>>(vehicles.size(),
+                                std::vector<unsigned char>(jobs.size(), true));
   if (_has_skills) {
     for (std::size_t v = 0; v < vehicles.size(); ++v) {
       const auto& v_skills = vehicles[v].skills;

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -84,14 +84,14 @@ public:
   bool has_homogeneous_locations() const;
 
   bool vehicle_ok_with_job(size_t v_index, size_t j_index) const {
-      return (bool)_vehicle_to_job_compatibility[v_index][j_index];
+    return (bool)_vehicle_to_job_compatibility[v_index][j_index];
   }
 
   // Returns true iff both vehicles have common job candidates.
   bool vehicle_ok_with_vehicle(Index v1_index, Index v2_index) const;
 
   const Matrix<Cost>& get_matrix() const {
-      return _matrix;
+    return _matrix;
   }
 
   Matrix<Cost> get_sub_matrix(const std::vector<Index>& indices) const;

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -90,7 +90,9 @@ public:
   // Returns true iff both vehicles have common job candidates.
   bool vehicle_ok_with_vehicle(Index v1_index, Index v2_index) const;
 
-  const Matrix<Cost>& get_matrix() const;
+  const Matrix<Cost>& get_matrix() const {
+      return _matrix;
+  }
 
   Matrix<Cost> get_sub_matrix(const std::vector<Index>& indices) const;
 

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -44,7 +44,7 @@ private:
   std::unordered_map<Location, Index> _locations_to_index;
   unsigned _amount_size;
   Amount _amount_lower_bound;
-  std::vector<std::vector<bool>> _vehicle_to_job_compatibility;
+  std::vector<std::vector<unsigned char>> _vehicle_to_job_compatibility;
   std::vector<std::vector<bool>> _vehicle_to_vehicle_compatibility;
   std::unordered_set<Index> _matrix_used_index;
   bool _all_locations_have_coords;
@@ -83,7 +83,9 @@ public:
 
   bool has_homogeneous_locations() const;
 
-  bool vehicle_ok_with_job(Index v_index, Index j_index) const;
+  bool vehicle_ok_with_job(size_t v_index, size_t j_index) const {
+      return (bool)_vehicle_to_job_compatibility[v_index][j_index];
+  }
 
   // Returns true iff both vehicles have common job candidates.
   bool vehicle_ok_with_vehicle(Index v1_index, Index v2_index) const;

--- a/src/structures/vroom/job.cpp
+++ b/src/structures/vroom/job.cpp
@@ -20,8 +20,8 @@ Job::Job(Id id,
          const Amount& amount,
          const Skills& skills,
          const std::vector<TimeWindow>& tws)
-  : id(id),
-    location(location),
+  : location(location),
+    id(id),
     service(service),
     amount(amount),
     skills(skills),
@@ -45,10 +45,6 @@ Job::Job(Id id,
       }
     }
   }
-}
-
-Index Job::index() const {
-  return location.index();
 }
 
 bool Job::is_valid_start(Duration time) const {

--- a/src/structures/vroom/job.h
+++ b/src/structures/vroom/job.h
@@ -20,8 +20,8 @@ All rights reserved (see LICENSE).
 namespace vroom {
 
 struct Job {
-  const Id id;
   Location location;
+  const Id id;
   const Duration service;
   const Amount amount;
   const Skills skills;
@@ -36,7 +36,9 @@ struct Job {
       const std::vector<TimeWindow>& tws =
         std::vector<TimeWindow>(1, TimeWindow()));
 
-  Index index() const;
+  Index index() const {
+    return location.index();
+  }
 
   bool is_valid_start(Duration time) const;
 };

--- a/src/structures/vroom/location.cpp
+++ b/src/structures/vroom/location.cpp
@@ -32,10 +32,6 @@ bool Location::has_coordinates() const {
   return _coords != boost::none;
 }
 
-Index Location::index() const {
-  return _index;
-}
-
 Coordinate Location::lon() const {
   assert(this->has_coordinates());
   return _coords.get()[0];

--- a/src/structures/vroom/location.h
+++ b/src/structures/vroom/location.h
@@ -33,7 +33,9 @@ public:
 
   bool has_coordinates() const;
 
-  Index index() const;
+  Index index() const {
+    return _index;
+  }
 
   Coordinate lon() const;
 

--- a/src/structures/vroom/solution_state.cpp
+++ b/src/structures/vroom/solution_state.cpp
@@ -89,8 +89,8 @@ void SolutionState::setup(const TWSolution& tw_sol) {
 }
 
 void SolutionState::update_amounts(const std::vector<Index>& route, Index v) {
-  fwd_amounts[v] = std::vector<Amount>(route.size());
-  bwd_amounts[v] = std::vector<Amount>(route.size());
+  fwd_amounts[v].resize(route.size());
+  bwd_amounts[v].resize(route.size());
   Amount current_amount(_input.amount_size());
 
   for (std::size_t i = 0; i < route.size(); ++i) {
@@ -98,11 +98,11 @@ void SolutionState::update_amounts(const std::vector<Index>& route, Index v) {
     fwd_amounts[v][i] = current_amount;
   }
 
+  const auto& total_amount = fwd_amounts[v].back();
   std::transform(fwd_amounts[v].cbegin(),
                  fwd_amounts[v].cend(),
                  bwd_amounts[v].begin(),
                  [&](const auto& a) {
-                   const auto& total_amount = fwd_amounts[v].back();
                    return total_amount - a;
                  });
 }

--- a/src/structures/vroom/solution_state.cpp
+++ b/src/structures/vroom/solution_state.cpp
@@ -102,9 +102,7 @@ void SolutionState::update_amounts(const std::vector<Index>& route, Index v) {
   std::transform(fwd_amounts[v].cbegin(),
                  fwd_amounts[v].cend(),
                  bwd_amounts[v].begin(),
-                 [&](const auto& a) {
-                   return total_amount - a;
-                 });
+                 [&](const auto& a) { return total_amount - a; });
 }
 
 void SolutionState::update_costs(const std::vector<Index>& route, Index v) {

--- a/src/structures/vroom/solution_state.cpp
+++ b/src/structures/vroom/solution_state.cpp
@@ -396,8 +396,8 @@ void SolutionState::update_nearest_job_rank_in_routes(
   const std::vector<Index>& route_2,
   Index v1,
   Index v2) {
-  nearest_job_rank_in_routes_from[v1][v2] = std::vector<Index>(route_1.size());
-  nearest_job_rank_in_routes_to[v1][v2] = std::vector<Index>(route_1.size());
+  nearest_job_rank_in_routes_from[v1][v2].assign(route_1.size(), 0);
+  nearest_job_rank_in_routes_to[v1][v2].assign(route_1.size(), 0);
 
   for (std::size_t r1 = 0; r1 < route_1.size(); ++r1) {
     Index index_r1 = _input.jobs[route_1[r1]].index();


### PR DESCRIPTION
## Issue

#254 

## Tasks

 - [x] check the performance improvement on different benchmarks and different hardware
 - [x] review


I had some old commits lying around that apply some micro optimizations with the goal of improving the performance of vroom somewhat. I think slight loss in maintainability and modularity is justified by the gained speedup.

Benchmark results on the Solomon VRPTW instances:
```
master:
,Gaps,Computing times
Min,0.0,106
First decile,0.0,171
Lower quartile,0.84,264
Median,3.51,358
Upper quartile,5.49,914
Ninth decile,7.65,1218
Max,11.68,2230

this branch:
,Gaps,Computing times
Min,0.0,71
First decile,0.0,141
Lower quartile,0.84,193
Median,3.51,280
Upper quartile,5.49,632
Ninth decile,7.65,786
Max,11.68,870
```
The computed solutions are exactly the same. I do expect similar computing time gains on other benchmarks, but I have not measured it yet