### PR TITLE
Fix Travis builds after Trusty EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,35 +23,35 @@ matrix:
             - libboost-all-dev
       env: COMPILER=g++-7
 
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-8
-            - libboost-all-dev
-      env: COMPILER=g++-8
+    # - os: linux
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #       packages:
+    #         - g++-8
+    #         - libboost-all-dev
+    #   env: COMPILER=g++-8
 
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - clang-5.0
-            - libboost-all-dev
-      env: COMPILER=clang++-5.0
+    # - os: linux
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #       packages:
+    #         - clang-5.0
+    #         - libboost-all-dev
+    #   env: COMPILER=clang++-5.0
 
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - clang-6.0
-            - libboost-all-dev
-      env: COMPILER=clang++-6.0
+    # - os: linux
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #       packages:
+    #         - clang-6.0
+    #         - libboost-all-dev
+    #   env: COMPILER=clang++-6.0
 
 before_script:
   - export ROOT_FOLDER="$(pwd)"
@@ -74,7 +74,7 @@ script:
   - sudo apt-get install build-essential git cmake pkg-config libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev libzip-dev lua5.2 liblua5.2-dev libtbb-dev libluabind-dev libluabind0.9.1v5
   - git clone https://github.com/Project-OSRM/osrm-backend.git
   - cd osrm-backend
-  - git checkout v5.22.0
+  - git checkout v5.11.0
   - mkdir build
   - cd build
   - cmake .. -DCMAKE_BUILD_TYPE=Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,35 +23,35 @@ matrix:
             - libboost-all-dev
       env: COMPILER=g++-7
 
-    # - os: linux
-    #   addons:
-    #     apt:
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    #       packages:
-    #         - g++-8
-    #         - libboost-all-dev
-    #   env: COMPILER=g++-8
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+            - libboost-all-dev
+      env: COMPILER=g++-8
 
-    # - os: linux
-    #   addons:
-    #     apt:
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    #       packages:
-    #         - clang-5.0
-    #         - libboost-all-dev
-    #   env: COMPILER=clang++-5.0
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-5.0
+            - libboost-all-dev
+      env: COMPILER=clang++-5.0
 
-    # - os: linux
-    #   addons:
-    #     apt:
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    #       packages:
-    #         - clang-6.0
-    #         - libboost-all-dev
-    #   env: COMPILER=clang++-6.0
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-6.0
+            - libboost-all-dev
+      env: COMPILER=clang++-6.0
 
 before_script:
   - export ROOT_FOLDER="$(pwd)"
@@ -59,9 +59,7 @@ before_script:
   - cd ${BUILD_FOLDER}
   - export CXX=${COMPILER}
   - ${CXX} --version
-  - cat /etc/apt/sources.list
   - sudo apt-get install -y libboost-all-dev
-  - dpkg -s libboost-all-dev
 
 script:
   - CHANGED_FILES=`git diff --name-only master ${TRAVIS_COMMIT}`
@@ -74,7 +72,7 @@ script:
   # - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && echo ${CHANGED_FILES} | grep -v "libosrm_wrapper"; then travis_terminate 0; fi
   - make clean
   - cd ${ROOT_FOLDER}
-  - sudo apt install build-essential git cmake pkg-config libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev libzip-dev lua5.2 liblua5.2-dev libtbb-dev libluabind-dev libluabind0.9.1v5
+  - sudo apt-get install build-essential git cmake pkg-config libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev libzip-dev lua5.2 liblua5.2-dev libtbb-dev libluabind-dev libluabind0.9.1v5
   - git clone https://github.com/Project-OSRM/osrm-backend.git
   - cd osrm-backend
   - git checkout v5.19.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,10 +62,10 @@ before_script:
 
 script:
   - CHANGED_FILES=`git diff --name-only master ${TRAVIS_COMMIT}`
