### PR TITLE
WIP: Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+*.o
+*.d
+bin/
+lib/
+scripts/
+libvroom_examples/
+docs/
+.github/
+.git/
+Dockerfile
+README.md
+LICENSE
+CHANGELOG.md
+CONTRIBUTING.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:18.04 as build
+LABEL maintainer="nils@gis-ops.com"
+
+WORKDIR /vroom
+
+RUN apt-get -y update; apt-get install -y \
+    build-essential \
+		g++ \
+    libssl-dev \
+		libboost-all-dev \
+		pkg-config
+
+COPY . .
+
+RUN make -C /vroom/src
+
+FROM node:12.13.1-alpine
+
+COPY --from=build /vroom/bin/vroom /usr/local/bin/vroom


### PR DESCRIPTION
Solves Issue # 307

As discussed in #307, a Dockerfile for Vroom itself is pretty useless. I'd see this as the base image for `vroom-express` to run everything with a single `docker run -dt -p 3000:3000 vroom-express`. In the end, I imagine the following:

- the `vroom` image is built multi-stage to keep the image size down; basically in a first stage it builds vroom and the second stage is based on a NodeJS image (for `vroom-express`) and simply copies from the first stage whatever it needs to run `vroom`
- the `vroom` image is hosted on Dockerhub with `latest` tag for `master` branch and other tags for releases
- `vroom-express` (I'd PR this soon) takes the second stage of the `vroom` image as base image

 Now, there's a few problems I'd like to address before this can reasonably happen:

- `vroom-express` would ideally create a release with every `vroom` release, always keeping the newest `vroom` release tag in the Dockerfile or else Docker tags need to be introduced which refer to `vroom` versions EDIT: actually that's not necessary, `vroom-express` wouldn't need to be on Dockerhub so one could specify whichever `vroom` version is preferred (and compatible)
- Currently it's not working yet for `vroom-express` as there's some libraries missing in the final image. Can you tell me which libraries `vroom` needs to just run (not build)? I'd like to keep an Alpine image, `boost-dev` is available. I tried the Ubuntu:18.04 image quickly but it was 10x the size of the `node:12.13.1-alpine` image.

I'd commit to keeping the Docker stuff up-to-date in both repositories, in case you're interested.

## Tasks

 - [ ] clear up final questions & get your approval;)
 - [ ] Update `CHANGELOG.md` (remove if irrelevant)
 - [ ] review
