### PR TITLE
Fix error on empty skills arrays for vehicles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Biased evaluation in `try_job_additions` (#572)
 - Routing error with custom matrix and `-g` (#561)
 - Crash on empty custom matrix (#570)
+- Properly allow empty skills arrays (#586)
 
 ## [v1.10.0] - 2021-05-06
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -31,6 +31,7 @@ namespace vroom {
 Input::Input(unsigned amount_size, const io::Servers& servers, ROUTER router)
   : _start_loading(std::chrono::high_resolution_clock::now()),
     _no_addition_yet(true),
+    _has_skills(false),
     _has_TW(false),
     _homogeneous_locations(true),
     _homogeneous_profiles(true),
@@ -331,13 +332,9 @@ void Input::add_vehicle(const Vehicle& vehicle) {
   // Ensure that skills or location index are either always or never
   // provided.
   if (_no_addition_yet) {
-    _has_skills = !current_v.skills.empty();
     _no_addition_yet = false;
     _has_custom_location_index = has_location_index;
   } else {
-    if (_has_skills != !current_v.skills.empty()) {
-      throw Exception(ERROR::INPUT, "Missing skills.");
-    }
     if (_has_custom_location_index != has_location_index) {
       throw Exception(ERROR::INPUT, "Missing location index.");
     }


### PR DESCRIPTION
## Issue

Fixes #586 

## Tasks

 - [x] Do not throw on empty vehicle skills array
 - [x] Update `CHANGELOG.md`
 - [x] review