-  # Check build without libosrm only if source files have been
-  # modified.
-  - if echo ${CHANGED_FILES} | grep -v -e "\.h" -e "\.cpp"; then travis_terminate 0; fi
-  - make
+  # # Check build without libosrm only if source files have been
+  # # modified.
+  # - if echo ${CHANGED_FILES} | grep -v -e "\.h" -e "\.cpp"; then travis_terminate 0; fi
+  # - make
   # # Check build with libosrm installed only on master and if relevant
   # # files have been modified.
   # - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && echo ${CHANGED_FILES} | grep -v "libosrm_wrapper"; then travis_terminate 0; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,9 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-5.0
           packages:
             - clang-5.0
             - libboost-all-dev
-            - g++-7
       env: COMPILER=clang++-5.0
 
     - os: linux
@@ -50,11 +48,9 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
           packages:
             - clang-6.0
             - libboost-all-dev
-            - g++-7
       env: COMPILER=clang++-6.0
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,11 @@ before_script:
   - cd ${BUILD_FOLDER}
   - export CXX=${COMPILER}
   - ${CXX} --version
+  - cat /etc/apt/sources.list
+  - sudo apt-get install -y libboost-all-dev
   - dpkg -s libboost-all-dev
 
 script:
-  - sudo apt install libboost-all-dev
   - CHANGED_FILES=`git diff --name-only master ${TRAVIS_COMMIT}`
   # # Check build without libosrm only if source files have been
   # # modified.

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,9 @@ script:
   # modified.
   - if echo ${CHANGED_FILES} | grep -v -e "\.h" -e "\.cpp"; then travis_terminate 0; fi
   - make
-  # Check build with libosrm installed only on master and if relevant
-  # files have been modified.
-  - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && echo ${CHANGED_FILES} | grep -v "libosrm_wrapper"; then travis_terminate 0; fi
+  # # Check build with libosrm installed only on master and if relevant
+  # # files have been modified.
+  # - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && echo ${CHANGED_FILES} | grep -v "libosrm_wrapper"; then travis_terminate 0; fi
   - make clean
   - cd ${ROOT_FOLDER}
   - sudo apt-get install build-essential git cmake pkg-config libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev libzip-dev lua5.2 liblua5.2-dev libtbb-dev libluabind-dev libluabind0.9.1v5

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-7
-            - libboost-all-dev
       env: COMPILER=g++-7
 
     # - os: linux
@@ -59,6 +58,7 @@ before_script:
   - cd ${BUILD_FOLDER}
   - export CXX=${COMPILER}
   - ${CXX} --version
+  - sudo apt install -y libboost-all-dev
 
 script:
   - CHANGED_FILES=`git diff --name-only master ${TRAVIS_COMMIT}`
@@ -71,7 +71,7 @@ script:
   # - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && echo ${CHANGED_FILES} | grep -v "libosrm_wrapper"; then travis_terminate 0; fi
   - make clean
   - cd ${ROOT_FOLDER}
-  - sudo apt-get install build-essential git cmake pkg-config libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev libzip-dev lua5.2 liblua5.2-dev libtbb-dev libluabind-dev libluabind0.9.1v5
+  - sudo apt install build-essential git cmake pkg-config libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev libzip-dev lua5.2 liblua5.2-dev libtbb-dev libluabind-dev libluabind0.9.1v5
   - git clone https://github.com/Project-OSRM/osrm-backend.git
   - cd osrm-backend
   - git checkout v5.19.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,9 @@ sudo: required
 matrix:
   include:
     - os: linux
+      # TODO restore when addons.apt.packages is enabled for bionic
       # addons:
       #   apt:
-      #     sources:
-      #       - ubuntu-toolchain-r-test
       #     packages:
       #       - g++-7
       #       - libboost-all-dev
@@ -26,10 +25,9 @@ matrix:
         - CXX-PACKAGE=g++-7
 
     - os: linux
+      # TODO restore when addons.apt.packages is enabled for bionic
       # addons:
       #   apt:
-      #     sources:
-      #       - ubuntu-toolchain-r-test
       #     packages:
       #       - g++-8
       #       - libboost-all-dev
