### PR TITLE
Optimize cost_wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Support for heterogeneous vehicle routing profiles (#394)
+- Support for heterogeneous vehicle routing profiles (#394) (#490)
 - Optional `speed_factor` key for vehicle-level tuning (#450)
 - Support Valhalla as routing engine (#306)
 - Report `type` for unassigned tasks in output (#469)

--- a/docs/API.md
+++ b/docs/API.md
@@ -111,7 +111,7 @@ A `vehicle` object has the following properties:
 | [`skills`] | an array of integers defining skills |
 | [`time_window`] | a `time_window` object describing working hours |
 | [`breaks`] | an array of `break` objects |
-| [`speed_factor`] | a double value used to scale **all** vehicle travel times (defaults to 1.) |
+| [`speed_factor`] | a double value used to scale **all** vehicle travel times (defaults to 1.), the respected precision is limited to two digits after the decimal point |
 | [`steps`] | an array of `vehicle_step` objects describing a custom route for this vehicle (only makes sense when using `-c`) |
 
 A `break` object has the following properties:

--- a/src/structures/generic/matrix.cpp
+++ b/src/structures/generic/matrix.cpp
@@ -12,12 +12,11 @@ All rights reserved (see LICENSE).
 namespace vroom {
 
 template <class T> Matrix<T>::Matrix(std::size_t n) : n(n) {
-    data.resize(n * n);
+  data.resize(n * n);
 }
 
 template <class T> Matrix<T>::Matrix() : Matrix(0) {
 }
-
 
 template <class T>
 Matrix<T> Matrix<T>::get_sub_matrix(const std::vector<Index>& indices) const {

--- a/src/structures/generic/matrix.cpp
+++ b/src/structures/generic/matrix.cpp
@@ -11,21 +11,13 @@ All rights reserved (see LICENSE).
 
 namespace vroom {
 
-template <class T> Line<T>::Line(std::size_t n) : parent(n) {
-}
-
-template <class T> Line<T>::Line(std::initializer_list<T> l) : parent(l) {
-}
-
-template <class T> Matrix<T>::Matrix(std::size_t n) : parent(n, Line<T>(n)) {
+template <class T> Matrix<T>::Matrix(std::size_t n) : n(n) {
+    data.resize(n * n);
 }
 
 template <class T> Matrix<T>::Matrix() : Matrix(0) {
 }
 
-template <class T>
-Matrix<T>::Matrix(std::initializer_list<Line<T>> l) : parent(l) {
-}
 
 template <class T>
 Matrix<T> Matrix<T>::get_sub_matrix(const std::vector<Index>& indices) const {
@@ -38,7 +30,6 @@ Matrix<T> Matrix<T>::get_sub_matrix(const std::vector<Index>& indices) const {
   return sub_matrix;
 }
 
-template class Line<Cost>;
 template class Matrix<Cost>;
 
 } // namespace vroom

--- a/src/structures/generic/matrix.h
+++ b/src/structures/generic/matrix.h
@@ -16,34 +16,29 @@ All rights reserved (see LICENSE).
 
 namespace vroom {
 
-template <class T> class Line : private std::vector<T> {
+template <class T> class Matrix {
 
-  using parent = std::vector<T>;
-
-public:
-  using parent::size;
-  using parent::operator[];
-
-  Line(std::size_t n);
-
-  Line(std::initializer_list<T> l);
-};
-
-template <class T> class Matrix : private std::vector<Line<T>> {
-
-  using parent = std::vector<Line<T>>;
+  std::size_t n;
+  std::vector<T> data;
 
 public:
-  using parent::size;
-  using parent::operator[];
 
   Matrix();
 
   Matrix(std::size_t n);
 
-  Matrix(std::initializer_list<Line<T>> l);
-
   Matrix<T> get_sub_matrix(const std::vector<Index>& indices) const;
+    
+   T* operator[](std::size_t i) {
+       return data.data() + (i * n);
+   }
+   const T* operator[](std::size_t i) const {
+       return data.data() + (i * n);
+   }
+
+   std::size_t size() const {
+    return n;
+   }
 };
 
 } // namespace vroom

--- a/src/structures/generic/matrix.h
+++ b/src/structures/generic/matrix.h
@@ -22,23 +22,22 @@ template <class T> class Matrix {
   std::vector<T> data;
 
 public:
-
   Matrix();
 
   Matrix(std::size_t n);
 
   Matrix<T> get_sub_matrix(const std::vector<Index>& indices) const;
-    
-   T* operator[](std::size_t i) {
-       return data.data() + (i * n);
-   }
-   const T* operator[](std::size_t i) const {
-       return data.data() + (i * n);
-   }
 
-   std::size_t size() const {
+  T* operator[](std::size_t i) {
+    return data.data() + (i * n);
+  }
+  const T* operator[](std::size_t i) const {
+    return data.data() + (i * n);
+  }
+
+  std::size_t size() const {
     return n;
-   }
+  }
 };
 
 } // namespace vroom

--- a/src/structures/vroom/cost_wrapper.cpp
+++ b/src/structures/vroom/cost_wrapper.cpp
@@ -17,6 +17,8 @@ CostWrapper::CostWrapper(double speed_factor)
 
 void CostWrapper::set_durations_matrix(const Matrix<Cost>* matrix) {
   durations_matrix = matrix;
+  cost_matrix_size = matrix->size();
+  cost_data = (*matrix)[0];
 }
 
 } // namespace vroom

--- a/src/structures/vroom/cost_wrapper.cpp
+++ b/src/structures/vroom/cost_wrapper.cpp
@@ -7,13 +7,14 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <cmath>
 #include "structures/vroom/cost_wrapper.h"
 
 namespace vroom {
 
 CostWrapper::CostWrapper(double speed_factor)
   : durations_factor(1. / speed_factor),
-    discrete_factor(durations_factor * DIVISOR) {
+    discrete_factor(std::round(durations_factor * DIVISOR)) {
 }
 
 void CostWrapper::set_durations_matrix(const Matrix<Cost>* matrix) {

--- a/src/structures/vroom/cost_wrapper.cpp
+++ b/src/structures/vroom/cost_wrapper.cpp
@@ -13,7 +13,7 @@ namespace vroom {
 
 CostWrapper::CostWrapper(double speed_factor)
   : durations_factor(1. / speed_factor),
-    discrete_factor(durations_factor * DIVISOR){
+    discrete_factor(durations_factor * DIVISOR) {
 }
 
 void CostWrapper::set_durations_matrix(const Matrix<Cost>* matrix) {

--- a/src/structures/vroom/cost_wrapper.cpp
+++ b/src/structures/vroom/cost_wrapper.cpp
@@ -7,18 +7,16 @@ All rights reserved (see LICENSE).
 
 */
 
-#include <cmath>
 #include "structures/vroom/cost_wrapper.h"
+#include <cmath>
 
 namespace vroom {
 
 CostWrapper::CostWrapper(double speed_factor)
-  : durations_factor(1. / speed_factor),
-    discrete_factor(std::round(durations_factor * DIVISOR)) {
+  : discrete_factor(std::round(1 / speed_factor * DIVISOR)) {
 }
 
 void CostWrapper::set_durations_matrix(const Matrix<Cost>* matrix) {
-  durations_matrix = matrix;
   cost_matrix_size = matrix->size();
   cost_data = (*matrix)[0];
 }

--- a/src/structures/vroom/cost_wrapper.cpp
+++ b/src/structures/vroom/cost_wrapper.cpp
@@ -12,7 +12,8 @@ All rights reserved (see LICENSE).
 namespace vroom {
 
 CostWrapper::CostWrapper(double speed_factor)
-  : durations_factor(1. / speed_factor) {
+  : durations_factor(1. / speed_factor),
+    discrete_factor(durations_factor * DIVISOR){
 }
 
 void CostWrapper::set_durations_matrix(const Matrix<Cost>* matrix) {

--- a/src/structures/vroom/cost_wrapper.h
+++ b/src/structures/vroom/cost_wrapper.h
@@ -16,7 +16,10 @@ All rights reserved (see LICENSE).
 namespace vroom {
 
 struct CostWrapper {
+  const static uint32_t DIVISOR = 128;
+
   const double durations_factor;
+  const uint32_t discrete_factor;
   const Matrix<Cost>* durations_matrix;
   
   std::size_t cost_matrix_size;
@@ -28,8 +31,7 @@ struct CostWrapper {
 
   Cost cost(Index i, Index j) const {
     Cost c = cost_data[i * cost_matrix_size + j];
-    return static_cast<Cost>(
-      durations_factor * static_cast<double>(c));
+    return (c * discrete_factor)/ DIVISOR;
   }
 
 };

--- a/src/structures/vroom/cost_wrapper.h
+++ b/src/structures/vroom/cost_wrapper.h
@@ -18,10 +18,7 @@ namespace vroom {
 struct CostWrapper {
   const static uint32_t DIVISOR = 100;
 
-  const double durations_factor;
   const uint32_t discrete_factor;
-  const Matrix<Cost>* durations_matrix;
-
   std::size_t cost_matrix_size;
   const Cost* cost_data;
 

--- a/src/structures/vroom/cost_wrapper.h
+++ b/src/structures/vroom/cost_wrapper.h
@@ -22,6 +22,13 @@ struct CostWrapper {
   CostWrapper(double speed_factor);
 
   void set_durations_matrix(const Matrix<Cost>* matrix);
+
+  Cost cost(Index i, Index j) const {
+    return static_cast<Cost>(
+      durations_factor *
+      static_cast<double>((*(durations_matrix))[i][j]));
+  }
+
 };
 
 } // namespace vroom

--- a/src/structures/vroom/cost_wrapper.h
+++ b/src/structures/vroom/cost_wrapper.h
@@ -18,15 +18,18 @@ namespace vroom {
 struct CostWrapper {
   const double durations_factor;
   const Matrix<Cost>* durations_matrix;
+  
+  std::size_t cost_matrix_size;
+  const Cost* cost_data;
 
   CostWrapper(double speed_factor);
 
   void set_durations_matrix(const Matrix<Cost>* matrix);
 
   Cost cost(Index i, Index j) const {
+    Cost c = cost_data[i * cost_matrix_size + j];
     return static_cast<Cost>(
-      durations_factor *
-      static_cast<double>((*(durations_matrix))[i][j]));
+      durations_factor * static_cast<double>(c));
   }
 
 };

--- a/src/structures/vroom/cost_wrapper.h
+++ b/src/structures/vroom/cost_wrapper.h
@@ -21,7 +21,7 @@ struct CostWrapper {
   const double durations_factor;
   const uint32_t discrete_factor;
   const Matrix<Cost>* durations_matrix;
-  
+
   std::size_t cost_matrix_size;
   const Cost* cost_data;
 
@@ -31,9 +31,8 @@ struct CostWrapper {
 
   Cost cost(Index i, Index j) const {
     Cost c = cost_data[i * cost_matrix_size + j];
-    return (c * discrete_factor)/ DIVISOR;
+    return (c * discrete_factor) / DIVISOR;
   }
-
 };
 
 } // namespace vroom

--- a/src/structures/vroom/cost_wrapper.h
+++ b/src/structures/vroom/cost_wrapper.h
@@ -16,7 +16,7 @@ All rights reserved (see LICENSE).
 namespace vroom {
 
 struct CostWrapper {
-  const static uint32_t DIVISOR = 128;
+  const static uint32_t DIVISOR = 100;
 
   const double durations_factor;
   const uint32_t discrete_factor;

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -106,8 +106,8 @@ bool Vehicle::has_same_locations(const Vehicle& other) const {
 
 bool Vehicle::has_same_profile(const Vehicle& other) const {
   return (this->profile == other.profile) and
-         (this->cost_wrapper.durations_factor ==
-          other.cost_wrapper.durations_factor);
+         (this->cost_wrapper.discrete_factor ==
+          other.cost_wrapper.discrete_factor);
 }
 
 } // namespace vroom

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -59,15 +59,11 @@ struct Vehicle {
   bool has_same_profile(const Vehicle& other) const;
 
   Cost duration(Index i, Index j) const {
-    return static_cast<Cost>(
-      cost_wrapper.durations_factor *
-      static_cast<double>((*(cost_wrapper.durations_matrix))[i][j]));
+    return cost_wrapper.cost(i, j);
   }
 
   Cost cost(Index i, Index j) const {
-    return static_cast<Cost>(
-      cost_wrapper.durations_factor *
-      static_cast<double>((*(cost_wrapper.durations_matrix))[i][j]));
+    return cost_wrapper.cost(i, j);
   }
 };
 


### PR DESCRIPTION
## Issue

Closes #490 

## Tasks

 - [x] Update `CHANGELOG.md` (remove if irrelevant)
 - [x] review

## Description
hommberger_200 VRPTW benchmark master at 1e32124bbfdf131364acbd52109628707aa0c284

```
,Gaps,Computing times
Min,-14.89,194
First decile,-4.56,386
Lower quartile,-0.0,482
Median,2.03,684
Upper quartile,6.67,1690
Ninth decile,8.88,2070
Max,11.53,2491
```

The first commit https://github.com/VROOM-Project/vroom/commit/3a0e9d9e2dfcb4e3d596a6f46b9046417e132e6e turns `Matrix`from a vector of vectors into a flat vector. This removes a layer of indirection and could perhaps improve memory locality.

```
,Gaps,Computing times
Min,-14.89,183
First decile,-4.56,377
Lower quartile,-0.0,478
Median,2.03,671
Upper quartile,6.67,1660
Ninth decile,8.88,2014
Max,11.53,2461
```

The second commit https://github.com/VROOM-Project/vroom/commit/3a0e9d9e2dfcb4e3d596a6f46b9046417e132e6e just moves some code around and should not have an impact.

```
,Gaps,Computing times
Min,-14.89,186
First decile,-4.56,375
Lower quartile,-0.0,480
Median,2.03,672
Upper quartile,6.67,1654
Ninth decile,8.88,2025
Max,11.53,2465
```

The third commit https://github.com/VROOM-Project/vroom/commit/9cba73ef6ad9540cf7552b879ef847020204fc9a removes another layer of indirection by allowing `cost_wrapper`to directly access the matrix array.

```
,Gaps,Computing times
Min,-14.89,181
First decile,-4.56,371
Lower quartile,-0.0,463
Median,2.03,664
Upper quartile,6.67,1623
Ninth decile,8.88,1994
Max,11.53,2407
```

My next idea was to get rid of the cast to double by turning the cost factor into a whole number. My first attempt was https://github.com/VROOM-Project/vroom/commit/510557e4c609e690dcb02d7ec60a5bf2c02890ba .

```
,Gaps,Computing times
Min,-14.89,162
First decile,-4.56,332
Lower quartile,-0.0,438
Median,2.03,646
Upper quartile,6.67,1445
Ninth decile,8.88,1872
Max,11.53,2369
```
However, it turned out that 128 as a factor did not lead to correct reported costs on the HVRP instances (the cost factors can not be exactly represented as multiples of 1/128). That's why I changed the factor to 100 and fixed an additional rounding problem in https://github.com/VROOM-Project/vroom/commit/eb253e2c141b75c71119488a86109704ac2a4b13 and https://github.com/VROOM-Project/vroom/commit/6b3e488d3e5cd714e2f082209895ecc92a8a332d . Leading to these final results:

```
,Gaps,Computing times
Min,-14.89,166
First decile,-4.56,343
Lower quartile,-0.0,455
Median,2.03,615
Upper quartile,6.67,1537
Ninth decile,8.88,1945
Max,11.53,2243
```
Note that these computing times tend to fluctuate quite a bit on my machine, but I think the general trend towards lower computing times is visible here.
The last change effectively restricts the duration factor to two digits after the decimal point. That should probably be documented somewhere if this PR is merged.