### PR TITLE
Implement reading input from stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Formatting script updated to use version 10 of clang-format (#452)
+- vroom will now read json input from stdin if no other input is specified (#457)
 
 ### Fixed
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@ void display_usage() {
   usage += "Version: " + vroom::get_version() + "\n";
   usage += "Usage:\n\tvroom [OPTION]... \"INPUT\"";
   usage += "\n\tvroom [OPTION]... -i FILE\n";
+  usage += "\tvroom [OPTION]...\n";
   usage += "Options:\n";
   usage += "\t-a PROFILE:HOST (=" + vroom::DEFAULT_PROFILE +
            ":0.0.0.0)\t routing server\n";
@@ -154,19 +155,21 @@ int main(int argc, char** argv) {
     cl_args.servers.emplace(vroom::DEFAULT_PROFILE, vroom::Server());
   }
 
-  if (cl_args.input_file.empty()) {
-    // Getting input from command-line.
-    if (argc == optind) {
-      // Missing argument!
-      display_usage();
-    }
-    cl_args.input = argv[optind];
-  } else {
-    // Getting input from provided file.
-    std::ifstream ifs(cl_args.input_file);
+  // Read input problem
+  if (optind == argc) {
     std::stringstream buffer;
-    buffer << ifs.rdbuf();
+    if (cl_args.input_file.empty()) {
+      // Getting input from stdin.
+      buffer << std::cin.rdbuf();
+    } else {
+      // Getting input from provided file.
+      std::ifstream ifs(cl_args.input_file);
+      buffer << ifs.rdbuf();
+    }
     cl_args.input = buffer.str();
+  } else {
+    // Getting input from command-line.
+    cl_args.input = argv[optind];
   }
 
   try {


### PR DESCRIPTION
## Issue

Fixes #457

## Tasks

 - [x] Update `CHANGELOG.md` 
 - [ ] review

## Description

With these changes, vroom follows the following strategy for getting its input:
1. If there are spare arguments, read the first spare argument as input
2. If the `-i FILE` option was used, read `FILE` as input
3. Otherwise read `stdin` as input

Previously vroom would display its help string in case 3. This degrades the experience for new users somewhat, since executing `vroom` without any arguments won't appear to do anything until the user closes `stdin` with `^D`, which then results in a cryptic json parsing exception.

Alternatives to consider:
* Only read from `stdin` as input if `stdin` is not a tty (unsure how portable `isatty` is)
* Display help string if the input read from `stdin` has length 0 or is not valid json