### PR TITLE
Computing more flexible job earliest/latest dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Support for string description of vehicles and tasks (#235)
 
+### Changed
+
+- Improved job earliest/latest dates handling internally (#330)
+
 ### Fixed
 
 - Documentation mismatch (#361)

--- a/src/structures/vroom/tw_route.h
+++ b/src/structures/vroom/tw_route.h
@@ -60,11 +60,10 @@ public:
   Duration v_end;
 
   // Margin for job at rank i in route: earliest[i] and latest[i]
-  // store earliest and latest date, considering we use time window at
-  // rank tw_ranks[i] for this job.
+  // store earliest and latest date. Those are potentially derived
+  // from different time windows in multiple TW situations.
   std::vector<Duration> earliest;
   std::vector<Duration> latest;
-  std::vector<Index> tw_ranks;
 
   // Store earliest date for route end.
   Duration earliest_end;

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -448,7 +448,7 @@ inline Route format_route(const Input& input,
     const auto j_tw =
       std::find_if(previous_job.tws.rbegin(),
                    previous_job.tws.rend(),
-                   [&](const auto& tw) { return tw.start <= step_start; });
+                   [&](const auto& tw) { return tw.start <= candidate_start; });
     assert(j_tw != previous_job.tws.rend());
 
     step_start = std::min(candidate_start, j_tw->end);


### PR DESCRIPTION
## Issue

Fixes #330 

## Tasks

 - [x] Compute latest/earliest dates based on (potentially) different job TW
 - [x] Remove TW rank storage for jobs
 - [x] Lookup job TW in `format_route` to account for the situation of earliest and latest dates not belonging to the same TW
 - [x] Evaluate gains on ad-hoc benchmarks
 - [x] Update `CHANGELOG.md` (remove if irrelevant)
 - [x] review
