### PR TITLE
remove braced-scalar-init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed redundant braced-scalar-init in Matrix declaration (#637)
+
 ## [v1.11.0] - 2021-11-19
 
 ### Added

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -682,7 +682,7 @@ void Input::set_matrices(unsigned nb_thread) {
           // Durations matrix not manually set so defined as empty
           // above.
           if (_locations.size() == 1) {
-            d_m->second = Matrix<Cost>({{0}});
+            d_m->second = Matrix<Cost>(0);
           } else {
             auto rw = std::find_if(_routing_wrappers.begin(),
                                    _routing_wrappers.end(),


### PR DESCRIPTION
## Issue

#634, this issue prevents compiling on clang, which is what is used to compile pyvroom on macos.

## Tasks

 - [X] Update `CHANGELOG.md` (remove if irrelevant)
 - [ ] review
