### PR TITLE
Drop boost/optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Switch to C++17 (#311)
+- Use `std::optional` and drop dependency to boost/optional (#312)
 - Refactor routing wrapper classes (#320)
 - Updated Travis script for CI builds (#301)
 

--- a/libvroom_examples/libvroom.cpp
+++ b/libvroom_examples/libvroom.cpp
@@ -104,7 +104,7 @@ void run_example_with_osrm() {
   vehicle_capacity[0] = 4;
   job_delivery[0] = 1;
 
-  // Define vehicles (use boost::none for no start or no end).
+  // Define vehicles (use std::nullopt for no start or no end).
   vroom::Location depot(vroom::Coordinates({{2.35044, 48.71764}}));
   vroom::Vehicle v1(1,                // id
                     depot,            // start
@@ -205,7 +205,7 @@ void run_example_with_custom_matrix() {
                                            {1299, 3153, 1102, 0}});
   problem_instance.set_matrix(std::move(matrix_input));
 
-  // Define vehicles (use boost::none for no start or no end).
+  // Define vehicles (use std::nullopt for no start or no end).
   vroom::Location v_start(0); // index in the provided matrix.
   vroom::Location v_end(3);   // index in the provided matrix.
 

--- a/libvroom_examples/makefile
+++ b/libvroom_examples/makefile
@@ -1,5 +1,5 @@
 CXX ?= g++
-CXXFLAGS = -I../src -std=c++14 -Wextra -Wpedantic -Wall -O3
+CXXFLAGS = -I../src -std=c++17 -Wextra -Wpedantic -Wall -O3
 LDLIBS = -L../lib/ -lvroom -lboost_system -lpthread -lssl -lcrypto
 
 MAIN = ./libvroom-example

--- a/src/algorithms/heuristics/solomon.cpp
+++ b/src/algorithms/heuristics/solomon.cpp
@@ -63,7 +63,7 @@ template <class T> T basic(const Input& input, INIT init, float lambda) {
 
     Cost current_cost = 0;
     if (v.has_start()) {
-      current_cost += m[v.start.get().index()][j_index];
+      current_cost += m[v.start.value().index()][j_index];
     }
 
     Index last_job_index = j_index;
@@ -77,7 +77,7 @@ template <class T> T basic(const Input& input, INIT init, float lambda) {
     }
 
     if (v.has_end()) {
-      current_cost += m[last_job_index][v.end.get().index()];
+      current_cost += m[last_job_index][v.end.value().index()];
     }
     costs[j] = current_cost;
     if (is_pickup) {
@@ -421,10 +421,10 @@ T dynamic_vehicle_choice(const Input& input, INIT init, float lambda) {
       const auto& vehicle = input.vehicles[vehicles_ranks[v]];
       Cost current_cost = is_pickup ? m[j_index][last_job_index] : 0;
       if (vehicle.has_start()) {
-        current_cost += m[vehicle.start.get().index()][j_index];
+        current_cost += m[vehicle.start.value().index()][j_index];
       }
       if (vehicle.has_end()) {
-        current_cost += m[last_job_index][vehicle.end.get().index()];
+        current_cost += m[last_job_index][vehicle.end.value().index()];
       }
       costs[j][v] = current_cost;
       if (is_pickup) {

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -1417,12 +1417,12 @@ Gain LocalSearch<Route,
   auto job_index = _input.jobs[_sol[v].route[r]].index();
 
   if (_input.vehicles[v_target].has_start()) {
-    auto start_index = _input.vehicles[v_target].start.get().index();
+    auto start_index = _input.vehicles[v_target].start.value().index();
     Gain start_cost = _matrix[start_index][job_index];
     cost = std::min(cost, start_cost);
   }
   if (_input.vehicles[v_target].has_end()) {
-    auto end_index = _input.vehicles[v_target].end.get().index();
+    auto end_index = _input.vehicles[v_target].end.value().index();
     Gain end_cost = _matrix[job_index][end_index];
     cost = std::min(cost, end_cost);
   }

--- a/src/makefile
+++ b/src/makefile
@@ -5,7 +5,7 @@
 
 # Variables.
 CXX ?= g++
-CXXFLAGS = -MMD -MP -I. -std=c++14 -Wextra -Wpedantic -Wall -O3
+CXXFLAGS = -MMD -MP -I. -std=c++17 -Wextra -Wpedantic -Wall -O3
 LDLIBS = -lboost_system -lpthread -lssl -lcrypto
 
 # Using all cpp files in current directory.

--- a/src/problems/cvrp/operators/cross_exchange.cpp
+++ b/src/problems/cvrp/operators/cross_exchange.cpp
@@ -94,7 +94,7 @@ Gain CrossExchange::gain_upper_bound() {
 
   if (s_rank == 0) {
     if (v_source.has_start()) {
-      auto p_index = v_source.start.get().index();
+      auto p_index = v_source.start.value().index();
       previous_cost = m[p_index][t_index];
       reverse_previous_cost = m[p_index][t_after_index];
     }
@@ -106,7 +106,7 @@ Gain CrossExchange::gain_upper_bound() {
 
   if (s_rank == s_route.size() - 2) {
     if (v_source.has_end()) {
-      auto n_index = v_source.end.get().index();
+      auto n_index = v_source.end.value().index();
       next_cost = m[t_after_index][n_index];
       reverse_next_cost = m[t_index][n_index];
     }
@@ -142,7 +142,7 @@ Gain CrossExchange::gain_upper_bound() {
 
   if (t_rank == 0) {
     if (v_target.has_start()) {
-      auto p_index = v_target.start.get().index();
+      auto p_index = v_target.start.value().index();
       previous_cost = m[p_index][s_index];
       reverse_previous_cost = m[p_index][s_after_index];
     }
@@ -154,7 +154,7 @@ Gain CrossExchange::gain_upper_bound() {
 
   if (t_rank == t_route.size() - 2) {
     if (v_target.has_end()) {
-      auto n_index = v_target.end.get().index();
+      auto n_index = v_target.end.value().index();
       next_cost = m[s_after_index][n_index];
       reverse_next_cost = m[s_index][n_index];
     }

--- a/src/problems/cvrp/operators/exchange.cpp
+++ b/src/problems/cvrp/operators/exchange.cpp
@@ -54,7 +54,7 @@ void Exchange::compute_gain() {
 
   if (s_rank == 0) {
     if (v_source.has_start()) {
-      auto p_index = v_source.start.get().index();
+      auto p_index = v_source.start.value().index();
       new_previous_cost = m[p_index][t_index];
     }
   } else {
@@ -64,7 +64,7 @@ void Exchange::compute_gain() {
 
   if (s_rank == s_route.size() - 1) {
     if (v_source.has_end()) {
-      auto n_index = v_source.end.get().index();
+      auto n_index = v_source.end.value().index();
       new_next_cost = m[t_index][n_index];
     }
   } else {
@@ -85,7 +85,7 @@ void Exchange::compute_gain() {
 
   if (t_rank == 0) {
     if (v_target.has_start()) {
-      auto p_index = v_target.start.get().index();
+      auto p_index = v_target.start.value().index();
       new_previous_cost = m[p_index][s_index];
     }
   } else {
@@ -95,7 +95,7 @@ void Exchange::compute_gain() {
 
   if (t_rank == t_route.size() - 1) {
     if (v_target.has_end()) {
-      auto n_index = v_target.end.get().index();
+      auto n_index = v_target.end.value().index();
       new_next_cost = m[s_index][n_index];
     }
   } else {

--- a/src/problems/cvrp/operators/intra_cross_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_cross_exchange.cpp
@@ -96,7 +96,7 @@ Gain IntraCrossExchange::gain_upper_bound() {
 
   if (s_rank == 0) {
     if (v.has_start()) {
-      auto p_index = v.start.get().index();
+      auto p_index = v.start.value().index();
       previous_cost = m[p_index][t_index];
       reverse_previous_cost = m[p_index][t_after_index];
     }
@@ -139,7 +139,7 @@ Gain IntraCrossExchange::gain_upper_bound() {
 
   if (t_rank == s_route.size() - 2) {
     if (v.has_end()) {
-      auto n_index = v.end.get().index();
+      auto n_index = v.end.value().index();
       next_cost = m[s_after_index][n_index];
       reverse_next_cost = m[s_index][n_index];
     }

--- a/src/problems/cvrp/operators/intra_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_exchange.cpp
@@ -58,7 +58,7 @@ void IntraExchange::compute_gain() {
 
   if (s_rank == 0) {
     if (v.has_start()) {
-      auto p_index = v.start.get().index();
+      auto p_index = v.start.value().index();
       new_previous_cost = m[p_index][t_index];
     }
   } else {
@@ -84,7 +84,7 @@ void IntraExchange::compute_gain() {
 
   if (t_rank == t_route.size() - 1) {
     if (v.has_end()) {
-      auto n_index = v.end.get().index();
+      auto n_index = v.end.value().index();
       new_next_cost = m[s_index][n_index];
     }
   } else {

--- a/src/problems/cvrp/operators/intra_mixed_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_mixed_exchange.cpp
@@ -99,7 +99,7 @@ Gain IntraMixedExchange::gain_upper_bound() {
 
   if (s_rank == 0) {
     if (v.has_start()) {
-      auto p_index = v.start.get().index();
+      auto p_index = v.start.value().index();
       previous_cost = m[p_index][t_index];
       reverse_previous_cost = m[p_index][t_after_index];
     }
@@ -111,7 +111,7 @@ Gain IntraMixedExchange::gain_upper_bound() {
 
   if (s_rank == s_route.size() - 1) {
     if (v.has_end()) {
-      auto n_index = v.end.get().index();
+      auto n_index = v.end.value().index();
       next_cost = m[t_after_index][n_index];
       reverse_next_cost = m[t_index][n_index];
     }
@@ -145,7 +145,7 @@ Gain IntraMixedExchange::gain_upper_bound() {
 
   if (t_rank == 0) {
     if (v.has_start()) {
-      auto p_index = v.start.get().index();
+      auto p_index = v.start.value().index();
       previous_cost = m[p_index][s_index];
     }
   } else {
@@ -155,7 +155,7 @@ Gain IntraMixedExchange::gain_upper_bound() {
 
   if (t_rank == s_route.size() - 2) {
     if (v.has_end()) {
-      auto n_index = v.end.get().index();
+      auto n_index = v.end.value().index();
       next_cost = m[s_index][n_index];
       reverse_next_cost = m[s_index][n_index];
     }

--- a/src/problems/cvrp/operators/intra_or_opt.cpp
+++ b/src/problems/cvrp/operators/intra_or_opt.cpp
@@ -101,7 +101,7 @@ Gain IntraOrOpt::gain_upper_bound() {
     previous_cost = m[p_index][s_index];
     reverse_previous_cost = m[p_index][after_s_index];
     if (v.has_end()) {
-      auto n_index = v.end.get().index();
+      auto n_index = v.end.value().index();
       old_edge_cost = m[p_index][n_index];
       next_cost = m[after_s_index][n_index];
       reverse_next_cost = m[s_index][n_index];
@@ -114,7 +114,7 @@ Gain IntraOrOpt::gain_upper_bound() {
 
     if (new_rank == 0) {
       if (v.has_start()) {
-        auto p_index = v.start.get().index();
+        auto p_index = v.start.value().index();
         previous_cost = m[p_index][s_index];
         reverse_previous_cost = m[p_index][after_s_index];
         old_edge_cost = m[p_index][n_index];

--- a/src/problems/cvrp/operators/mixed_exchange.cpp
+++ b/src/problems/cvrp/operators/mixed_exchange.cpp
@@ -78,7 +78,7 @@ Gain MixedExchange::gain_upper_bound() {
 
   if (s_rank == 0) {
     if (v_source.has_start()) {
-      auto p_index = v_source.start.get().index();
+      auto p_index = v_source.start.value().index();
       previous_cost = m[p_index][t_index];
       reverse_previous_cost = m[p_index][t_after_index];
     }
@@ -90,7 +90,7 @@ Gain MixedExchange::gain_upper_bound() {
 
   if (s_rank == s_route.size() - 1) {
     if (v_source.has_end()) {
-      auto n_index = v_source.end.get().index();
+      auto n_index = v_source.end.value().index();
       next_cost = m[t_after_index][n_index];
       reverse_next_cost = m[t_index][n_index];
     }
@@ -125,7 +125,7 @@ Gain MixedExchange::gain_upper_bound() {
 
   if (t_rank == 0) {
     if (v_target.has_start()) {
-      auto p_index = v_target.start.get().index();
+      auto p_index = v_target.start.value().index();
       previous_cost = m[p_index][s_index];
     }
   } else {
@@ -135,7 +135,7 @@ Gain MixedExchange::gain_upper_bound() {
 
   if (t_rank == t_route.size() - 2) {
     if (v_target.has_end()) {
-      auto n_index = v_target.end.get().index();
+      auto n_index = v_target.end.value().index();
       next_cost = m[s_index][n_index];
     }
   } else {

--- a/src/problems/cvrp/operators/or_opt.cpp
+++ b/src/problems/cvrp/operators/or_opt.cpp
@@ -65,12 +65,13 @@ Gain OrOpt::gain_upper_bound() {
     if (t_route.size() == 0) {
       // Adding edge to an empty route.
       if (v_target.has_start()) {
-        previous_cost = m[v_target.start.get().index()][s_index];
-        reverse_previous_cost = m[v_target.start.get().index()][after_s_index];
+        previous_cost = m[v_target.start.value().index()][s_index];
+        reverse_previous_cost =
+          m[v_target.start.value().index()][after_s_index];
       }
       if (v_target.has_end()) {
-        next_cost = m[after_s_index][v_target.end.get().index()];
-        reverse_next_cost = m[s_index][v_target.end.get().index()];
+        next_cost = m[after_s_index][v_target.end.value().index()];
+        reverse_next_cost = m[s_index][v_target.end.value().index()];
       }
     } else {
       // Adding edge past the end after a real job.
@@ -78,7 +79,7 @@ Gain OrOpt::gain_upper_bound() {
       previous_cost = m[p_index][s_index];
       reverse_previous_cost = m[p_index][after_s_index];
       if (v_target.has_end()) {
-        auto n_index = v_target.end.get().index();
+        auto n_index = v_target.end.value().index();
         old_edge_cost = m[p_index][n_index];
         next_cost = m[after_s_index][n_index];
         reverse_next_cost = m[s_index][n_index];
@@ -92,7 +93,7 @@ Gain OrOpt::gain_upper_bound() {
 
     if (t_rank == 0) {
       if (v_target.has_start()) {
-        auto p_index = v_target.start.get().index();
+        auto p_index = v_target.start.value().index();
         previous_cost = m[p_index][s_index];
         reverse_previous_cost = m[p_index][after_s_index];
         old_edge_cost = m[p_index][n_index];

--- a/src/problems/cvrp/operators/reverse_two_opt.cpp
+++ b/src/problems/cvrp/operators/reverse_two_opt.cpp
@@ -85,7 +85,7 @@ void ReverseTwoOpt::compute_gain() {
     if (last_in_target) {
       if (v_target.has_end()) {
         // Handle target route new end.
-        auto end_t = v_target.end.get().index();
+        auto end_t = v_target.end.value().index();
         stored_gain += m[t_index][end_t];
         stored_gain -= m[next_s_index][end_t];
       }
@@ -98,14 +98,14 @@ void ReverseTwoOpt::compute_gain() {
 
   if (v_source.has_end()) {
     // Update cost to source end because last job changed.
-    auto end_s = v_source.end.get().index();
+    auto end_s = v_source.end.value().index();
     stored_gain += m[last_s][end_s];
     stored_gain -= m[first_t][end_s];
   }
 
   if (v_target.has_start()) {
     // Spare cost from target start because first job changed.
-    auto start_t = v_target.start.get().index();
+    auto start_t = v_target.start.value().index();
     stored_gain += m[start_t][first_t];
     if (!last_in_source) {
       stored_gain -= m[start_t][last_s];
@@ -119,7 +119,7 @@ void ReverseTwoOpt::compute_gain() {
         // Emptying the whole target route here, so also gaining cost
         // to end if it exists.
         if (v_target.has_end()) {
-          auto end_t = v_target.end.get().index();
+          auto end_t = v_target.end.value().index();
           stored_gain += m[t_index][end_t];
         }
       }

--- a/src/problems/cvrp/operators/route_exchange.cpp
+++ b/src/problems/cvrp/operators/route_exchange.cpp
@@ -45,36 +45,36 @@ void RouteExchange::compute_gain() {
   if (s_route.size() > 0) {
     auto first_s_index = _input.jobs[s_route.front()].index();
     if (v_source.has_start()) {
-      previous_cost += m[v_source.start.get().index()][first_s_index];
+      previous_cost += m[v_source.start.value().index()][first_s_index];
     }
     if (v_target.has_start()) {
-      new_cost += m[v_target.start.get().index()][first_s_index];
+      new_cost += m[v_target.start.value().index()][first_s_index];
     }
 
     auto last_s_index = _input.jobs[s_route.back()].index();
     if (v_source.has_end()) {
-      previous_cost += m[last_s_index][v_source.end.get().index()];
+      previous_cost += m[last_s_index][v_source.end.value().index()];
     }
     if (v_target.has_end()) {
-      new_cost += m[last_s_index][v_target.end.get().index()];
+      new_cost += m[last_s_index][v_target.end.value().index()];
     }
   }
 
   if (t_route.size() > 0) {
     auto first_t_index = _input.jobs[t_route.front()].index();
     if (v_target.has_start()) {
-      previous_cost += m[v_target.start.get().index()][first_t_index];
+      previous_cost += m[v_target.start.value().index()][first_t_index];
     }
     if (v_source.has_start()) {
-      new_cost += m[v_source.start.get().index()][first_t_index];
+      new_cost += m[v_source.start.value().index()][first_t_index];
     }
 
     auto last_t_index = _input.jobs[t_route.back()].index();
     if (v_target.has_end()) {
-      previous_cost += m[last_t_index][v_target.end.get().index()];
+      previous_cost += m[last_t_index][v_target.end.value().index()];
     }
     if (v_source.has_end()) {
-      new_cost += m[last_t_index][v_source.end.get().index()];
+      new_cost += m[last_t_index][v_source.end.value().index()];
     }
   }
 

--- a/src/problems/cvrp/operators/two_opt.cpp
+++ b/src/problems/cvrp/operators/two_opt.cpp
@@ -75,12 +75,12 @@ void TwoOpt::compute_gain() {
   // Handling end route cost change because vehicle ends can be
   // different or none.
   if (v_source.has_end()) {
-    auto end_s = v_source.end.get().index();
+    auto end_s = v_source.end.value().index();
     stored_gain += m[last_s][end_s];
     stored_gain -= m[new_last_s][end_s];
   }
   if (v_target.has_end()) {
-    auto end_t = v_target.end.get().index();
+    auto end_t = v_target.end.value().index();
     stored_gain += m[last_t][end_t];
     stored_gain -= m[new_last_t][end_t];
   }

--- a/src/problems/tsp/heuristics/christofides.cpp
+++ b/src/problems/tsp/heuristics/christofides.cpp
@@ -7,6 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <cassert>
 #include <random>
 #include <set>
 

--- a/src/problems/tsp/heuristics/local_search.cpp
+++ b/src/problems/tsp/heuristics/local_search.cpp
@@ -7,6 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <algorithm>
 #include <numeric>
 #include <thread>
 #include <unordered_map>

--- a/src/problems/tsp/tsp.cpp
+++ b/src/problems/tsp/tsp.cpp
@@ -36,17 +36,19 @@ TSP::TSP(const Input& input, std::vector<Index> job_ranks, Index vehicle_rank)
   if (_has_start) {
     // Add start and remember rank in _matrix.
     _start = matrix_ranks.size();
-    matrix_ranks.push_back(_input.vehicles[_vehicle_rank].start.get().index());
+    matrix_ranks.push_back(
+      _input.vehicles[_vehicle_rank].start.value().index());
   }
   if (_has_end) {
     // Add end and remember rank in _matrix.
-    if (_has_start and (_input.vehicles[_vehicle_rank].start.get().index() ==
-                        _input.vehicles[_vehicle_rank].end.get().index())) {
+    if (_has_start and (_input.vehicles[_vehicle_rank].start.value().index() ==
+                        _input.vehicles[_vehicle_rank].end.value().index())) {
       // Avoiding duplicate for identical ranks.
       _end = _start;
     } else {
       _end = matrix_ranks.size();
-      matrix_ranks.push_back(_input.vehicles[_vehicle_rank].end.get().index());
+      matrix_ranks.push_back(
+        _input.vehicles[_vehicle_rank].end.value().index());
     }
   }
 

--- a/src/structures/cl_args.cpp
+++ b/src/structures/cl_args.cpp
@@ -7,6 +7,8 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <cassert>
+
 #include "structures/cl_args.h"
 
 namespace vroom {

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -17,8 +17,6 @@ All rights reserved (see LICENSE).
 #include <unordered_set>
 #include <vector>
 
-#include <boost/optional.hpp>
-
 namespace vroom {
 
 // To easily differentiate variable types.
@@ -35,7 +33,7 @@ using Priority = uint32_t;
 
 // Type helpers.
 using Coordinates = std::array<Coordinate, 2>;
-using OptionalCoordinates = boost::optional<Coordinates>;
+using OptionalCoordinates = std::optional<Coordinates>;
 using Skills = std::unordered_set<Skill>;
 
 // Setting max value would cause trouble with further additions.

--- a/src/structures/vroom/amount.h
+++ b/src/structures/vroom/amount.h
@@ -10,6 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <cassert>
 #include <vector>
 
 #include "structures/typedefs.h"

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -8,8 +8,6 @@ All rights reserved (see LICENSE).
 */
 #include <array>
 
-#include <boost/optional.hpp>
-
 #include "problems/cvrp/cvrp.h"
 #include "problems/tsp/tsp.h"
 #include "problems/vrp.h"
@@ -165,7 +163,7 @@ void Input::add_vehicle(const Vehicle& vehicle) {
   bool has_end = current_v.has_end();
 
   if (has_start) {
-    auto& start_loc = current_v.start.get();
+    auto& start_loc = current_v.start.value();
 
     if (!start_loc.user_index()) {
       // Index of this start in the matrix was not specified upon
@@ -190,7 +188,7 @@ void Input::add_vehicle(const Vehicle& vehicle) {
   }
 
   if (has_end) {
-    auto& end_loc = current_v.end.get();
+    auto& end_loc = current_v.end.value();
 
     if (!end_loc.user_index()) {
       // Index of this end in the matrix was not specified upon
@@ -284,12 +282,12 @@ void Input::check_cost_bound() const {
     if (v.has_start()) {
       start_bound =
         utils::add_without_overflow(start_bound,
-                                    max_cost_per_line[v.start.get().index()]);
+                                    max_cost_per_line[v.start.value().index()]);
     }
     if (v.has_end()) {
       end_bound =
         utils::add_without_overflow(end_bound,
-                                    max_cost_per_column[v.end.get().index()]);
+                                    max_cost_per_column[v.end.value().index()]);
     }
   }
 

--- a/src/structures/vroom/location.cpp
+++ b/src/structures/vroom/location.cpp
@@ -7,12 +7,14 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <cassert>
+
 #include "structures/vroom/location.h"
 
 namespace vroom {
 
 Location::Location(Index index)
-  : _index(index), _coords(boost::none), _user_index(true) {
+  : _index(index), _coords(std::nullopt), _user_index(true) {
 }
 
 Location::Location(Index index, const Coordinates& coords)
@@ -29,17 +31,17 @@ void Location::set_index(Index index) {
 }
 
 bool Location::has_coordinates() const {
-  return _coords != boost::none;
+  return _coords != std::nullopt;
 }
 
 Coordinate Location::lon() const {
   assert(this->has_coordinates());
-  return _coords.get()[0];
+  return _coords.value()[0];
 }
 
 Coordinate Location::lat() const {
   assert(this->has_coordinates());
-  return _coords.get()[1];
+  return _coords.value()[1];
 }
 
 bool Location::user_index() const {

--- a/src/structures/vroom/solution_state.cpp
+++ b/src/structures/vroom/solution_state.cpp
@@ -151,7 +151,7 @@ void SolutionState::set_node_gains(const std::vector<Index>& route, Index v) {
 
   if (_input.vehicles[v].has_start()) {
     // There is a previous step before job at rank 0.
-    p_index = _input.vehicles[v].start.get().index();
+    p_index = _input.vehicles[v].start.value().index();
     previous_cost = _m[p_index][c_index];
 
     // Update next_cost with next job or end.
@@ -162,7 +162,7 @@ void SolutionState::set_node_gains(const std::vector<Index>& route, Index v) {
     } else {
       // route.size() is 1 and first job is also the last.
       if (_input.vehicles[v].has_end()) {
-        next_cost = _m[c_index][_input.vehicles[v].end.get().index()];
+        next_cost = _m[c_index][_input.vehicles[v].end.value().index()];
       }
     }
   } else {
@@ -172,7 +172,7 @@ void SolutionState::set_node_gains(const std::vector<Index>& route, Index v) {
       n_index = _input.jobs[route[1]].index();
     } else {
       assert(_input.vehicles[v].has_end());
-      n_index = _input.vehicles[v].end.get().index();
+      n_index = _input.vehicles[v].end.value().index();
     }
     next_cost = _m[c_index][n_index];
   }
@@ -219,7 +219,7 @@ void SolutionState::set_node_gains(const std::vector<Index>& route, Index v) {
 
   if (_input.vehicles[v].has_end()) {
     // There is a next step after last job.
-    n_index = _input.vehicles[v].end.get().index();
+    n_index = _input.vehicles[v].end.value().index();
     next_cost = _m[c_index][n_index];
 
     if (route.size() > 1) {
@@ -234,7 +234,7 @@ void SolutionState::set_node_gains(const std::vector<Index>& route, Index v) {
       p_index = _input.jobs[route[last_rank - 1]].index();
     } else {
       assert(_input.vehicles[v].has_start());
-      p_index = _input.vehicles[v].start.get().index();
+      p_index = _input.vehicles[v].start.value().index();
     }
     previous_cost = _m[p_index][c_index];
   }
@@ -272,7 +272,7 @@ void SolutionState::set_edge_gains(const std::vector<Index>& route, Index v) {
 
   if (_input.vehicles[v].has_start()) {
     // There is a previous step before job at rank 0.
-    p_index = _input.vehicles[v].start.get().index();
+    p_index = _input.vehicles[v].start.value().index();
     previous_cost = _m[p_index][c_index];
 
     // Update next_cost with next job or end.
@@ -283,7 +283,7 @@ void SolutionState::set_edge_gains(const std::vector<Index>& route, Index v) {
     } else {
       // route.size() is 2 and first edge is also the last.
       if (_input.vehicles[v].has_end()) {
-        next_cost = _m[after_c_index][_input.vehicles[v].end.get().index()];
+        next_cost = _m[after_c_index][_input.vehicles[v].end.value().index()];
       }
     }
   } else {
@@ -293,7 +293,7 @@ void SolutionState::set_edge_gains(const std::vector<Index>& route, Index v) {
       n_index = _input.jobs[route[2]].index();
     } else {
       assert(_input.vehicles[v].has_end());
-      n_index = _input.vehicles[v].end.get().index();
+      n_index = _input.vehicles[v].end.value().index();
     }
     next_cost = _m[after_c_index][n_index];
   }
@@ -343,7 +343,7 @@ void SolutionState::set_edge_gains(const std::vector<Index>& route, Index v) {
 
   if (_input.vehicles[v].has_end()) {
     // There is a next step after last job.
-    n_index = _input.vehicles[v].end.get().index();
+    n_index = _input.vehicles[v].end.value().index();
     next_cost = _m[after_c_index][n_index];
 
     if (route.size() > 2) {
@@ -358,7 +358,7 @@ void SolutionState::set_edge_gains(const std::vector<Index>& route, Index v) {
       p_index = _input.jobs[route[last_edge_rank - 1]].index();
     } else {
       assert(_input.vehicles[v].has_start());
-      p_index = _input.vehicles[v].start.get().index();
+      p_index = _input.vehicles[v].start.value().index();
     }
     previous_cost = _m[p_index][c_index];
   }
@@ -406,7 +406,7 @@ void SolutionState::set_pd_gains(const std::vector<Index>& route, Index v) {
       } else {
         if (_input.vehicles[v].has_start()) {
           has_previous_step = true;
-          p_index = _input.vehicles[v].start.get().index();
+          p_index = _input.vehicles[v].start.value().index();
           previous_cost = _m[p_index][pickup_index];
         }
       }
@@ -420,7 +420,7 @@ void SolutionState::set_pd_gains(const std::vector<Index>& route, Index v) {
       } else {
         if (_input.vehicles[v].has_end()) {
           has_next_step = true;
-          n_index = _input.vehicles[v].end.get().index();
+          n_index = _input.vehicles[v].end.value().index();
           next_cost = _m[delivery_index][n_index];
         }
       }

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -13,8 +13,8 @@ All rights reserved (see LICENSE).
 namespace vroom {
 
 Vehicle::Vehicle(Id id,
-                 const boost::optional<Location>& start,
-                 const boost::optional<Location>& end,
+                 const std::optional<Location>& start,
+                 const std::optional<Location>& end,
                  const Amount& capacity,
                  const Skills& skills,
                  const TimeWindow& tw)
@@ -39,11 +39,11 @@ bool Vehicle::has_same_locations(const Vehicle& other) const {
               (this->has_end() == other.has_end());
 
   if (same and this->has_start()) {
-    same = this->start.get() == other.start.get();
+    same = this->start.value() == other.start.value();
   }
 
   if (same and this->has_end()) {
-    same = this->end.get() == other.end.get();
+    same = this->end.value() == other.end.value();
   }
 
   return same;

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -19,15 +19,15 @@ namespace vroom {
 
 struct Vehicle {
   const Id id;
-  boost::optional<Location> start;
-  boost::optional<Location> end;
+  std::optional<Location> start;
+  std::optional<Location> end;
   const Amount capacity;
   const Skills skills;
   const TimeWindow tw;
 
   Vehicle(Id id,
-          const boost::optional<Location>& start,
-          const boost::optional<Location>& end,
+          const std::optional<Location>& start,
+          const std::optional<Location>& end,
           const Amount& capacity = Amount(0),
           const Skills& skills = Skills(),
           const TimeWindow& tw = TimeWindow());

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -336,20 +336,19 @@ Input parse(const CLArgs& cl_args) {
       std::optional<Location> start;
       if (has_start_index) {
         if (has_start_coords) {
-          start = std::optional<Location>(
-            Location({start_index, parse_coordinates(json_vehicle, "start")}));
+          start =
+            Location({start_index, parse_coordinates(json_vehicle, "start")});
         } else {
-          start = std::optional<Location>(start_index);
+          start = start_index;
         }
       }
 
       std::optional<Location> end;
       if (has_end_index) {
         if (has_end_coords) {
-          end = std::optional<Location>(
-            Location({end_index, parse_coordinates(json_vehicle, "end")}));
+          end = Location({end_index, parse_coordinates(json_vehicle, "end")});
         } else {
-          end = std::optional<Location>(end_index);
+          end = end_index;
         }
       }
 
@@ -478,13 +477,12 @@ Input parse(const CLArgs& cl_args) {
 
       std::optional<Location> start;
       if (json_vehicle.HasMember("start")) {
-        start =
-          std::optional<Location>(parse_coordinates(json_vehicle, "start"));
+        start = parse_coordinates(json_vehicle, "start");
       }
 
       std::optional<Location> end;
       if (json_vehicle.HasMember("end")) {
-        end = std::optional<Location>(parse_coordinates(json_vehicle, "end"));
+        end = parse_coordinates(json_vehicle, "end");
       }
 
       Vehicle vehicle(json_vehicle["id"].GetUint64(),

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -7,6 +7,7 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <algorithm>
 #include <array>
 #include <vector>
 
@@ -332,23 +333,23 @@ Input parse(const CLArgs& cl_args) {
       bool has_end_coords = json_vehicle.HasMember("end");
 
       // Add vehicle to input
-      boost::optional<Location> start;
+      std::optional<Location> start;
       if (has_start_index) {
         if (has_start_coords) {
-          start = boost::optional<Location>(
+          start = std::optional<Location>(
             Location({start_index, parse_coordinates(json_vehicle, "start")}));
         } else {
-          start = boost::optional<Location>(start_index);
+          start = std::optional<Location>(start_index);
         }
       }
 
-      boost::optional<Location> end;
+      std::optional<Location> end;
       if (has_end_index) {
         if (has_end_coords) {
-          end = boost::optional<Location>(
+          end = std::optional<Location>(
             Location({end_index, parse_coordinates(json_vehicle, "end")}));
         } else {
-          end = boost::optional<Location>(end_index);
+          end = std::optional<Location>(end_index);
         }
       }
 
@@ -475,22 +476,15 @@ Input parse(const CLArgs& cl_args) {
       auto& json_vehicle = json_input["vehicles"][i];
       check_id(json_vehicle, "vehicle");
 
-      // Start def is a ugly workaround as using plain:
-      //
-      // boost::optional<Location> start;
-      //
-      // will raise a false positive -Wmaybe-uninitialized with gcc,
-      // see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47679
-
-      auto start([]() -> boost::optional<Location> { return boost::none; }());
+      std::optional<Location> start;
       if (json_vehicle.HasMember("start")) {
         start =
-          boost::optional<Location>(parse_coordinates(json_vehicle, "start"));
+          std::optional<Location>(parse_coordinates(json_vehicle, "start"));
       }
 
-      boost::optional<Location> end;
+      std::optional<Location> end;
       if (json_vehicle.HasMember("end")) {
-        end = boost::optional<Location>(parse_coordinates(json_vehicle, "end"));
+        end = std::optional<Location>(parse_coordinates(json_vehicle, "end"));
       }
 
       Vehicle vehicle(json_vehicle["id"].GetUint64(),


### PR DESCRIPTION
## Issue

Fixes #311, #312 

## Tasks

 - [x] Build with c++17 standard
 - [x] Replace usage of `boost::optional` with `std::optional`
 - [x] Update `CHANGELOG.md` (remove if irrelevant)
 - [x] review
