### PR TITLE
Solve as a VRPTW when breaks are defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@
 
 ### Fixed
 
--  "Infeasible route" error while an existing route plan exists (#506)
+- "Infeasible route" error while an existing route plan exists (#506)
+- Break omitted with no other time window (#497)
 
 ## [v1.10.0] - 2021-05-06
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -238,7 +238,7 @@ void Input::add_vehicle(const Vehicle& vehicle) {
   }
 
   // Check for time-windows and skills.
-  _has_TW = _has_TW || !vehicle.tw.is_default();
+  _has_TW = _has_TW || !vehicle.tw.is_default() || !vehicle.breaks.empty();
   _has_skills = _has_skills || !current_v.skills.empty();
 
   bool has_location_index = false;


### PR DESCRIPTION
## Issue

Fixes #497 

## Tasks

 - [x] Set `_has_TW` to `true` whenever any vehicle has breaks
 - [x] Update `CHANGELOG.md`
 - [x] review
