### PR TITLE
Refactor/exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Refactor exception class (#639)
+
 ### Fixed
 
 - Remove duplicate definition of LocalSearch (#638)

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -806,9 +806,8 @@ template <class T> T initial_routes(const Input& input) {
       }
     }
     if (!(current_load <= vehicle.capacity)) {
-      throw Exception(ERROR::INPUT,
-                      "Route over capacity for vehicle " +
-                        std::to_string(vehicle.id) + ".");
+      throw InputException("Route over capacity for vehicle " +
+                           std::to_string(vehicle.id) + ".");
     }
 
     std::vector<Index> job_ranks;
@@ -823,9 +822,8 @@ template <class T> T initial_routes(const Input& input) {
       job_ranks.push_back(job_rank);
 
       if (!input.vehicle_ok_with_job(v, job_rank)) {
-        throw Exception(ERROR::INPUT,
-                        "Missing skill or step out of reach for vehicle " +
-                          std::to_string(vehicle.id) + ".");
+        throw InputException("Missing skill or step out of reach for vehicle " +
+                             std::to_string(vehicle.id) + ".");
       }
 
       switch (step.job_type) {
@@ -843,9 +841,8 @@ template <class T> T initial_routes(const Input& input) {
       case JOB_TYPE::DELIVERY: {
         auto search = expected_delivery_ranks.find(job_rank);
         if (search == expected_delivery_ranks.end()) {
-          throw Exception(ERROR::INPUT,
-                          "Invalid shipment in route for vehicle " +
-                            std::to_string(vehicle.id) + ".");
+          throw InputException("Invalid shipment in route for vehicle " +
+                               std::to_string(vehicle.id) + ".");
         }
         expected_delivery_ranks.erase(search);
 
@@ -856,22 +853,19 @@ template <class T> T initial_routes(const Input& input) {
 
       // Check validity after this step wrt capacity.
       if (!(current_load <= vehicle.capacity)) {
-        throw Exception(ERROR::INPUT,
-                        "Route over capacity for vehicle " +
-                          std::to_string(vehicle.id) + ".");
+        throw InputException("Route over capacity for vehicle " +
+                             std::to_string(vehicle.id) + ".");
       }
     }
 
     if (vehicle.max_tasks < job_ranks.size()) {
-      throw Exception(ERROR::INPUT,
-                      "Too many tasks for vehicle " +
-                        std::to_string(vehicle.id) + ".");
+      throw InputException("Too many tasks for vehicle " +
+                           std::to_string(vehicle.id) + ".");
     }
 
     if (!expected_delivery_ranks.empty()) {
-      throw Exception(ERROR::INPUT,
-                      "Invalid shipment in route for vehicle " +
-                        std::to_string(vehicle.id) + ".");
+      throw InputException("Invalid shipment in route for vehicle " +
+                           std::to_string(vehicle.id) + ".");
     }
 
     // Now route is OK with regard to capacity, precedence and skills
@@ -882,9 +876,8 @@ template <class T> T initial_routes(const Input& input) {
                                               job_ranks.end(),
                                               0,
                                               0)) {
-        throw Exception(ERROR::INPUT,
-                        "Infeasible route for vehicle " +
-                          std::to_string(vehicle.id) + ".");
+        throw InputException("Infeasible route for vehicle " +
+                             std::to_string(vehicle.id) + ".");
       }
 
       current_r.replace(input, job_ranks.begin(), job_ranks.end(), 0, 0);

--- a/src/algorithms/validation/choose_ETA.cpp
+++ b/src/algorithms/validation/choose_ETA.cpp
@@ -219,9 +219,8 @@ Route choose_ETA(const Input& input,
     if (latest_date != std::numeric_limits<Duration>::max()) {
       const auto reach_time = relative_ETA[s];
       if (latest_date < reach_time) {
-        throw Exception(ERROR::INPUT,
-                        "Infeasible route for vehicle " + std::to_string(v.id) +
-                          ".");
+        throw InputException("Infeasible route for vehicle " +
+                             std::to_string(v.id) + ".");
       }
       start_candidate = std::min(start_candidate, latest_date - reach_time);
     }
@@ -263,9 +262,8 @@ Route choose_ETA(const Input& input,
         std::max(earliest_date, step.forced_service.after.value());
     }
     if (earliest_date > latest_dates[s]) {
-      throw Exception(ERROR::INPUT,
-                      "Infeasible route for vehicle " + std::to_string(v.id) +
-                        ".");
+      throw InputException("Infeasible route for vehicle " +
+                           std::to_string(v.id) + ".");
     }
 
     switch (step.type) {
@@ -693,9 +691,8 @@ Route choose_ETA(const Input& input,
     const Duration UB = t_i_UB[i];
 
     if (UB < LB) {
-      throw Exception(ERROR::INPUT,
-                      "Infeasible route for vehicle " + std::to_string(v.id) +
-                        ".");
+      throw InputException("Infeasible route for vehicle " +
+                           std::to_string(v.id) + ".");
     }
 
     if (LB == UB) {
@@ -977,9 +974,8 @@ Route choose_ETA(const Input& input,
 
   auto status = glp_mip_status(lp);
   if (status == GLP_UNDEF or status == GLP_NOFEAS) {
-    throw Exception(ERROR::INPUT,
-                    "Infeasible route for vehicle " + std::to_string(v.id) +
-                      ".");
+    throw InputException("Infeasible route for vehicle " +
+                         std::to_string(v.id) + ".");
   }
   // We should not get GLP_FEAS.
   assert(status == GLP_OPT);
@@ -1035,9 +1031,8 @@ Route choose_ETA(const Input& input,
 
   status = glp_mip_status(lp);
   if (status == GLP_UNDEF or status == GLP_NOFEAS) {
-    throw Exception(ERROR::INPUT,
-                    "Infeasible route for vehicle " + std::to_string(v.id) +
-                      ".");
+    throw InputException("Infeasible route for vehicle " +
+                         std::to_string(v.id) + ".");
   }
   // We should not get GLP_FEAS.
   assert(status == GLP_OPT);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -206,7 +206,7 @@ int main(int argc, char** argv) {
 #if USE_LIBOSRM
   catch (const osrm::exception& e) {
     // In case of an unhandled routing error.
-    auto error_code = vroom::RouterException("").error_code;
+    auto error_code = vroom::RoutingException("").error_code;
     auto message = "Routing problem: " + std::string(e.what());
     std::cerr << "[Error] " << message << std::endl;
     vroom::io::write_to_json({error_code, message}, false, cl_args.output_file);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,12 +153,11 @@ int main(int argc, char** argv) {
                      return vroom::utils::str_to_heuristic_param(str_param);
                    });
   } catch (const vroom::Exception& e) {
-    auto error_code = vroom::utils::get_code(e.error);
     std::cerr << "[Error] " << e.message << std::endl;
-    vroom::io::write_to_json({error_code, e.message},
+    vroom::io::write_to_json({e.error_code, e.message},
                              false,
                              cl_args.output_file);
-    exit(error_code);
+    exit(e.error_code);
   }
 
   // Add default server if none provided in input.
@@ -197,12 +196,11 @@ int main(int argc, char** argv) {
     // Write solution.
     vroom::io::write_to_json(sol, cl_args.geometry, cl_args.output_file);
   } catch (const vroom::Exception& e) {
-    auto error_code = vroom::utils::get_code(e.error);
     std::cerr << "[Error] " << e.message << std::endl;
-    vroom::io::write_to_json({error_code, e.message},
+    vroom::io::write_to_json({e.error_code, e.message},
                              false,
                              cl_args.output_file);
-    exit(error_code);
+    exit(e.error_code);
   }
 #if USE_LIBOSRM
   catch (const osrm::exception& e) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@ All rights reserved (see LICENSE).
 #include "utils/input_parser.h"
 #include "utils/output_json.h"
 #include "utils/version.h"
+#include "utils/exception.h"
 
 void display_usage() {
   std::string usage = "VROOM Copyright (C) 2015-2021, Julien Coupey\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,7 +121,7 @@ int main(int argc, char** argv) {
     cl_args.exploration_level =
       std::min(cl_args.exploration_level, cl_args.max_exploration_level);
   } catch (const std::exception& e) {
-    auto error_code = vroom::utils::get_code(vroom::ERROR::INPUT);
+    auto error_code = vroom::InputException("").error_code;
     std::string message = "Invalid numerical value in option.";
     std::cerr << "[Error] " << message << std::endl;
     vroom::io::write_to_json({error_code, message}, false, cl_args.output_file);
@@ -136,7 +136,7 @@ int main(int argc, char** argv) {
   } else if (router_arg == "valhalla") {
     cl_args.router = vroom::ROUTER::VALHALLA;
   } else if (!router_arg.empty() and router_arg != "osrm") {
-    auto error_code = vroom::utils::get_code(vroom::ERROR::INPUT);
+    auto error_code = vroom::InputException("").error_code;
     std::string message = "Invalid routing engine: " + router_arg + ".";
     std::cerr << "[Error] " << message << std::endl;
     vroom::io::write_to_json({error_code, message}, false, cl_args.output_file);
@@ -205,7 +205,7 @@ int main(int argc, char** argv) {
 #if USE_LIBOSRM
   catch (const osrm::exception& e) {
     // In case of an unhandled routing error.
-    auto error_code = vroom::utils::get_code(vroom::ERROR::ROUTING);
+    auto error_code = vroom::RouterException("").error_code;
     auto message = "Routing problem: " + std::string(e.what());
     std::cerr << "[Error] " << message << std::endl;
     vroom::io::write_to_json({error_code, message}, false, cl_args.output_file);
@@ -214,7 +214,7 @@ int main(int argc, char** argv) {
 #endif
   catch (const std::exception& e) {
     // In case of an unhandled internal error.
-    auto error_code = vroom::utils::get_code(vroom::ERROR::INTERNAL);
+    auto error_code = vroom::InternalException("").error_code;
     std::cerr << "[Error] " << e.what() << std::endl;
     vroom::io::write_to_json({error_code, e.what()},
                              false,

--- a/src/routing/http_wrapper.cpp
+++ b/src/routing/http_wrapper.cpp
@@ -63,19 +63,18 @@ std::string HttpWrapper::send_then_receive(const std::string& query) const {
       }
     }
   } catch (std::system_error& e) {
-    throw Exception(ERROR::ROUTING,
-                    "Failed to connect to " + _server.host + ":" +
-                      _server.port);
+    throw RoutingException("Failed to connect to " + _server.host + ":" +
+                           _server.port);
   }
 
   // Removing headers.
   auto start = response.find("{");
   if (start == std::string::npos) {
-    throw Exception(ERROR::ROUTING, "Invalid routing response.");
+    throw RoutingException("Invalid routing response.");
   }
   auto end = response.rfind("}");
   if (end == std::string::npos) {
-    throw Exception(ERROR::ROUTING, "Invalid routing response.");
+    throw RoutingException("Invalid routing response.");
   }
 
   std::string json_string = response.substr(start, end - start + 1);
@@ -116,9 +115,8 @@ std::string HttpWrapper::ssl_send_then_receive(const std::string& query) const {
       }
     }
   } catch (std::system_error& e) {
-    throw Exception(ERROR::ROUTING,
-                    "Failed to connect to " + _server.host + ":" +
-                      _server.port);
+    throw RoutingException("Failed to connect to " + _server.host + ":" +
+                           _server.port);
   }
 
   // Removing headers.
@@ -158,7 +156,7 @@ Matrix<Cost> HttpWrapper::get_matrix(const std::vector<Location>& locs) const {
   this->check_response(json_result, _matrix_service);
 
   if (!json_result.HasMember(_matrix_durations_key.c_str())) {
-    throw Exception(ERROR::ROUTING, "Missing " + _matrix_durations_key + ".");
+    throw RoutingException("Missing " + _matrix_durations_key + ".");
   }
   assert(json_result[_matrix_durations_key.c_str()].Size() == m_size);
 

--- a/src/routing/libosrm_wrapper.cpp
+++ b/src/routing/libosrm_wrapper.cpp
@@ -46,11 +46,9 @@ LibosrmWrapper::get_matrix(const std::vector<Location>& locs) const {
   osrm::Status status = _osrm.Table(params, result);
 
   if (status == osrm::Status::Error) {
-    throw Exception(ERROR::ROUTING,
-                    "libOSRM: " +
-                      result.values["code"].get<osrm::json::String>().value +
-                      ": " +
-                      result.values["message"].get<osrm::json::String>().value);
+    throw RoutingException(
+      "libOSRM: " + result.values["code"].get<osrm::json::String>().value +
+      ": " + result.values["message"].get<osrm::json::String>().value);
   }
 
   auto& table = result.values["durations"].get<osrm::json::Array>();
@@ -121,10 +119,9 @@ void LibosrmWrapper::add_route_info(Route& route) const {
   osrm::Status status = _osrm.Route(params, result);
 
   if (status == osrm::Status::Error) {
-    throw Exception(ERROR::ROUTING,
-                    result.values["code"].get<osrm::json::String>().value +
-                      ": " +
-                      result.values["message"].get<osrm::json::String>().value);
+    throw RoutingException(
+      result.values["code"].get<osrm::json::String>().value + ": " +
+      result.values["message"].get<osrm::json::String>().value);
   }
 
   auto& result_routes = result.values["routes"].get<osrm::json::Array>();

--- a/src/routing/ors_wrapper.cpp
+++ b/src/routing/ors_wrapper.cpp
@@ -61,8 +61,8 @@ std::string OrsWrapper::build_query(const std::vector<Location>& locations,
 void OrsWrapper::check_response(const rapidjson::Document& json_result,
                                 const std::string&) const {
   if (json_result.HasMember("error")) {
-    throw Exception(ERROR::ROUTING,
-                    std::string(json_result["error"]["message"].GetString()));
+    throw RoutingException(
+      std::string(json_result["error"]["message"].GetString()));
   }
 }
 

--- a/src/routing/osrm_routed_wrapper.cpp
+++ b/src/routing/osrm_routed_wrapper.cpp
@@ -55,8 +55,7 @@ void OsrmRoutedWrapper::check_response(const rapidjson::Document& json_result,
                                        const std::string&) const {
   assert(json_result.HasMember("code"));
   if (json_result["code"] != "Ok") {
-    throw Exception(ERROR::ROUTING,
-                    std::string(json_result["message"].GetString()));
+    throw RoutingException(std::string(json_result["message"].GetString()));
   }
 }
 

--- a/src/routing/valhalla_wrapper.cpp
+++ b/src/routing/valhalla_wrapper.cpp
@@ -104,16 +104,15 @@ void ValhallaWrapper::check_response(const rapidjson::Document& json_result,
       error += json_result["error"].GetString();
       error += ").";
     }
-    throw Exception(ERROR::ROUTING, error);
+    throw RoutingException(error);
   }
 
   if (service == _route_service) {
     assert(json_result.HasMember("trip") and
            json_result["trip"].HasMember("status"));
     if (json_result["trip"]["status"] != 0) {
-      throw Exception(ERROR::ROUTING,
-                      std::string(
-                        json_result["trip"]["status_message"].GetString()));
+      throw RoutingException(
+        std::string(json_result["trip"]["status_message"].GetString()));
     }
   }
 }

--- a/src/routing/wrapper.h
+++ b/src/routing/wrapper.h
@@ -67,7 +67,7 @@ protected:
       error_msg += "location [" + std::to_string(locs[error_loc].lon()) + ";" +
                    std::to_string(locs[error_loc].lat()) + "]";
 
-      throw Exception(ERROR::ROUTING, error_msg);
+      throw RoutingException(error_msg);
     }
   }
 };

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -71,9 +71,6 @@ struct Server {
   }
 };
 
-// Specific error statuses used when handling exceptions.
-enum class ERROR { INTERNAL, INPUT, ROUTING };
-
 // 'Single' job is a regular one-stop job without precedence
 // constraints.
 enum class JOB_TYPE { SINGLE, PICKUP, DELIVERY };

--- a/src/structures/vroom/cost_wrapper.cpp
+++ b/src/structures/vroom/cost_wrapper.cpp
@@ -17,8 +17,8 @@ CostWrapper::CostWrapper(double speed_factor)
   : discrete_duration_factor(std::round(1 / speed_factor * DIVISOR)),
     discrete_cost_factor(std::round(1 / speed_factor * DIVISOR)) {
   if (speed_factor <= 0 || speed_factor > MAX_SPEED_FACTOR) {
-    throw Exception(ERROR::INPUT,
-                    "Invalid speed factor: " + std::to_string(speed_factor));
+    throw InputException("Invalid speed factor: " +
+                         std::to_string(speed_factor));
   }
 }
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -65,7 +65,7 @@ void Input::add_routing_wrapper(const std::string& profile) {
     // Use osrm-routed.
     auto search = _servers.find(profile);
     if (search == _servers.end()) {
-      throw Exception(ERROR::INPUT, "Invalid profile: " + profile + ".");
+      throw InputException("Invalid profile: " + profile + ".");
     }
     routing_wrapper =
       std::make_unique<routing::OsrmRoutedWrapper>(profile, search->second);
@@ -76,19 +76,18 @@ void Input::add_routing_wrapper(const std::string& profile) {
     try {
       routing_wrapper = std::make_unique<routing::LibosrmWrapper>(profile);
     } catch (const osrm::exception& e) {
-      throw Exception(ERROR::ROUTING, "Invalid profile: " + profile);
+      throw RoutingException("Invalid profile: " + profile);
     }
 #else
     // Attempt to use libosrm while compiling without it.
-    throw Exception(ERROR::ROUTING,
-                    "VROOM compiled without libosrm installed.");
+    throw RoutingException("VROOM compiled without libosrm installed.");
 #endif
     break;
   case ROUTER::ORS: {
     // Use ORS http wrapper.
     auto search = _servers.find(profile);
     if (search == _servers.end()) {
-      throw Exception(ERROR::INPUT, "Invalid profile: " + profile + ".");
+      throw InputException("Invalid profile: " + profile + ".");
     }
     routing_wrapper =
       std::make_unique<routing::OrsWrapper>(profile, search->second);
@@ -97,7 +96,7 @@ void Input::add_routing_wrapper(const std::string& profile) {
     // Use Valhalla http wrapper.
     auto search = _servers.find(profile);
     if (search == _servers.end()) {
-      throw Exception(ERROR::INPUT, "Invalid profile: " + profile + ".");
+      throw InputException("Invalid profile: " + profile + ".");
     }
     routing_wrapper =
       std::make_unique<routing::ValhallaWrapper>(profile, search->second);
@@ -109,19 +108,17 @@ void Input::check_job(Job& job) {
   // Ensure delivery size consistency.
   const auto& delivery_size = job.delivery.size();
   if (delivery_size != _amount_size) {
-    throw Exception(ERROR::INPUT,
-                    "Inconsistent delivery length: " +
-                      std::to_string(delivery_size) + " instead of " +
-                      std::to_string(_amount_size) + '.');
+    throw InputException(
+      "Inconsistent delivery length: " + std::to_string(delivery_size) +
+      " instead of " + std::to_string(_amount_size) + '.');
   }
 
   // Ensure pickup size consistency.
   const auto& pickup_size = job.pickup.size();
   if (pickup_size != _amount_size) {
-    throw Exception(ERROR::INPUT,
-                    "Inconsistent pickup length: " +
-                      std::to_string(pickup_size) + " instead of " +
-                      std::to_string(_amount_size) + '.');
+    throw InputException(
+      "Inconsistent pickup length: " + std::to_string(pickup_size) +
+      " instead of " + std::to_string(_amount_size) + '.');
   }
 
   // Ensure that location index are either always or never provided.
@@ -131,7 +128,7 @@ void Input::check_job(Job& job) {
     _has_custom_location_index = has_location_index;
   } else {
     if (_has_custom_location_index != has_location_index) {
-      throw Exception(ERROR::INPUT, "Missing location index.");
+      throw InputException("Missing location index.");
     }
   }
 
@@ -173,11 +170,10 @@ void Input::check_job(Job& job) {
 
 void Input::add_job(const Job& job) {
   if (job.type != JOB_TYPE::SINGLE) {
-    throw Exception(ERROR::INPUT, "Wrong job type.");
+    throw InputException("Wrong job type.");
   }
   if (job_id_to_rank.find(job.id) != job_id_to_rank.end()) {
-    throw Exception(ERROR::INPUT,
-                    "Duplicate job id: " + std::to_string(job.id) + ".");
+    throw InputException("Duplicate job id: " + std::to_string(job.id) + ".");
   }
   job_id_to_rank[job.id] = jobs.size();
   jobs.push_back(job);
@@ -187,38 +183,37 @@ void Input::add_job(const Job& job) {
 
 void Input::add_shipment(const Job& pickup, const Job& delivery) {
   if (pickup.priority != delivery.priority) {
-    throw Exception(ERROR::INPUT, "Inconsistent shipment priority.");
+    throw InputException("Inconsistent shipment priority.");
   }
   if (!(pickup.pickup == delivery.delivery)) {
-    throw Exception(ERROR::INPUT, "Inconsistent shipment amount.");
+    throw InputException("Inconsistent shipment amount.");
   }
   if (pickup.skills.size() != delivery.skills.size()) {
-    throw Exception(ERROR::INPUT, "Inconsistent shipment skills.");
+    throw InputException("Inconsistent shipment skills.");
   }
   for (const auto s : pickup.skills) {
     if (delivery.skills.find(s) == delivery.skills.end()) {
-      throw Exception(ERROR::INPUT, "Inconsistent shipment skills.");
+      throw InputException("Inconsistent shipment skills.");
     }
   }
 
   if (pickup.type != JOB_TYPE::PICKUP) {
-    throw Exception(ERROR::INPUT, "Wrong pickup type.");
+    throw InputException("Wrong pickup type.");
   }
   if (pickup_id_to_rank.find(pickup.id) != pickup_id_to_rank.end()) {
-    throw Exception(ERROR::INPUT,
-                    "Duplicate pickup id: " + std::to_string(pickup.id) + ".");
+    throw InputException("Duplicate pickup id: " + std::to_string(pickup.id) +
+                         ".");
   }
   pickup_id_to_rank[pickup.id] = jobs.size();
   jobs.push_back(pickup);
   check_job(jobs.back());
 
   if (delivery.type != JOB_TYPE::DELIVERY) {
-    throw Exception(ERROR::INPUT, "Wrong delivery type.");
+    throw InputException("Wrong delivery type.");
   }
   if (delivery_id_to_rank.find(delivery.id) != delivery_id_to_rank.end()) {
-    throw Exception(ERROR::INPUT,
-                    "Duplicate delivery id: " + std::to_string(delivery.id) +
-                      ".");
+    throw InputException(
+      "Duplicate delivery id: " + std::to_string(delivery.id) + ".");
   }
   delivery_id_to_rank[delivery.id] = jobs.size();
   jobs.push_back(delivery);
@@ -234,10 +229,9 @@ void Input::add_vehicle(const Vehicle& vehicle) {
   // Ensure amount size consistency.
   const auto& vehicle_amount_size = current_v.capacity.size();
   if (vehicle_amount_size != _amount_size) {
-    throw Exception(ERROR::INPUT,
-                    "Inconsistent capacity length: " +
-                      std::to_string(vehicle_amount_size) + " instead of " +
-                      std::to_string(_amount_size) + '.');
+    throw InputException(
+      "Inconsistent capacity length: " + std::to_string(vehicle_amount_size) +
+      " instead of " + std::to_string(_amount_size) + '.');
   }
 
   // Check for time-windows and skills.
@@ -291,7 +285,7 @@ void Input::add_vehicle(const Vehicle& vehicle) {
         (has_location_index != end_loc.user_index())) {
       // Start and end provided in a non-consistent manner with regard
       // to location index definition.
-      throw Exception(ERROR::INPUT, "Missing start_index or end_index.");
+      throw InputException("Missing start_index or end_index.");
     }
 
     has_location_index = end_loc.user_index();
@@ -336,7 +330,7 @@ void Input::add_vehicle(const Vehicle& vehicle) {
     _has_custom_location_index = has_location_index;
   } else {
     if (_has_custom_location_index != has_location_index) {
-      throw Exception(ERROR::INPUT, "Missing location index.");
+      throw InputException("Missing location index.");
     }
   }
 
@@ -357,16 +351,14 @@ void Input::add_vehicle(const Vehicle& vehicle) {
 void Input::set_durations_matrix(const std::string& profile,
                                  Matrix<Duration>&& m) {
   if (m.size() == 0) {
-    throw Exception(ERROR::INPUT,
-                    "Empty durations matrix for " + profile + " profile.");
+    throw InputException("Empty durations matrix for " + profile + " profile.");
   }
   _durations_matrices.insert_or_assign(profile, m);
 }
 
 void Input::set_costs_matrix(const std::string& profile, Matrix<Cost>&& m) {
   if (m.size() == 0) {
-    throw Exception(ERROR::INPUT,
-                    "Empty costs matrix for " + profile + " profile.");
+    throw InputException("Empty costs matrix for " + profile + " profile.");
   }
   _costs_matrices.insert_or_assign(profile, m);
 }
@@ -559,10 +551,9 @@ void Input::set_vehicle_steps_ranks() {
       if (step.type == STEP_TYPE::BREAK) {
         auto search = current_vehicle.break_id_to_rank.find(step.id);
         if (search == current_vehicle.break_id_to_rank.end()) {
-          throw Exception(ERROR::INPUT,
-                          "Invalid break id " + std::to_string(step.id) +
-                            " for vehicle " +
-                            std::to_string(current_vehicle.id) + ".");
+          throw InputException("Invalid break id " + std::to_string(step.id) +
+                               " for vehicle " +
+                               std::to_string(current_vehicle.id) + ".");
         }
         step.rank = search->second;
       }
@@ -572,19 +563,17 @@ void Input::set_vehicle_steps_ranks() {
         case JOB_TYPE::SINGLE: {
           auto search = job_id_to_rank.find(step.id);
           if (search == job_id_to_rank.end()) {
-            throw Exception(ERROR::INPUT,
-                            "Invalid job id " + std::to_string(step.id) +
-                              " for vehicle " +
-                              std::to_string(current_vehicle.id) + ".");
+            throw InputException("Invalid job id " + std::to_string(step.id) +
+                                 " for vehicle " +
+                                 std::to_string(current_vehicle.id) + ".");
           }
           step.rank = search->second;
 
           auto planned_job = planned_job_ids.find(step.id);
           if (planned_job != planned_job_ids.end()) {
-            throw Exception(ERROR::INPUT,
-                            "Duplicate job id " + std::to_string(step.id) +
-                              " in input steps for vehicle " +
-                              std::to_string(current_vehicle.id) + ".");
+            throw InputException("Duplicate job id " + std::to_string(step.id) +
+                                 " in input steps for vehicle " +
+                                 std::to_string(current_vehicle.id) + ".");
           }
           planned_job_ids.insert(step.id);
           break;
@@ -592,19 +581,18 @@ void Input::set_vehicle_steps_ranks() {
         case JOB_TYPE::PICKUP: {
           auto search = pickup_id_to_rank.find(step.id);
           if (search == pickup_id_to_rank.end()) {
-            throw Exception(ERROR::INPUT,
-                            "Invalid pickup id " + std::to_string(step.id) +
-                              " for vehicle " +
-                              std::to_string(current_vehicle.id) + ".");
+            throw InputException("Invalid pickup id " +
+                                 std::to_string(step.id) + " for vehicle " +
+                                 std::to_string(current_vehicle.id) + ".");
           }
           step.rank = search->second;
 
           auto planned_pickup = planned_pickup_ids.find(step.id);
           if (planned_pickup != planned_pickup_ids.end()) {
-            throw Exception(ERROR::INPUT,
-                            "Duplicate pickup id " + std::to_string(step.id) +
-                              " in input steps for vehicle " +
-                              std::to_string(current_vehicle.id) + ".");
+            throw InputException("Duplicate pickup id " +
+                                 std::to_string(step.id) +
+                                 " in input steps for vehicle " +
+                                 std::to_string(current_vehicle.id) + ".");
           }
           planned_pickup_ids.insert(step.id);
           break;
@@ -612,19 +600,18 @@ void Input::set_vehicle_steps_ranks() {
         case JOB_TYPE::DELIVERY: {
           auto search = delivery_id_to_rank.find(step.id);
           if (search == delivery_id_to_rank.end()) {
-            throw Exception(ERROR::INPUT,
-                            "Invalid delivery id " + std::to_string(step.id) +
-                              " for vehicle " +
-                              std::to_string(current_vehicle.id) + ".");
+            throw InputException("Invalid delivery id " +
+                                 std::to_string(step.id) + " for vehicle " +
+                                 std::to_string(current_vehicle.id) + ".");
           }
           step.rank = search->second;
 
           auto planned_delivery = planned_delivery_ids.find(step.id);
           if (planned_delivery != planned_delivery_ids.end()) {
-            throw Exception(ERROR::INPUT,
-                            "Duplicate delivery id " + std::to_string(step.id) +
-                              " in input steps for vehicle " +
-                              std::to_string(current_vehicle.id) + ".");
+            throw InputException("Duplicate delivery id " +
+                                 std::to_string(step.id) +
+                                 " in input steps for vehicle " +
+                                 std::to_string(current_vehicle.id) + ".");
           }
           planned_delivery_ids.insert(step.id);
           break;
@@ -638,7 +625,7 @@ void Input::set_vehicle_steps_ranks() {
 void Input::set_matrices(unsigned nb_thread) {
   if ((!_durations_matrices.empty() or !_costs_matrices.empty()) and
       !_has_custom_location_index) {
-    throw Exception(ERROR::INPUT, "Missing location index.");
+    throw InputException("Missing location index.");
   }
 
   // Split computing matrices across threads based on number of
@@ -713,18 +700,16 @@ void Input::set_matrices(unsigned nb_thread) {
         }
 
         if (d_m->second.size() <= _max_matrices_used_index) {
-          throw Exception(ERROR::INPUT,
-                          "location_index exceeding matrix size for " +
-                            profile + " profile.");
+          throw InputException("location_index exceeding matrix size for " +
+                               profile + " profile.");
         }
 
         const auto c_m = _costs_matrices.find(profile);
 
         if (c_m != _costs_matrices.end()) {
           if (c_m->second.size() <= _max_matrices_used_index) {
-            throw Exception(ERROR::INPUT,
-                            "location_index exceeding matrix size for " +
-                              profile + " profile.");
+            throw InputException("location_index exceeding matrix size for " +
+                                 profile + " profile.");
           }
 
           // Check for potential overflow in solution cost.
@@ -776,8 +761,7 @@ Solution Input::solve(unsigned exploration_level,
                       const std::vector<HeuristicParameters>& h_param) {
   if (_geometry and !_all_locations_have_coords) {
     // Early abort when info is required with missing coordinates.
-    throw Exception(ERROR::INPUT,
-                    "Route geometry request with missing coordinates.");
+    throw InputException("Route geometry request with missing coordinates.");
   }
 
   if (_has_initial_routes) {
@@ -832,9 +816,8 @@ Solution Input::solve(unsigned exploration_level,
                      _routing_wrappers.end(),
                      [&](const auto& wr) { return wr->profile == profile; });
       if (rw == _routing_wrappers.end()) {
-        throw Exception(ERROR::INPUT,
-                        "Route geometry request with non-routable profile " +
-                          profile + ".");
+        throw InputException(
+          "Route geometry request with non-routable profile " + profile + ".");
       }
       (*rw)->add_route_info(route);
 
@@ -856,8 +839,7 @@ Solution Input::check(unsigned nb_thread) {
 #if USE_LIBGLPK
   if (_geometry and !_all_locations_have_coords) {
     // Early abort when info is required with missing coordinates.
-    throw Exception(ERROR::INPUT,
-                    "Route geometry request with missing coordinates.");
+    throw InputException("Route geometry request with missing coordinates.");
   }
 
   set_vehicle_steps_ranks();
@@ -895,9 +877,8 @@ Solution Input::check(unsigned nb_thread) {
                      _routing_wrappers.end(),
                      [&](const auto& wr) { return wr->profile == profile; });
       if (rw == _routing_wrappers.end()) {
-        throw Exception(ERROR::INPUT,
-                        "Route geometry request with non-routable profile " +
-                          profile + ".");
+        throw InputException(
+          "Route geometry request with non-routable profile " + profile + ".");
       }
       (*rw)->add_route_info(route);
 
@@ -915,7 +896,7 @@ Solution Input::check(unsigned nb_thread) {
   return sol;
 #else
   // Attempt to use libglpk while compiling without it.
-  throw Exception(ERROR::INPUT, "VROOM compiled without libglpk installed.");
+  throw InputException("VROOM compiled without libglpk installed.");
   // Silence -Wunused-parameter warning.
   (void)nb_thread;
 #endif

--- a/src/structures/vroom/time_window.cpp
+++ b/src/structures/vroom/time_window.cpp
@@ -22,9 +22,8 @@ TimeWindow::TimeWindow()
 TimeWindow::TimeWindow(Duration start, Duration end)
   : start(start), end(end), length(end - start) {
   if (start > end) {
-    throw Exception(ERROR::INPUT,
-                    "Invalid time window: [" + std::to_string(start) + ", " +
-                      std::to_string(end) + "]");
+    throw InputException("Invalid time window: [" + std::to_string(start) +
+                         ", " + std::to_string(end) + "]");
   }
 }
 

--- a/src/structures/vroom/tw_route.cpp
+++ b/src/structures/vroom/tw_route.cpp
@@ -37,7 +37,7 @@ TWRoute::TWRoute(const Input& input, Index v)
         return previous_earliest <= tw.end;
       });
     if (b_tw == b.tws.end()) {
-      throw Exception(ERROR::INPUT, break_error);
+      throw InputException(break_error);
     }
 
     break_earliest[i] = std::max(previous_earliest, b_tw->start);
@@ -52,7 +52,7 @@ TWRoute::TWRoute(const Input& input, Index v)
     const auto& b = breaks[i];
 
     if (next_latest < b.service) {
-      throw Exception(ERROR::INPUT, break_error);
+      throw InputException(break_error);
     }
     next_latest -= b.service;
 
@@ -61,7 +61,7 @@ TWRoute::TWRoute(const Input& input, Index v)
         return tw.start <= next_latest;
       });
     if (b_tw == b.tws.rend()) {
-      throw Exception(ERROR::INPUT, break_error);
+      throw InputException(break_error);
     }
 
     break_latest[i] = std::min(next_latest, b_tw->end);
@@ -70,7 +70,7 @@ TWRoute::TWRoute(const Input& input, Index v)
     next_latest = break_latest[i];
 
     if (break_latest[i] < break_earliest[i]) {
-      throw Exception(ERROR::INPUT, break_error);
+      throw InputException(break_error);
     }
   }
 }

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -36,16 +36,14 @@ Vehicle::Vehicle(Id id,
     cost_wrapper(speed_factor),
     max_tasks(max_tasks) {
   if (!static_cast<bool>(start) and !static_cast<bool>(end)) {
-    throw Exception(ERROR::INPUT,
-                    "No start or end specified for vehicle " +
-                      std::to_string(id) + '.');
+    throw InputException("No start or end specified for vehicle " +
+                         std::to_string(id) + '.');
   }
 
   for (unsigned i = 0; i < breaks.size(); ++i) {
     const auto& b = breaks[i];
     if (break_id_to_rank.find(b.id) != break_id_to_rank.end()) {
-      throw Exception(ERROR::INPUT,
-                      "Duplicate break id: " + std::to_string(b.id) + ".");
+      throw InputException("Duplicate break id: " + std::to_string(b.id) + ".");
     }
     break_id_to_rank[b.id] = i;
   }
@@ -63,15 +61,13 @@ Vehicle::Vehicle(Id id,
 
     for (unsigned i = rank_after_start; i < input_steps.size(); ++i) {
       if (input_steps[i].type == STEP_TYPE::START) {
-        throw Exception(ERROR::INPUT,
-                        "Unexpected start in input steps for vehicle " +
-                          std::to_string(id) + ".");
+        throw InputException("Unexpected start in input steps for vehicle " +
+                             std::to_string(id) + ".");
       }
       if (input_steps[i].type == STEP_TYPE::END and
           (i != input_steps.size() - 1)) {
-        throw Exception(ERROR::INPUT,
-                        "Unexpected end in input steps for vehicle " +
-                          std::to_string(id) + ".");
+        throw InputException("Unexpected end in input steps for vehicle " +
+                             std::to_string(id) + ".");
       }
 
       steps.push_back(input_steps[i]);

--- a/src/utils/exception.cpp
+++ b/src/utils/exception.cpp
@@ -11,22 +11,20 @@ All rights reserved (see LICENSE).
 
 namespace vroom {
 
-Exception::Exception(ERROR error,
-                     const std::string& message,
-                     unsigned int error_code)
-  : error(error), message(message), error_code(error_code) {
+Exception::Exception(const std::string& message, unsigned int error_code)
+  : message(message), error_code(error_code) {
 }
 
 InternalException::InternalException(const std::string& message)
-  : Exception(ERROR::INTERNAL, message, 1) {
+  : Exception(message, 1) {
 }
 
 InputException::InputException(const std::string& message)
-  : Exception(ERROR::INPUT, message, 2) {
+  : Exception(message, 2) {
 }
 
 RoutingException::RoutingException(const std::string& message)
-  : Exception(ERROR::ROUTING, message, 3) {
+  : Exception(message, 3) {
 }
 
 } // namespace vroom

--- a/src/utils/exception.cpp
+++ b/src/utils/exception.cpp
@@ -11,8 +11,22 @@ All rights reserved (see LICENSE).
 
 namespace vroom {
 
-Exception::Exception(ERROR error, const std::string& message)
-  : error(error), message(message) {
+Exception::Exception(ERROR error,
+                     const std::string& message,
+                     unsigned int error_code)
+  : error(error), message(message), error_code(error_code) {
+}
+
+InternalException::InternalException(const std::string& message)
+  : Exception(ERROR::INTERNAL, message, 1) {
+}
+
+InputException::InputException(const std::string& message)
+  : Exception(ERROR::INPUT, message, 2) {
+}
+
+RoutingException::RoutingException(const std::string& message)
+  : Exception(ERROR::ROUTING, message, 3) {
 }
 
 } // namespace vroom

--- a/src/utils/exception.h
+++ b/src/utils/exception.h
@@ -18,11 +18,10 @@ namespace vroom {
 
 class Exception : public std::exception {
 public:
-  const ERROR error;
   const std::string message;
   unsigned int error_code;
 
-  Exception(ERROR error, const std::string& message, unsigned int error_code);
+  Exception(const std::string& message, unsigned int error_code);
 
   const char* what() const noexcept override {
     return message.c_str();

--- a/src/utils/exception.h
+++ b/src/utils/exception.h
@@ -20,8 +20,28 @@ class Exception : public std::exception {
 public:
   const ERROR error;
   const std::string message;
+  unsigned int error_code;
 
-  Exception(ERROR error, const std::string& message);
+  Exception(ERROR error, const std::string& message, unsigned int error_code);
+
+  const char* what() const noexcept override {
+    return message.c_str();
+  };
+};
+
+class InternalException : public Exception {
+public:
+  InternalException(const std::string& message);
+};
+
+class InputException : public Exception {
+public:
+  InputException(const std::string& message);
+};
+
+class RoutingException : public Exception {
+public:
+  RoutingException(const std::string& message);
 };
 
 } // namespace vroom

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -870,23 +870,6 @@ inline Solution format_solution(const Input& input,
                   std::move(unassigned_jobs));
 }
 
-inline unsigned get_code(ERROR e) {
-  unsigned code = 0;
-  switch (e) {
-  case ERROR::INTERNAL:
-    code = 1;
-    break;
-  case ERROR::INPUT:
-    code = 2;
-    break;
-  case ERROR::ROUTING:
-    code = 3;
-    break;
-  }
-
-  return code;
-}
-
 } // namespace utils
 } // namespace vroom
 

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -31,8 +31,8 @@ inline TimePoint now() {
 
 inline Cost add_without_overflow(Cost a, Cost b) {
   if (a > std::numeric_limits<Cost>::max() - b) {
-    throw Exception(ERROR::INPUT,
-                    "Too high cost values, stopping to avoid overflowing.");
+    throw InputException(
+      "Too high cost values, stopping to avoid overflowing.");
   }
   return a + b;
 }
@@ -49,8 +49,7 @@ inline INIT get_init(const std::string& s) {
   } else if (s == "EARLIEST_DEADLINE") {
     return INIT::EARLIEST_DEADLINE;
   } else {
-    throw Exception(ERROR::INPUT,
-                    "Invalid heuristic parameter in command-line.");
+    throw InputException("Invalid heuristic parameter in command-line.");
   }
 }
 
@@ -65,8 +64,7 @@ inline HeuristicParameters str_to_heuristic_param(const std::string& s) {
   }
 
   if (tokens.size() != 3 or tokens[0].size() != 1) {
-    throw Exception(ERROR::INPUT,
-                    "Invalid heuristic parameter in command-line.");
+    throw InputException("Invalid heuristic parameter in command-line.");
   }
 
   auto init = get_init(tokens[1]);
@@ -74,20 +72,17 @@ inline HeuristicParameters str_to_heuristic_param(const std::string& s) {
     auto h = std::stoul(tokens[0]);
 
     if (h != 0 and h != 1) {
-      throw Exception(ERROR::INPUT,
-                      "Invalid heuristic parameter in command-line.");
+      throw InputException("Invalid heuristic parameter in command-line.");
     }
 
     auto regret_coeff = std::stof(tokens[2]);
     if (regret_coeff < 0) {
-      throw Exception(ERROR::INPUT,
-                      "Invalid heuristic parameter in command-line.");
+      throw InputException("Invalid heuristic parameter in command-line.");
     }
 
     return HeuristicParameters(static_cast<HEURISTIC>(h), init, regret_coeff);
   } catch (const std::exception& e) {
-    throw Exception(ERROR::INPUT,
-                    "Invalid heuristic parameter in command-line.");
+    throw InputException("Invalid heuristic parameter in command-line.");
   }
 }
 
@@ -293,13 +288,13 @@ inline void check_precedence(const Input& input,
 
 inline void check_tws(const std::vector<TimeWindow>& tws) {
   if (tws.size() == 0) {
-    throw Exception(ERROR::INPUT, "Empty time-windows.");
+    throw InputException("Empty time-windows.");
   }
 
   if (tws.size() > 1) {
     for (std::size_t i = 0; i < tws.size() - 1; ++i) {
       if (tws[i + 1].start <= tws[i].end) {
-        throw Exception(ERROR::INPUT, "Unsorted or overlapping time-windows.");
+        throw InputException("Unsorted or overlapping time-windows.");
       }
     }
   }

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -23,7 +23,7 @@ inline Coordinates parse_coordinates(const rapidjson::Value& object,
                                      const char* key) {
   if (!object[key].IsArray() or (object[key].Size() < 2) or
       !object[key][0].IsNumber() or !object[key][1].IsNumber()) {
-    throw Exception(ERROR::INPUT, "Invalid " + std::string(key) + " array.");
+    throw InputException("Invalid " + std::string(key) + " array.");
   }
   return {{object[key][0].GetDouble(), object[key][1].GetDouble()}};
 }
@@ -32,7 +32,7 @@ inline std::string get_string(const rapidjson::Value& object, const char* key) {
   std::string value;
   if (object.HasMember(key)) {
     if (!object[key].IsString()) {
-      throw Exception(ERROR::INPUT, "Invalid " + std::string(key) + " value.");
+      throw InputException("Invalid " + std::string(key) + " value.");
     }
     value = object[key].GetString();
   }
@@ -43,7 +43,7 @@ inline double get_double(const rapidjson::Value& object, const char* key) {
   double value = 1.;
   if (object.HasMember(key)) {
     if (!object[key].IsNumber()) {
-      throw Exception(ERROR::INPUT, "Invalid " + std::string(key) + " value.");
+      throw InputException("Invalid " + std::string(key) + " value.");
     }
     value = object[key].GetDouble();
   }
@@ -58,20 +58,18 @@ inline Amount get_amount(const rapidjson::Value& object,
 
   if (object.HasMember(key)) {
     if (!object[key].IsArray()) {
-      throw Exception(ERROR::INPUT, "Invalid " + std::string(key) + " array.");
+      throw InputException("Invalid " + std::string(key) + " array.");
     }
 
     if (object[key].Size() != size) {
-      throw Exception(ERROR::INPUT,
-                      "Inconsistent " + std::string(key) +
-                        " length: " + std::to_string(object[key].Size()) +
-                        " and " + std::to_string(size) + '.');
+      throw InputException("Inconsistent " + std::string(key) +
+                           " length: " + std::to_string(object[key].Size()) +
+                           " and " + std::to_string(size) + '.');
     }
 
     for (rapidjson::SizeType i = 0; i < object[key].Size(); ++i) {
       if (!object[key][i].IsUint()) {
-        throw Exception(ERROR::INPUT,
-                        "Invalid " + std::string(key) + " value.");
+        throw InputException("Invalid " + std::string(key) + " value.");
       }
       amount[i] = object[key][i].GetUint();
     }
@@ -84,11 +82,11 @@ inline Skills get_skills(const rapidjson::Value& object) {
   Skills skills;
   if (object.HasMember("skills")) {
     if (!object["skills"].IsArray()) {
-      throw Exception(ERROR::INPUT, "Invalid skills object.");
+      throw InputException("Invalid skills object.");
     }
     for (rapidjson::SizeType i = 0; i < object["skills"].Size(); ++i) {
       if (!object["skills"][i].IsUint()) {
-        throw Exception(ERROR::INPUT, "Invalid skill value.");
+        throw InputException("Invalid skill value.");
       }
       skills.insert(object["skills"][i].GetUint());
     }
@@ -101,8 +99,7 @@ inline Duration get_duration(const rapidjson::Value& object, const char* key) {
   Duration duration = 0;
   if (object.HasMember(key)) {
     if (!object[key].IsUint()) {
-      throw Exception(ERROR::INPUT,
-                      "Invalid " + std::string(key) + " duration.");
+      throw InputException("Invalid " + std::string(key) + " duration.");
     }
     duration = object[key].GetUint();
   }
@@ -113,11 +110,11 @@ inline Duration get_priority(const rapidjson::Value& object) {
   Priority priority = 0;
   if (object.HasMember("priority")) {
     if (!object["priority"].IsUint()) {
-      throw Exception(ERROR::INPUT, "Invalid priority value.");
+      throw InputException("Invalid priority value.");
     }
     priority = object["priority"].GetUint();
     if (priority > MAX_PRIORITY) {
-      throw Exception(ERROR::INPUT, "Invalid priority value.");
+      throw InputException("Invalid priority value.");
     }
   }
   return priority;
@@ -127,7 +124,7 @@ inline size_t get_max_tasks(const rapidjson::Value& object) {
   size_t max_tasks = std::numeric_limits<size_t>::max();
   if (object.HasMember("max_tasks")) {
     if (!object["max_tasks"].IsUint()) {
-      throw Exception(ERROR::INPUT, "Invalid max_tasks value.");
+      throw InputException("Invalid max_tasks value.");
     }
     max_tasks = object["max_tasks"].GetUint();
   }
@@ -136,36 +133,35 @@ inline size_t get_max_tasks(const rapidjson::Value& object) {
 
 inline void check_id(const rapidjson::Value& v, const std::string& type) {
   if (!v.IsObject()) {
-    throw Exception(ERROR::INPUT, "Invalid " + type + ".");
+    throw InputException("Invalid " + type + ".");
   }
   if (!v.HasMember("id") or !v["id"].IsUint64()) {
-    throw Exception(ERROR::INPUT, "Invalid or missing id for " + type + ".");
+    throw InputException("Invalid or missing id for " + type + ".");
   }
 }
 
 inline void check_shipment(const rapidjson::Value& v) {
   if (!v.IsObject()) {
-    throw Exception(ERROR::INPUT, "Invalid shipment.");
+    throw InputException("Invalid shipment.");
   }
   if (!v.HasMember("pickup") or !v["pickup"].IsObject()) {
-    throw Exception(ERROR::INPUT, "Missing pickup for shipment.");
+    throw InputException("Missing pickup for shipment.");
   }
   if (!v.HasMember("delivery") or !v["delivery"].IsObject()) {
-    throw Exception(ERROR::INPUT, "Missing delivery for shipment.");
+    throw InputException("Missing delivery for shipment.");
   }
 }
 
 inline void check_location(const rapidjson::Value& v, const std::string& type) {
   if (!v.HasMember("location") or !v["location"].IsArray()) {
-    throw Exception(ERROR::INPUT,
-                    "Invalid location for " + type + " " +
-                      std::to_string(v["id"].GetUint64()) + ".");
+    throw InputException("Invalid location for " + type + " " +
+                         std::to_string(v["id"].GetUint64()) + ".");
   }
 }
 
 inline TimeWindow get_time_window(const rapidjson::Value& tw) {
   if (!tw.IsArray() or tw.Size() < 2 or !tw[0].IsUint() or !tw[1].IsUint()) {
-    throw Exception(ERROR::INPUT, "Invalid time-window.");
+    throw InputException("Invalid time-window.");
   }
   return TimeWindow(tw[0].GetUint(), tw[1].GetUint());
 }
@@ -182,9 +178,8 @@ inline std::vector<TimeWindow> get_job_time_windows(const rapidjson::Value& j) {
   std::vector<TimeWindow> tws;
   if (j.HasMember("time_windows")) {
     if (!j["time_windows"].IsArray() or j["time_windows"].Empty()) {
-      throw Exception(ERROR::INPUT,
-                      "Invalid time_windows array for job " +
-                        std::to_string(j["id"].GetUint64()) + ".");
+      throw InputException("Invalid time_windows array for job " +
+                           std::to_string(j["id"].GetUint64()) + ".");
     }
 
     std::transform(j["time_windows"].Begin(),
@@ -205,9 +200,8 @@ get_break_time_windows(const rapidjson::Value& b) {
   std::vector<TimeWindow> tws;
   if (!b.HasMember("time_windows") or !b["time_windows"].IsArray() or
       b["time_windows"].Empty()) {
-    throw Exception(ERROR::INPUT,
-                    "Invalid time_windows array for break " +
-                      std::to_string(b["id"].GetUint64()) + ".");
+    throw InputException("Invalid time_windows array for break " +
+                         std::to_string(b["id"].GetUint64()) + ".");
   }
 
   std::transform(b["time_windows"].Begin(),
@@ -232,9 +226,8 @@ inline std::vector<Break> get_vehicle_breaks(const rapidjson::Value& v) {
   std::vector<Break> breaks;
   if (v.HasMember("breaks")) {
     if (!v["breaks"].IsArray()) {
-      throw Exception(ERROR::INPUT,
-                      "Invalid breaks for vehicle " +
-                        std::to_string(v["id"].GetUint64()) + ".");
+      throw InputException("Invalid breaks for vehicle " +
+                           std::to_string(v["id"].GetUint64()) + ".");
     }
 
     std::transform(v["breaks"].Begin(),
@@ -256,9 +249,8 @@ inline std::vector<VehicleStep> get_vehicle_steps(const rapidjson::Value& v) {
 
   if (v.HasMember("steps")) {
     if (!v["steps"].IsArray()) {
-      throw Exception(ERROR::INPUT,
-                      "Invalid steps for vehicle " +
-                        std::to_string(v["id"].GetUint64()) + ".");
+      throw InputException("Invalid steps for vehicle " +
+                           std::to_string(v["id"].GetUint64()) + ".");
     }
 
     for (rapidjson::SizeType i = 0; i < v["steps"].Size(); ++i) {
@@ -267,7 +259,7 @@ inline std::vector<VehicleStep> get_vehicle_steps(const rapidjson::Value& v) {
       std::optional<Duration> at;
       if (json_step.HasMember("service_at")) {
         if (!json_step["service_at"].IsUint()) {
-          throw Exception(ERROR::INPUT, "Invalid service_at value.");
+          throw InputException("Invalid service_at value.");
         }
 
         at = json_step["service_at"].GetUint();
@@ -275,7 +267,7 @@ inline std::vector<VehicleStep> get_vehicle_steps(const rapidjson::Value& v) {
       std::optional<Duration> after;
       if (json_step.HasMember("service_after")) {
         if (!json_step["service_after"].IsUint()) {
-          throw Exception(ERROR::INPUT, "Invalid service_after value.");
+          throw InputException("Invalid service_after value.");
         }
 
         after = json_step["service_after"].GetUint();
@@ -283,7 +275,7 @@ inline std::vector<VehicleStep> get_vehicle_steps(const rapidjson::Value& v) {
       std::optional<Duration> before;
       if (json_step.HasMember("service_before")) {
         if (!json_step["service_before"].IsUint()) {
-          throw Exception(ERROR::INPUT, "Invalid service_before value.");
+          throw InputException("Invalid service_before value.");
         }
 
         before = json_step["service_before"].GetUint();
@@ -304,9 +296,8 @@ inline std::vector<VehicleStep> get_vehicle_steps(const rapidjson::Value& v) {
       }
 
       if (!json_step.HasMember("id") or !json_step["id"].IsUint64()) {
-        throw Exception(ERROR::INPUT,
-                        "Invalid id in steps for vehicle " +
-                          std::to_string(v["id"].GetUint64()) + ".");
+        throw InputException("Invalid id in steps for vehicle " +
+                             std::to_string(v["id"].GetUint64()) + ".");
       }
 
       if (type_str == "job") {
@@ -326,9 +317,8 @@ inline std::vector<VehicleStep> get_vehicle_steps(const rapidjson::Value& v) {
                            json_step["id"].GetUint64(),
                            std::move(forced_service));
       } else {
-        throw Exception(ERROR::INPUT,
-                        "Invalid type in steps for vehicle " +
-                          std::to_string(v["id"].GetUint64()) + ".");
+        throw InputException("Invalid type in steps for vehicle " +
+                             std::to_string(v["id"].GetUint64()) + ".");
       }
     }
   }
@@ -346,9 +336,8 @@ inline Vehicle get_vehicle(const rapidjson::Value& json_vehicle,
   bool has_start_coords = json_vehicle.HasMember("start");
   bool has_start_index = json_vehicle.HasMember("start_index");
   if (has_start_index and !json_vehicle["start_index"].IsUint()) {
-    throw Exception(ERROR::INPUT,
-                    "Invalid start_index for vehicle " + std::to_string(v_id) +
-                      ".");
+    throw InputException("Invalid start_index for vehicle " +
+                         std::to_string(v_id) + ".");
   }
 
   std::optional<Location> start;
@@ -371,9 +360,8 @@ inline Vehicle get_vehicle(const rapidjson::Value& json_vehicle,
   bool has_end_coords = json_vehicle.HasMember("end");
   bool has_end_index = json_vehicle.HasMember("end_index");
   if (has_end_index and !json_vehicle["end_index"].IsUint()) {
-    throw Exception(ERROR::INPUT,
-                    "Invalid end_index for vehicle" + std::to_string(v_id) +
-                      ".");
+    throw InputException("Invalid end_index for vehicle" +
+                         std::to_string(v_id) + ".");
   }
 
   std::optional<Location> end;
@@ -416,9 +404,8 @@ inline Location get_task_location(const rapidjson::Value& v,
   bool has_location_coords = v.HasMember("location");
   bool has_location_index = v.HasMember("location_index");
   if (has_location_index and !v["location_index"].IsUint()) {
-    throw Exception(ERROR::INPUT,
-                    "Invalid location_index for " + type + " " +
-                      std::to_string(v["id"].GetUint64()) + ".");
+    throw InputException("Invalid location_index for " + type + " " +
+                         std::to_string(v["id"].GetUint64()) + ".");
   }
 
   if (has_location_index) {
@@ -460,7 +447,7 @@ inline Job get_job(const rapidjson::Value& json_job, unsigned amount_size) {
 
 template <class T> inline Matrix<T> get_matrix(rapidjson::Value& m) {
   if (!m.IsArray()) {
-    throw Exception(ERROR::INPUT, "Invalid matrix.");
+    throw InputException("Invalid matrix.");
   }
   // Load custom matrix while checking if it is square.
   rapidjson::SizeType matrix_size = m.Size();
@@ -468,12 +455,12 @@ template <class T> inline Matrix<T> get_matrix(rapidjson::Value& m) {
   Matrix<T> matrix(matrix_size);
   for (rapidjson::SizeType i = 0; i < matrix_size; ++i) {
     if (!m[i].IsArray() or m[i].Size() != matrix_size) {
-      throw Exception(ERROR::INPUT, "Unexpected matrix line length.");
+      throw InputException("Unexpected matrix line length.");
     }
     rapidjson::Document::Array mi = m[i].GetArray();
     for (rapidjson::SizeType j = 0; j < matrix_size; ++j) {
       if (!mi[j].IsUint()) {
-        throw Exception(ERROR::INPUT, "Invalid matrix entry.");
+        throw InputException("Invalid matrix entry.");
       }
       matrix[i][j] = mi[j].GetUint();
     }
@@ -491,7 +478,7 @@ Input parse(const CLArgs& cl_args) {
     std::string error_msg =
       std::string(rapidjson::GetParseError_En(json_input.GetParseError())) +
       " (offset: " + std::to_string(json_input.GetErrorOffset()) + ")";
-    throw Exception(ERROR::INPUT, error_msg);
+    throw InputException(error_msg);
   }
 
   // Main checks for valid json input.
@@ -501,12 +488,12 @@ Input parse(const CLArgs& cl_args) {
                        json_input["shipments"].IsArray() and
                        !json_input["shipments"].Empty();
   if (!has_jobs and !has_shipments) {
-    throw Exception(ERROR::INPUT, "Invalid jobs or shipments.");
+    throw InputException("Invalid jobs or shipments.");
   }
 
   if (!json_input.HasMember("vehicles") or !json_input["vehicles"].IsArray() or
       json_input["vehicles"].Empty()) {
-    throw Exception(ERROR::INPUT, "Invalid vehicles.");
+    throw InputException("Invalid vehicles.");
   }
   const auto& first_vehicle = json_input["vehicles"][0];
   check_id(first_vehicle, "vehicle");
@@ -582,7 +569,7 @@ Input parse(const CLArgs& cl_args) {
 
   if (json_input.HasMember("matrices")) {
     if (!json_input["matrices"].IsObject()) {
-      throw Exception(ERROR::INPUT, "Unexpected matrices value.");
+      throw InputException("Unexpected matrices value.");
     }
     for (auto& profile_entry : json_input["matrices"].GetObject()) {
       if (profile_entry.value.IsObject()) {


### PR DESCRIPTION
## Issue

Issue #639 

Solution deprecates both `ERROR` and `get_code`. the solution for getting the error code is not super elegant, but it is simple and it does have the advatage of keeping the error codes close to their associated Exception class and being the single point of truth.

I've isolated this part of the PR in a single commit, so it is super easy to revert if you rather we use enums and `get_code`.

## Tasks

 - [X] Update `docs/API.md`
 - [X] Update `CHANGELOG.md`
 - [x] review