### PR TITLE
Remove duplicate definition of LocalSearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove duplicate definition of LocalSearch (#638)
+
 ## [v1.11.0] - 2021-11-19
 
 ### Added

--- a/src/problems/cvrp/cvrp.cpp
+++ b/src/problems/cvrp/cvrp.cpp
@@ -35,6 +35,8 @@ namespace vroom {
 
 using RawSolution = std::vector<RawRoute>;
 
+namespace cvrp {
+
 using LocalSearch = ls::LocalSearch<RawRoute,
                                     cvrp::UnassignedExchange,
                                     cvrp::SwapStar,
@@ -51,6 +53,7 @@ using LocalSearch = ls::LocalSearch<RawRoute,
                                     cvrp::IntraOrOpt,
                                     cvrp::PDShift,
                                     cvrp::RouteExchange>;
+} // namespace cvrp
 
 const std::vector<HeuristicParameters> CVRP::homogeneous_parameters =
   {HeuristicParameters(HEURISTIC::BASIC, INIT::NONE, 0.3),
@@ -220,10 +223,10 @@ Solution CVRP::solve(unsigned exploration_level,
         }
 
         // Local search phase.
-        LocalSearch ls(_input,
-                       solutions[rank],
-                       max_nb_jobs_removal,
-                       search_time);
+        cvrp::LocalSearch ls(_input,
+                             solutions[rank],
+                             max_nb_jobs_removal,
+                             search_time);
         ls.run();
 
         // Store solution indicators.

--- a/src/problems/vrptw/vrptw.cpp
+++ b/src/problems/vrptw/vrptw.cpp
@@ -34,7 +34,7 @@ namespace vroom {
 
 using TWSolution = std::vector<TWRoute>;
 
-using LocalSearch = ls::LocalSearch<TWRoute,
+using LocalSearch_ = ls::LocalSearch<TWRoute,
                                     vrptw::UnassignedExchange,
                                     vrptw::SwapStar,
                                     vrptw::CrossExchange,
@@ -202,7 +202,7 @@ Solution VRPTW::solve(unsigned exploration_level,
         }
 
         // Local search phase.
-        LocalSearch ls(_input,
+        LocalSearch_ ls(_input,
                        tw_solutions[rank],
                        max_nb_jobs_removal,
                        search_time);

--- a/src/problems/vrptw/vrptw.cpp
+++ b/src/problems/vrptw/vrptw.cpp
@@ -34,7 +34,9 @@ namespace vroom {
 
 using TWSolution = std::vector<TWRoute>;
 
-using LocalSearch_ = ls::LocalSearch<TWRoute,
+namespace vrptw {
+
+using LocalSearch = ls::LocalSearch<TWRoute,
                                     vrptw::UnassignedExchange,
                                     vrptw::SwapStar,
                                     vrptw::CrossExchange,
@@ -50,6 +52,7 @@ using LocalSearch_ = ls::LocalSearch<TWRoute,
                                     vrptw::IntraOrOpt,
                                     vrptw::PDShift,
                                     vrptw::RouteExchange>;
+} // namespace vrptw
 
 const std::vector<HeuristicParameters> VRPTW::homogeneous_parameters =
   {HeuristicParameters(HEURISTIC::BASIC, INIT::HIGHER_AMOUNT, 0.3),
@@ -202,10 +205,10 @@ Solution VRPTW::solve(unsigned exploration_level,
         }
 
         // Local search phase.
-        LocalSearch_ ls(_input,
-                       tw_solutions[rank],
-                       max_nb_jobs_removal,
-                       search_time);
+        vrptw::LocalSearch ls(_input,
+                              tw_solutions[rank],
+                              max_nb_jobs_removal,
+                              search_time);
         ls.run();
 
         // Store solution indicators.


### PR DESCRIPTION
## Issue

#634:
Python requires a large list of includes in memory at all given times. Using the same name in the same namespace causes compile issues.

The proposed minimal solution is to just rename the conflicting variable, but removing the name all together is also possible here as it is only used for convinience.

## Tasks

 - [X] Update `CHANGELOG.md` (remove if irrelevant)
 - [x] review
