### PR TITLE
Earlier check for compatibility aborts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Steps `type` in json output can also have value `pickup` and `delivery` (#274)
 - Extended range for valid priority values (#287)
 - Use `operator&&` for short-circuit evaluation (#293)
+- Earlier local search aborts based on incompatibilities (#281)
 
 ### Fixed
 

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -496,6 +496,13 @@ void LocalSearch<Route,
       }
 
       for (unsigned s_rank = 0; s_rank < _sol[s_t.first].size() - 1; ++s_rank) {
+        if (!_input.vehicle_ok_with_job(s_t.second,
+                                        _sol[s_t.first].route[s_rank]) or
+            !_input.vehicle_ok_with_job(s_t.second,
+                                        _sol[s_t.first].route[s_rank + 1])) {
+          continue;
+        }
+
         const auto& job_s_type =
           _input.jobs[_sol[s_t.first].route[s_rank]].type;
 
@@ -514,6 +521,13 @@ void LocalSearch<Route,
 
         for (unsigned t_rank = 0; t_rank < _sol[s_t.second].size() - 1;
              ++t_rank) {
+          if (!_input.vehicle_ok_with_job(s_t.first,
+                                          _sol[s_t.second].route[t_rank]) or
+              !_input.vehicle_ok_with_job(s_t.first,
+                                          _sol[s_t.second].route[t_rank + 1])) {
+            continue;
+          }
+
           const auto& job_t_type =
             _input.jobs[_sol[s_t.second].route[t_rank]].type;
 

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -452,17 +452,21 @@ void LocalSearch<Route,
         }
 
         for (unsigned s_rank = 0; s_rank < _sol[s_t.first].size(); ++s_rank) {
-          if (_input.jobs[_sol[s_t.first].route[s_rank]].type !=
-              JOB_TYPE::SINGLE) {
-            // Don't try moving (part of) a shipment.
+          const auto& s_job_rank = _sol[s_t.first].route[s_rank];
+          if (_input.jobs[s_job_rank].type != JOB_TYPE::SINGLE or
+              !_input.vehicle_ok_with_job(s_t.second, s_job_rank)) {
+            // Don't try moving (part of) a shipment or an
+            // incompatible job.
             continue;
           }
 
           for (unsigned t_rank = 0; t_rank < _sol[s_t.second].size();
                ++t_rank) {
-            if (_input.jobs[_sol[s_t.second].route[t_rank]].type !=
-                JOB_TYPE::SINGLE) {
-              // Don't try moving (part of) a shipment.
+            const auto& t_job_rank = _sol[s_t.second].route[t_rank];
+            if (_input.jobs[t_job_rank].type != JOB_TYPE::SINGLE or
+                !_input.vehicle_ok_with_job(s_t.first, t_job_rank)) {
+              // Don't try moving (part of) a shipment or an
+              // incompatible job.
               continue;
             }
 

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -719,8 +719,11 @@ void LocalSearch<Route,
             continue;
           }
 
-          if (_input.jobs[_sol[s_t.first].route[s_rank]].type !=
-              JOB_TYPE::SINGLE) {
+          const auto& s_job_rank = _sol[s_t.first].route[s_rank];
+          if (_input.jobs[s_job_rank].type != JOB_TYPE::SINGLE or
+              !_input.vehicle_ok_with_job(s_t.second, s_job_rank)) {
+            // Don't try moving (part of) a shipment or an
+            // incompatible job.
             continue;
           }
 

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -576,14 +576,24 @@ void LocalSearch<Route,
         }
 
         for (unsigned s_rank = 0; s_rank < _sol[s_t.first].size(); ++s_rank) {
-          if (_input.jobs[_sol[s_t.first].route[s_rank]].type !=
-              JOB_TYPE::SINGLE) {
-            // Don't try moving part of a shipment.
+          const auto& s_job_rank = _sol[s_t.first].route[s_rank];
+          if (_input.jobs[s_job_rank].type != JOB_TYPE::SINGLE or
+              !_input.vehicle_ok_with_job(s_t.second, s_job_rank)) {
+            // Don't try moving part of a shipment or an incompatible
+            // job.
             continue;
           }
 
           for (unsigned t_rank = 0; t_rank < _sol[s_t.second].size() - 1;
                ++t_rank) {
+            if (!_input.vehicle_ok_with_job(s_t.first,
+                                            _sol[s_t.second].route[t_rank]) or
+                !_input
+                   .vehicle_ok_with_job(s_t.first,
+                                        _sol[s_t.second].route[t_rank + 1])) {
+              continue;
+            }
+
             const auto& job_t_type =
               _input.jobs[_sol[s_t.second].route[t_rank]].type;
 

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -691,12 +691,24 @@ void LocalSearch<Route,
         continue;
       }
 
-      for (unsigned s_rank = 0; s_rank < _sol[s_t.first].size(); ++s_rank) {
+      // Determine first rank for inner loop based on vehicles/jobs
+      // compatibility along the routes.
+      unsigned first_s_rank = 0;
+      const auto first_s_candidate =
+        _sol_state.bwd_skill_rank[s_t.first][s_t.second];
+      if (first_s_candidate > 0) {
+        first_s_rank = first_s_candidate - 1;
+      }
+
+      for (unsigned s_rank = first_s_rank; s_rank < _sol[s_t.first].size();
+           ++s_rank) {
         if (_sol[s_t.first].has_delivery_after_rank(s_rank)) {
           continue;
         }
 
-        for (unsigned t_rank = 0; t_rank < _sol[s_t.second].size(); ++t_rank) {
+        for (unsigned t_rank = 0;
+             t_rank < _sol_state.fwd_skill_rank[s_t.second][s_t.first];
+             ++t_rank) {
           if (_sol[s_t.second].has_pickup_up_to_rank(t_rank)) {
             continue;
           }

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -762,6 +762,13 @@ void LocalSearch<Route,
             continue;
           }
 
+          if (!_input.vehicle_ok_with_job(s_t.second,
+                                          _sol[s_t.first].route[s_rank]) or
+              !_input.vehicle_ok_with_job(s_t.second,
+                                          _sol[s_t.first].route[s_rank + 1])) {
+            continue;
+          }
+
           if (_input.jobs[_sol[s_t.first].route[s_rank]].type !=
                 JOB_TYPE::SINGLE or
               _input.jobs[_sol[s_t.first].route[s_rank + 1]].type !=

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -640,12 +640,30 @@ void LocalSearch<Route,
         continue;
       }
 
-      for (unsigned s_rank = 0; s_rank < _sol[s_t.first].size(); ++s_rank) {
+      // Determine first ranks for inner loops based on vehicles/jobs
+      // compatibility along the routes.
+      unsigned first_s_rank = 0;
+      const auto first_s_candidate =
+        _sol_state.bwd_skill_rank[s_t.first][s_t.second];
+      if (first_s_candidate > 0) {
+        first_s_rank = first_s_candidate - 1;
+      }
+
+      int first_t_rank = 0;
+      const auto first_t_candidate =
+        _sol_state.bwd_skill_rank[s_t.second][s_t.first];
+      if (first_t_candidate > 0) {
+        first_t_rank = first_t_candidate - 1;
+      }
+
+      for (unsigned s_rank = first_s_rank; s_rank < _sol[s_t.first].size();
+           ++s_rank) {
         if (_sol[s_t.first].has_pending_delivery_after_rank(s_rank)) {
           continue;
         }
 
-        for (int t_rank = _sol[s_t.second].size() - 1; t_rank >= 0; --t_rank) {
+        for (int t_rank = _sol[s_t.second].size() - 1; t_rank >= first_t_rank;
+             --t_rank) {
           if (_sol[s_t.second].has_pending_delivery_after_rank(t_rank)) {
             continue;
           }

--- a/src/problems/cvrp/operators/exchange.cpp
+++ b/src/problems/cvrp/operators/exchange.cpp
@@ -33,6 +33,8 @@ Exchange::Exchange(const Input& input,
   assert(t_route.size() >= 1);
   assert(s_rank < s_route.size());
   assert(t_rank < t_route.size());
+  assert(_input.vehicle_ok_with_job(t_vehicle, this->s_route[s_rank]));
+  assert(_input.vehicle_ok_with_job(s_vehicle, this->t_route[t_rank]));
 }
 
 void Exchange::compute_gain() {

--- a/src/problems/cvrp/operators/exchange.cpp
+++ b/src/problems/cvrp/operators/exchange.cpp
@@ -109,14 +109,7 @@ void Exchange::compute_gain() {
 }
 
 bool Exchange::is_valid() {
-  auto s_job_rank = s_route[s_rank];
-  auto t_job_rank = t_route[t_rank];
-
-  bool valid = _input.vehicle_ok_with_job(t_vehicle, s_job_rank);
-  valid = valid && _input.vehicle_ok_with_job(s_vehicle, t_job_rank);
-
-  valid =
-    valid &&
+  bool valid =
     target.is_valid_addition_for_capacity_margins(_input,
                                                   _input.jobs[s_route[s_rank]]
                                                     .pickup,

--- a/src/problems/cvrp/operators/or_opt.cpp
+++ b/src/problems/cvrp/operators/or_opt.cpp
@@ -36,6 +36,9 @@ OrOpt::OrOpt(const Input& input,
   assert(s_route.size() >= 2);
   assert(s_rank < s_route.size() - 1);
   assert(t_rank <= t_route.size());
+
+  assert(_input.vehicle_ok_with_job(t_vehicle, this->s_route[s_rank]));
+  assert(_input.vehicle_ok_with_job(t_vehicle, this->s_route[s_rank + 1]));
 }
 
 Gain OrOpt::gain_upper_bound() {
@@ -146,17 +149,12 @@ void OrOpt::compute_gain() {
 }
 
 bool OrOpt::is_valid() {
-  auto current_job_rank = s_route[s_rank];
-  auto after_job_rank = s_route[s_rank + 1];
+  auto edge_pickup = _input.jobs[s_route[s_rank]].pickup +
+                     _input.jobs[s_route[s_rank + 1]].pickup;
+  auto edge_delivery = _input.jobs[s_route[s_rank]].delivery +
+                       _input.jobs[s_route[s_rank + 1]].delivery;
 
-  auto edge_pickup =
-    _input.jobs[current_job_rank].pickup + _input.jobs[after_job_rank].pickup;
-  auto edge_delivery = _input.jobs[current_job_rank].delivery +
-                       _input.jobs[after_job_rank].delivery;
-
-  bool valid = _input.vehicle_ok_with_job(t_vehicle, current_job_rank) and
-               _input.vehicle_ok_with_job(t_vehicle, after_job_rank) and
-               target.is_valid_addition_for_capacity(_input,
+  bool valid = target.is_valid_addition_for_capacity(_input,
                                                      edge_pickup,
                                                      edge_delivery,
                                                      t_rank);

--- a/src/problems/cvrp/operators/relocate.cpp
+++ b/src/problems/cvrp/operators/relocate.cpp
@@ -33,6 +33,8 @@ Relocate::Relocate(const Input& input,
   assert(s_route.size() >= 1);
   assert(s_rank < s_route.size());
   assert(t_rank <= t_route.size());
+
+  assert(_input.vehicle_ok_with_job(t_vehicle, this->s_route[s_rank]));
 }
 
 void Relocate::compute_gain() {
@@ -53,13 +55,11 @@ void Relocate::compute_gain() {
 }
 
 bool Relocate::is_valid() {
-  return _input.vehicle_ok_with_job(t_vehicle, s_route[s_rank]) and
-         target
-           .is_valid_addition_for_capacity(_input,
-                                           _input.jobs[s_route[s_rank]].pickup,
-                                           _input.jobs[s_route[s_rank]]
-                                             .delivery,
-                                           t_rank);
+  return target
+    .is_valid_addition_for_capacity(_input,
+                                    _input.jobs[s_route[s_rank]].pickup,
+                                    _input.jobs[s_route[s_rank]].delivery,
+                                    t_rank);
 }
 
 void Relocate::apply() {

--- a/src/problems/cvrp/operators/reverse_two_opt.cpp
+++ b/src/problems/cvrp/operators/reverse_two_opt.cpp
@@ -33,6 +33,9 @@ ReverseTwoOpt::ReverseTwoOpt(const Input& input,
   assert(t_route.size() >= 1);
   assert(s_rank < s_route.size());
   assert(t_rank < t_route.size());
+
+  assert(_sol_state.bwd_skill_rank[s_vehicle][t_vehicle] <= s_rank + 1);
+  assert(t_rank < _sol_state.fwd_skill_rank[t_vehicle][s_vehicle]);
 }
 
 void ReverseTwoOpt::compute_gain() {
@@ -127,19 +130,14 @@ void ReverseTwoOpt::compute_gain() {
 }
 
 bool ReverseTwoOpt::is_valid() {
-  bool valid = (_sol_state.bwd_skill_rank[s_vehicle][t_vehicle] <= s_rank + 1);
-
-  valid = valid && (t_rank < _sol_state.fwd_skill_rank[t_vehicle][s_vehicle]);
-
   auto t_delivery = target.delivery_in_range(0, t_rank + 1);
   auto t_pickup = target.pickup_in_range(0, t_rank + 1);
 
-  valid =
-    valid && source.is_valid_addition_for_capacity_margins(_input,
-                                                           t_pickup,
-                                                           t_delivery,
-                                                           s_rank + 1,
-                                                           s_route.size());
+  bool valid = source.is_valid_addition_for_capacity_margins(_input,
+                                                             t_pickup,
+                                                             t_delivery,
+                                                             s_rank + 1,
+                                                             s_route.size());
 
   auto s_delivery = source.delivery_in_range(s_rank + 1, s_route.size());
   auto s_pickup = source.pickup_in_range(s_rank + 1, s_route.size());

--- a/src/problems/cvrp/operators/two_opt.cpp
+++ b/src/problems/cvrp/operators/two_opt.cpp
@@ -33,6 +33,9 @@ TwoOpt::TwoOpt(const Input& input,
   assert(t_route.size() >= 1);
   assert(s_rank < s_route.size());
   assert(t_rank < t_route.size());
+
+  assert(_sol_state.bwd_skill_rank[s_vehicle][t_vehicle] <= s_rank + 1);
+  assert(_sol_state.bwd_skill_rank[t_vehicle][s_vehicle] <= t_rank + 1);
 }
 
 void TwoOpt::compute_gain() {
@@ -86,20 +89,14 @@ void TwoOpt::compute_gain() {
 }
 
 bool TwoOpt::is_valid() {
-  bool valid = (_sol_state.bwd_skill_rank[s_vehicle][t_vehicle] <= s_rank + 1);
-
-  valid =
-    valid && (_sol_state.bwd_skill_rank[t_vehicle][s_vehicle] <= t_rank + 1);
-
   auto t_delivery = target.delivery_in_range(t_rank + 1, t_route.size());
   auto t_pickup = target.pickup_in_range(t_rank + 1, t_route.size());
 
-  valid =
-    valid && source.is_valid_addition_for_capacity_margins(_input,
-                                                           t_pickup,
-                                                           t_delivery,
-                                                           s_rank + 1,
-                                                           s_route.size());
+  bool valid = source.is_valid_addition_for_capacity_margins(_input,
+                                                             t_pickup,
+                                                             t_delivery,
+                                                             s_rank + 1,
+                                                             s_route.size());
 
   auto s_delivery = source.delivery_in_range(s_rank + 1, s_route.size());
   auto s_pickup = source.pickup_in_range(s_rank + 1, s_route.size());


### PR DESCRIPTION
## Issue

Fixes #281 

## Tasks

 - [x] Apply to Exchange
 - [x] Apply to Relocate
 - [x] Apply to OrOpt
 - [x] Apply to MixedExchange
 - [x] Apply to CrossExchange
 - [x] Apply to TwoOpt
 - [x] Apply to ReverseTwoOpt
 - [x] Update `CHANGELOG.md`
 - [x] review
