### PR TITLE
Extend cvrp::PDShift::compute_gain loop range.

### DIFF
--- a/src/problems/cvrp/operators/pd_shift.cpp
+++ b/src/problems/cvrp/operators/pd_shift.cpp
@@ -56,7 +56,7 @@ void PDShift::compute_gain() {
                                                 t_d_rank);
   }
 
-  for (unsigned t_p_rank = 0; t_p_rank < t_route.size(); ++t_p_rank) {
+  for (unsigned t_p_rank = 0; t_p_rank <= t_route.size(); ++t_p_rank) {
     Gain t_p_gain = -utils::addition_cost(_input,
                                           m,
                                           s_route[_s_p_rank],


### PR DESCRIPTION
## Issue

Fixes #462 by extending the `vrptw::PDShift` change from #464 to `cvrp::PDShift`.

## Tasks

 - [x] Extend loop range
 - [x] Benchmark on PD instances without TW
 - [x] review
