### PR TITLE
Output number of routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `setup` key for tasks to refine service time modeling (#358)
 - `max_tasks` key limiting route size at vehicle level (#421)
+- number of routes in solution summary (#524)
 - Github Actions CI (#436)
 - Check for libvroom example build in CI (#514)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -285,6 +285,7 @@ The `summary` object has the following properties:
 | Key         | Description |
 | ----------- | ----------- |
 | `cost` | total cost for all routes |
+| `routes` | number of routes in the solution |
 | `unassigned` | number of tasks that could not be served |
 | `setup` | total setup time for all routes |
 | `service` | total service time for all routes |

--- a/docs/example_1_sol.json
+++ b/docs/example_1_sol.json
@@ -2,6 +2,7 @@
   "code": 0,
   "summary": {
     "cost": 18711,
+    "routes": 2,
     "unassigned": 0,
     "delivery": [
       4

--- a/docs/example_2_sol.json
+++ b/docs/example_2_sol.json
@@ -2,6 +2,7 @@
   "code": 0,
   "summary": {
     "cost": 5461,
+    "routes": 1,
     "unassigned": 0,
     "setup": 0,
     "service": 0,

--- a/docs/example_3_sol.json
+++ b/docs/example_3_sol.json
@@ -2,6 +2,7 @@
   "code": 0,
   "summary": {
     "cost": 18711,
+    "routes": 2,
     "unassigned": 0,
     "delivery": [
       10

--- a/src/structures/vroom/solution/solution.cpp
+++ b/src/structures/vroom/solution/solution.cpp
@@ -20,7 +20,7 @@ Solution::Solution(unsigned code,
                    std::vector<Route>&& routes,
                    std::vector<Job>&& unassigned)
   : code(code),
-    summary(unassigned.size(), amount_size),
+    summary(routes.size(), unassigned.size(), amount_size),
     routes(std::move(routes)),
     unassigned(std::move(unassigned)) {
 

--- a/src/structures/vroom/solution/summary.cpp
+++ b/src/structures/vroom/solution/summary.cpp
@@ -11,11 +11,12 @@ All rights reserved (see LICENSE).
 
 namespace vroom {
 
-Summary::Summary() : cost(0), unassigned(0), setup(0), service(0) {
+Summary::Summary() : cost(0), routes(0), unassigned(0), setup(0), service(0) {
 }
 
-Summary::Summary(unsigned unassigned, unsigned amount_size)
+Summary::Summary(unsigned routes, unsigned unassigned, unsigned amount_size)
   : cost(0),
+    routes(routes),
     unassigned(unassigned),
     delivery(amount_size),
     pickup(amount_size),

--- a/src/structures/vroom/solution/summary.h
+++ b/src/structures/vroom/solution/summary.h
@@ -18,6 +18,7 @@ namespace vroom {
 
 struct Summary {
   Cost cost;
+  const unsigned routes;
   const unsigned unassigned;
   Amount delivery;
   Amount pickup;
@@ -34,7 +35,7 @@ struct Summary {
 
   Summary();
 
-  Summary(unsigned unassigned, unsigned amount_size);
+  Summary(unsigned routes, unsigned unassigned, unsigned amount_size);
 };
 
 } // namespace vroom

--- a/src/utils/output_json.cpp
+++ b/src/utils/output_json.cpp
@@ -118,6 +118,7 @@ rapidjson::Value to_json(const Summary& summary,
   rapidjson::Value json_summary(rapidjson::kObjectType);
 
   json_summary.AddMember("cost", summary.cost, allocator);
+  json_summary.AddMember("routes", summary.routes, allocator);
   json_summary.AddMember("unassigned", summary.unassigned, allocator);
 
   if (summary.delivery.size() > 0) {


### PR DESCRIPTION
## Issue

Fixes #524 by adding a new `summary.routes` key in json output.

## Tasks

 - [x] Add a member for number of routes in `vroom::Summary`
 - [x] Adjust `summary` serialization
 - [x] Update `docs/example_*_sol.json`
 - [x] Update `docs/API.md`
 - [x] Update `CHANGELOG.md`
 - [x] review
