### PR TITLE
Fix usage with recent libosrm versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Implicit instantiation of undefined template error for macos g++ compiler (#231)
 - Parsing vehicle ids as `uint64_t` (#228)
+- `osrm::EngineConfig` initialization for use with recent `libosrm` versions (#259)
 
 ## [v1.4.0] - 2019-03-26
 

--- a/src/routing/libosrm_wrapper.cpp
+++ b/src/routing/libosrm_wrapper.cpp
@@ -18,24 +18,18 @@ All rights reserved (see LICENSE).
 namespace vroom {
 namespace routing {
 
+osrm::EngineConfig LibosrmWrapper::get_config(const std::string& profile) {
+  osrm::EngineConfig config;
+
+  // Only update non-default values.
+  config.max_alternatives = 1;
+  config.dataset_name = profile;
+
+  return config;
+}
+
 LibosrmWrapper::LibosrmWrapper(const std::string& profile)
-  : RoutingWrapper(profile),
-    _config({
-      {},     // storare_config
-      -1,     // max_locations_trip
-      -1,     // max_locations_viaroute
-      -1,     // max_locations_distance_table
-      -1,     // max_locations_map_matching
-      -1.0,   // max_radius_map_matching
-      -1,     // max_results_nearest
-      1,      // max_alternatives
-      true,   // use_shared_memory
-      {},     // memory_file
-      {},     // algorithm
-      {},     // verbosity
-      profile // dataset_name
-    }),
-    _osrm(_config) {
+  : RoutingWrapper(profile), _config(get_config(profile)), _osrm(_config) {
 }
 
 Matrix<Cost>

--- a/src/routing/libosrm_wrapper.h
+++ b/src/routing/libosrm_wrapper.h
@@ -24,6 +24,8 @@ private:
   osrm::EngineConfig _config;
   const osrm::OSRM _osrm;
 
+  static osrm::EngineConfig get_config(const std::string& profile);
+
 public:
   LibosrmWrapper(const std::string& profile);
 


### PR DESCRIPTION
## Issue

As part of the discussion in #256 it turns out the way the `osrm::EngineConfig` object is  initialized in `libosrm_wrapper.cpp` does not work with recent `libosrm` versions.

This PR contains a simple fix for this + maybe some further changes when we can figure out the rest of the problem in #256. cc @KieCap

## Tasks

 - [x] Initialize `osrm::EngineConfig` object in a way that is compatible with recent `libosrm` versions
 - [x] Update `CHANGELOG.md`
 - [x] review
