### PR TITLE
Move priority check to Job constructor instead of input parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Remove duplicate definition of LocalSearch (#638)
+- Move priority check to Job constructor instead of input parser (#628)
 
 ## [v1.11.0] - 2021-11-19
 

--- a/src/structures/vroom/job.cpp
+++ b/src/structures/vroom/job.cpp
@@ -44,6 +44,7 @@ Job::Job(Id id,
     description(description),
     tw_length(get_tw_length(tws)) {
   utils::check_tws(tws);
+  utils::check_priority(priority);
 }
 
 Job::Job(Id id,
@@ -70,6 +71,7 @@ Job::Job(Id id,
     tw_length(get_tw_length(tws)) {
   assert(type == JOB_TYPE::PICKUP or type == JOB_TYPE::DELIVERY);
   utils::check_tws(tws);
+  utils::check_priority(priority);
 }
 
 bool Job::is_valid_start(Duration time) const {

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -305,6 +305,12 @@ inline void check_tws(const std::vector<TimeWindow>& tws) {
   }
 }
 
+inline void check_priority(const Priority priority) {
+  if (priority > MAX_PRIORITY) {
+    throw Exception(ERROR::INPUT, "Invalid priority value.");
+  }
+}
+
 inline Solution format_solution(const Input& input,
                                 const RawSolution& raw_routes) {
   std::vector<Route> routes;

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -116,9 +116,6 @@ inline Duration get_priority(const rapidjson::Value& object) {
       throw Exception(ERROR::INPUT, "Invalid priority value.");
     }
     priority = object["priority"].GetUint();
-    if (priority > MAX_PRIORITY) {
-      throw Exception(ERROR::INPUT, "Invalid priority value.");
-    }
   }
   return priority;
 }


### PR DESCRIPTION
## Issue

Fixes #628 

## Tasks

 - [x] Move priority check to Job constructor instead of input parser
 - [x] Update `CHANGELOG.md`
 - [x] review
