### PR TITLE
Python binding access to Amount and Matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Exposing some internals for Python through compile flags (#640)
+
 ### Fixed
 
 - Remove duplicate definition of LocalSearch (#638)

--- a/src/structures/generic/matrix.h
+++ b/src/structures/generic/matrix.h
@@ -38,6 +38,12 @@ public:
   std::size_t size() const {
     return n;
   }
+
+#if USE_PYTHON_BINDINGS
+  T* get_data() {
+    return data.data();
+  };
+#endif
 };
 
 } // namespace vroom

--- a/src/structures/vroom/amount.h
+++ b/src/structures/vroom/amount.h
@@ -128,6 +128,12 @@ public:
     }
     return *this;
   }
+
+#if USE_PYTHON_BINDINGS
+  Capacity* get_data() {
+    return elems.data();
+  };
+#endif
 };
 
 template <typename E1, typename E2>


### PR DESCRIPTION
## Issue

Issue #640.

Access to Matrix and Amount class.

I feel it does not make sense at this time to do anyting with the makefile, as the python installer can not use it.

## Tasks

 - [X] Update `docs/API.md` (remove if irrelevant)
 - [X] Update `CHANGELOG.md` (remove if irrelevant)
 - [ ] review