@@ -38,10 +36,9 @@ matrix:
         - CXX-PACKAGE=g++-8
 
     - os: linux
+      # TODO restore when addons.apt.packages is enabled for bionic
       # addons:
       #   apt:
-      #     sources:
-      #       - ubuntu-toolchain-r-test
       #     packages:
       #       - clang-5.0
       #       - libboost-all-dev
@@ -50,13 +47,12 @@ matrix:
         - CXX-PACKAGE=clang-5.0
 
     - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - clang-6.0
-            - libboost-all-dev
+      # TODO restore when addons.apt.packages is enabled for bionic
+      # addons:
+      #   apt:
+      #     packages:
+      #       - clang-6.0
+      #       - libboost-all-dev
       env:
         - COMPILER=clang++-6.0
         - CXX-PACKAGE=clang-6.0
@@ -66,19 +62,20 @@ before_script:
   - export BUILD_FOLDER="$(pwd)/src"
   - cd ${BUILD_FOLDER}
   - export CXX=${COMPILER}
+  # TODO remove when addons.apt.packages is enabled for bionic
   - sudo apt-get install -y ${CXX-PACKAGE}
-  - ${CXX} --version
   - sudo apt-get install -y libboost-all-dev
+  - ${CXX} --version
 
 script:
   - CHANGED_FILES=`git diff --name-only master ${TRAVIS_COMMIT}`
-  # # Check build without libosrm only if source files have been
-  # # modified.
-  # - if echo ${CHANGED_FILES} | grep -v -e "\.h" -e "\.cpp"; then travis_terminate 0; fi
+  # Check build without libosrm only if source files have been
+  # modified.
+  - if echo ${CHANGED_FILES} | grep -v -e "\.h" -e "\.cpp"; then travis_terminate 0; fi
   - make
-  # # Check build with libosrm installed only on master and if relevant
-  # # files have been modified.
-  # - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && echo ${CHANGED_FILES} | grep -v "libosrm_wrapper"; then travis_terminate 0; fi
+  # Check build with libosrm installed only on master and if relevant
+  # files have been modified.
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && echo ${CHANGED_FILES} | grep -v "libosrm_wrapper"; then travis_terminate 0; fi
   - make clean
   - cd ${ROOT_FOLDER}
   - sudo apt-get install build-essential git cmake pkg-config libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev libzip-dev lua5.2 liblua5.2-dev libtbb-dev libluabind-dev libluabind0.9.1v5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: xenial
+dist: bionic
 
 git:
   quiet: true
@@ -74,7 +74,7 @@ script:
   - sudo apt-get install build-essential git cmake pkg-config libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev libzip-dev lua5.2 liblua5.2-dev libtbb-dev libluabind-dev libluabind0.9.1v5
   - git clone https://github.com/Project-OSRM/osrm-backend.git
   - cd osrm-backend
-  - git checkout v5.11.0
+  - git checkout v5.19.0
   - mkdir build
   - cd build
   - cmake .. -DCMAKE_BUILD_TYPE=Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,34 +14,40 @@ sudo: required
 matrix:
   include:
     - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-            - libboost-all-dev
-      env: COMPILER=g++-7
+      # addons:
+      #   apt:
+      #     sources:
+      #       - ubuntu-toolchain-r-test
+      #     packages:
+      #       - g++-7
+      #       - libboost-all-dev
+      env:
+        - COMPILER=g++-7
+        - CXX-PACKAGE=g++-7
 
     - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-8
-            - libboost-all-dev
-      env: COMPILER=g++-8
+      # addons:
+      #   apt:
+      #     sources:
+      #       - ubuntu-toolchain-r-test
+      #     packages:
+      #       - g++-8
+      #       - libboost-all-dev
+      env:
+        - COMPILER=g++-8
+        - CXX-PACKAGE=g++-8
 
     - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - clang-5.0
