### PR TITLE
Add `location_index` and `description` field to output, add shared target to makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- `description` key to unallocated tasks in the output, if provided (#403)
+- `location_index` key to to unassigned tasks and each step, if provided (#625)
+- Shared target to makefile, for creating Position Independent Code (#617)
+
 ## [v1.11.0] - 2021-11-19
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -301,7 +301,7 @@ The computed solution is written as `json` on standard output or a file
 | `code` | status code |
 | `error` | error message (present iff `code` is different from `0`) |
 | [`summary`](#summary) | object summarizing solution indicators |
-| `unassigned` | array of objects describing unassigned tasks with their `id`, `type` and `location` (if provided) |
+| `unassigned` | array of objects describing unassigned tasks with their `id`, `type`, and if provided, `description`, `location` and `location_index` |
 | [`routes`](#routes) | array of `route` objects |
 
 ## Code
@@ -376,6 +376,7 @@ A `step` object has the following properties:
 | `violations` | array of `violation` objects for this step |
 | [`description`] | step description, if provided in input |
 | [`location`] | coordinates array for this step (if provided in input) |
+| [`location_index`] | index of relevant row and column in custom matrices for this step (if provided in input) |
 | [`id`] | id of the task performed at this step, only provided if `type` value is `job`, `pickup`, `delivery` or `break` |
 | ~~[`job`]~~ | ~~id of the job performed at this step, only provided if `type` value is `job`~~ |
 | [`load`] | vehicle load after step completion (with capacity constraints) |

--- a/docs/example_2_sol.json
+++ b/docs/example_2_sol.json
@@ -24,6 +24,7 @@
       "steps": [
         {
           "type": "start",
+          "location_index": 0,
           "setup": 0,
           "service": 0,
           "waiting_time": 0,
@@ -34,6 +35,7 @@
         {
           "type": "job",
           "id": 1414,
+          "location_index": 1,
           "setup": 0,
           "service": 0,
           "waiting_time": 0,
@@ -45,6 +47,7 @@
         {
           "type": "job",
           "id": 1515,
+          "location_index": 2,
           "setup": 0,
           "service": 0,
           "waiting_time": 0,
@@ -55,6 +58,7 @@
         },
         {
           "type": "end",
+          "location_index": 3,
           "setup": 0,
           "service": 0,
           "waiting_time": 0,

--- a/src/makefile
+++ b/src/makefile
@@ -51,6 +51,10 @@ DEPS = $(SRC:.cpp=.d)
 # Main target.
 all : $(MAIN) $(LIB)
 
+# Shared target, for creating Position Independent Code (PIC)
+shared : CXXFLAGS += -fPIC
+shared : all
+
 $(MAIN) : $(OBJ) main.o
 	mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDLIBS)

--- a/src/utils/output_json.cpp
+++ b/src/utils/output_json.cpp
@@ -99,6 +99,13 @@ rapidjson::Document to_json(const Solution& sol, bool geometry) {
       }
       json_job["type"].SetString(str_type.c_str(), str_type.size(), allocator);
 
+      if (!job.description.empty()) {
+        json_job.AddMember("description", rapidjson::Value(), allocator);
+        json_job["description"].SetString(job.description.c_str(),
+                                          job.description.size(),
+                                          allocator);
+      }
+
       json_unassigned.PushBack(json_job, allocator);
     }
 

--- a/src/utils/output_json.cpp
+++ b/src/utils/output_json.cpp
@@ -84,6 +84,9 @@ rapidjson::Document to_json(const Solution& sol, bool geometry) {
                            to_json(job.location, allocator),
                            allocator);
       }
+      if (job.location.user_index()) {
+        json_job.AddMember("location_index", job.location.index(), allocator);
+      }
       json_job.AddMember("type", rapidjson::Value(), allocator);
       std::string str_type;
       switch (job.type) {
@@ -301,6 +304,10 @@ rapidjson::Value to_json(const Step& s,
 
   if (s.location.has_coordinates()) {
     json_step.AddMember("location", to_json(s.location, allocator), allocator);
+  }
+
+  if (s.location.user_index()) {
+    json_step.AddMember("location_index", s.location.index(), allocator);
   }
 
   if (s.step_type == STEP_TYPE::JOB or s.step_type == STEP_TYPE::BREAK) {


### PR DESCRIPTION
## Issue

Fixes #403, #617, #625

## Tasks

 - [x] Add `description` key to unallocated tasks in the output, if provided (#403)
 - [x] Add `location_index` key to to unassigned tasks and each step, if provided (#625)
 - [x] Add shared target to makefile (`make shared`), for creating Position Independent Code (#617)
 - [x] Update `docs/API.md`
 - [x] Update `CHANGELOG.md`
 - [x] review
