### PR TITLE
Report type for unassigned tasks in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Report `type` for unassigned tasks in output (#469)
+
 ### Changed
 
 - Formatting script updated to use version 10 of clang-format (#452)

--- a/docs/API.md
+++ b/docs/API.md
@@ -231,7 +231,7 @@ The computed solution is written as `json` on standard output or a file
 | `code` | status code |
 | `error` | error message (present iff `code` is different from `0`) |
 | [`summary`](#summary) | object summarizing solution indicators |
-| `unassigned` | array of objects describing unassigned tasks with their `id` and `location` (if provided) |
+| `unassigned` | array of objects describing unassigned tasks with their `id`, `type` and `location` (if provided) |
 | [`routes`](#routes) | array of `route` objects |
 
 ## Code

--- a/src/utils/output_json.cpp
+++ b/src/utils/output_json.cpp
@@ -81,6 +81,21 @@ rapidjson::Document to_json(const Solution& sol, bool geometry) {
                            to_json(job.location, allocator),
                            allocator);
       }
+      json_job.AddMember("type", rapidjson::Value(), allocator);
+      std::string str_type;
+      switch (job.type) {
+      case JOB_TYPE::SINGLE:
+        str_type = "job";
+        break;
+      case JOB_TYPE::PICKUP:
+        str_type = "pickup";
+        break;
+      case JOB_TYPE::DELIVERY:
+        str_type = "delivery";
+        break;
+      }
+      json_job["type"].SetString(str_type.c_str(), str_type.size(), allocator);
+
       json_unassigned.PushBack(json_job, allocator);
     }
 


### PR DESCRIPTION
## Issue

Fixes #469.

## Tasks

 - [x] Add `type` key in output
 - [x] Update `docs/API.md`
 - [x] Update `CHANGELOG.md`
 - [ ] review