-            - libboost-all-dev
-      env: COMPILER=clang++-5.0
+      # addons:
+      #   apt:
+      #     sources:
+      #       - ubuntu-toolchain-r-test
+      #     packages:
+      #       - clang-5.0
+      #       - libboost-all-dev
+      env:
+        - COMPILER=clang++-5.0
+        - CXX-PACKAGE=clang-5.0
 
     - os: linux
       addons:
@@ -51,13 +57,16 @@ matrix:
           packages:
             - clang-6.0
             - libboost-all-dev
-      env: COMPILER=clang++-6.0
+      env:
+        - COMPILER=clang++-6.0
+        - CXX-PACKAGE=clang-6.0
 
 before_script:
   - export ROOT_FOLDER="$(pwd)"
   - export BUILD_FOLDER="$(pwd)/src"
   - cd ${BUILD_FOLDER}
   - export CXX=${COMPILER}
+  - sudo apt-get install -y ${CXX-PACKAGE}
   - ${CXX} --version
   - sudo apt-get install -y libboost-all-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ script:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && echo ${CHANGED_FILES} | grep -v "libosrm_wrapper"; then travis_terminate 0; fi
   - make clean
   - cd ${ROOT_FOLDER}
-  - sudo apt-get install build-essential wget cmake3 pkg-config libbz2-dev libstxxl-dev libstxxl1 libxml2-dev libzip-dev lua5.2 liblua5.2-dev libtbb-dev
+  - sudo apt-get install build-essential git cmake pkg-config libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev libzip-dev lua5.2 liblua5.2-dev libtbb-dev libluabind-dev libluabind0.9.1v5
   - git clone https://github.com/Project-OSRM/osrm-backend.git
   - cd osrm-backend
   - git checkout v5.19.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
   # # Check build without libosrm only if source files have been
   # # modified.
   # - if echo ${CHANGED_FILES} | grep -v -e "\.h" -e "\.cpp"; then travis_terminate 0; fi
-  # - make
+  - make
   # # Check build with libosrm installed only on master and if relevant
   # # files have been modified.
   # - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && echo ${CHANGED_FILES} | grep -v "libosrm_wrapper"; then travis_terminate 0; fi
@@ -74,7 +74,7 @@ script:
   - sudo apt-get install build-essential git cmake pkg-config libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev libzip-dev lua5.2 liblua5.2-dev libtbb-dev libluabind-dev libluabind0.9.1v5
   - git clone https://github.com/Project-OSRM/osrm-backend.git
   - cd osrm-backend
-  - git checkout v5.19.0
+  - git checkout v5.22.0
   - mkdir build
   - cd build
   - cmake .. -DCMAKE_BUILD_TYPE=Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,6 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-6
-            - libboost-all-dev
-      env: COMPILER=g++-6
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
             - g++-7
             - libboost-all-dev
       env: COMPILER=g++-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+dist: xenial
 
 git:
   quiet: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-7
+            - libboost-all-dev
       env: COMPILER=g++-7
 
     # - os: linux
@@ -58,9 +59,10 @@ before_script:
   - cd ${BUILD_FOLDER}
   - export CXX=${COMPILER}
   - ${CXX} --version
-  - sudo apt install -y libboost-all-dev
+  - dpkg -s libboost-all-dev
 
 script:
+  - sudo apt install libboost-all-dev
   - CHANGED_FILES=`git diff --name-only master ${TRAVIS_COMMIT}`
   # # Check build without libosrm only if source files have been
   # # modified.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Speed up solving by 25% for CVRP and up to 30% for VRPTW benchmark instances (#255)
+- Update Travis configuration to use Ubuntu Bionic (#260)
 
 ### Fixed
 


### PR DESCRIPTION
## Issue

Fixes #260

## Tasks

 - [x] Drop support for `g++-6` in CI builds
 - [x] Explicitly pin OS version to ~~xenial~~ bionic to avoid relying on default
 - [x] Fix problems with clang installation
 - [x] Update OSRM dependencies
 - [x] Update `CHANGELOG.md`
 - [x] review