### PR TITLE
Add support for disabling use of routing entirely at the compiler level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Shared target to makefile, for creating Position Independent Code (#617)
 - Exposing some internals for Python through compile flags (#640)
 - Stats on local search operators use for dev/debug purposes (#658)
+- Project can be compiled without routing support to limit dependencies (#676)
 
 ### Changed
 
@@ -272,11 +273,11 @@
 - Support for user-defined matrices (#47)
 - New flag `-x` to set the trade-off between computing time and exploration depth (#131)
 - Provide ETA at step level in the routes, using optional service time for each job (#101, #103)
-- Experimental* support to use `vroom` directly from C++ as a library (#42)
+- Experimental\* support to use `vroom` directly from C++ as a library (#42)
 - Automatic code formatting script based on `clang-format` (#66)
 - PR template
 
-*: read "functional with no C++ API stability guarantee"
+\*: read "functional with no C++ API stability guarantee"
 
 ### Changed
 
@@ -321,7 +322,7 @@
 
 ### Added
 
-- Support for OSRM v5.*
+- Support for OSRM v5.\*
 - Dedicated folder for API documentation
 
 ### Changed
@@ -331,7 +332,7 @@
 
 ### Removed
 
-- Drop support for OSRM v4.*
+- Drop support for OSRM v4.\*
 - Flags `-s` and `-e` (see new API)
 
 ### Fixed
@@ -362,7 +363,7 @@
 - New local search operator to improve results in specific asymmetric
   context (e.g. many locations in a dense urban area with lots of
   one-way streets).
-- OSRM v4.9.* compatibility.
+- OSRM v4.9.\* compatibility.
 - Use rapidjson for json i/o (#19)
 - Append the `tour` key to the solution in any case.
 
@@ -421,4 +422,3 @@
   solution and execution details.
 - Optional ready-to-use detailed route.
 - Optional use of euclidean distance for matrix computation.
-

--- a/src/makefile
+++ b/src/makefile
@@ -31,15 +31,15 @@ ifeq ($(USE_ROUTING),false)
 	SRC := $(filter-out $(wildcard ./routing/*.cpp), $(SRC))
 else
 	LDLIBS += -lssl -lcrypto
-endif
 
-# Checking for libosrm
-ifeq ($(shell pkg-config --exists libosrm && echo 1),1)
-	LDLIBS += $(shell pkg-config --libs libosrm) -lboost_system -lboost_filesystem -lboost_iostreams -lboost_thread -lrt -ltbb
-	LIBOSRMFLAGS = $(shell pkg-config --cflags libosrm)
-	CXXFLAGS += $(filter-out -std=c++14, $(LIBOSRMFLAGS)) -D USE_LIBOSRM=true
-else
-	SRC := $(filter-out ./routing/libosrm_wrapper.cpp, $(SRC))
+	# Checking for libosrm
+	ifeq ($(shell pkg-config --exists libosrm && echo 1),1)
+		LDLIBS += $(shell pkg-config --libs libosrm) -lboost_system -lboost_filesystem -lboost_iostreams -lboost_thread -lrt -ltbb
+		LIBOSRMFLAGS = $(shell pkg-config --cflags libosrm)
+		CXXFLAGS += $(filter-out -std=c++14, $(LIBOSRMFLAGS)) -D USE_LIBOSRM=true
+	else
+		SRC := $(filter-out ./routing/libosrm_wrapper.cpp, $(SRC))
+	endif
 endif
 
 # Checking for libglpk based on whether the header file is found as

--- a/src/makefile
+++ b/src/makefile
@@ -5,7 +5,8 @@
 
 # Variables.
 CXX ?= g++
-CXXFLAGS = -MMD -MP -I. -std=c++17 -Wextra -Wpedantic -Wall -O3 -DASIO_STANDALONE
+USE_ROUTING ?= true
+CXXFLAGS = -MMD -MP -I. -std=c++17 -Wextra -Wpedantic -Wall -O3 -DASIO_STANDALONE -DUSE_ROUTING=$(USE_ROUTING)
 LDLIBS = -lpthread -lssl -lcrypto
 
 # Using all cpp files in current directory.
@@ -24,6 +25,11 @@ SRC = $(wildcard *.cpp)\
 			$(wildcard ./structures/vroom/solution/*.cpp)\
 			$(wildcard ./structures/*.cpp)\
 			$(wildcard ./utils/*.cpp)
+
+# Remove routing if we don't require it
+ifeq ($(USE_ROUTING),false)
+	SRC := $(filter-out $(wildcard ./routing/*.cpp), $(SRC))
+endif
 
 # Checking for libosrm
 ifeq ($(shell pkg-config --exists libosrm && echo 1),1)

--- a/src/makefile
+++ b/src/makefile
@@ -7,7 +7,7 @@
 CXX ?= g++
 USE_ROUTING ?= true
 CXXFLAGS = -MMD -MP -I. -std=c++17 -Wextra -Wpedantic -Wall -O3 -DASIO_STANDALONE -DUSE_ROUTING=$(USE_ROUTING)
-LDLIBS = -lpthread -lssl -lcrypto
+LDLIBS = -lpthread
 
 # Using all cpp files in current directory.
 MAIN = ../bin/vroom
@@ -29,6 +29,8 @@ SRC = $(wildcard *.cpp)\
 # Remove routing if we don't require it
 ifeq ($(USE_ROUTING),false)
 	SRC := $(filter-out $(wildcard ./routing/*.cpp), $(SRC))
+else
+	LDLIBS += -lssl -lcrypto
 endif
 
 # Checking for libosrm

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -58,9 +58,9 @@ void Input::set_geometry(bool geometry) {
 }
 
 void Input::add_routing_wrapper(const std::string& profile) {
-  #if !USE_ROUTING
-    throw RoutingException("VROOM compiled without routing support.");
-  #endif
+#if !USE_ROUTING
+  throw RoutingException("VROOM compiled without routing support.");
+#endif
 
   assert(std::find_if(_routing_wrappers.begin(),
                       _routing_wrappers.end(),

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -649,21 +649,27 @@ void Input::set_matrices(unsigned nb_thread) {
   for (const auto& profile : _profiles) {
     thread_profiles[t_rank % nb_buckets].push_back(profile);
     ++t_rank;
-    #if USE_ROUTING
     if (_durations_matrices.find(profile) == _durations_matrices.end()) {
       // Durations matrix has not been manually set, create routing
       // wrapper and empty matrix to allow for concurrent modification
       // later on.
+      #if USE_ROUTING
       add_routing_wrapper(profile);
       _durations_matrices.emplace(profile, Matrix<Duration>());
+      #else
+        throw RoutingException("VROOM compiled without routing support."); 
+      #endif
     } else {
       if (_geometry) {
         // Even with a custom matrix, we still want routing after
         // optimization.
+        #if USE_ROUTING
         add_routing_wrapper(profile);
+        #else
+          throw RoutingException("VROOM compiled without routing support."); 
+        #endif
       }
     }
-    #endif
   }
 
   std::exception_ptr ep = nullptr;

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -17,12 +17,14 @@ All rights reserved (see LICENSE).
 #include "algorithms/validation/check.h"
 #include "problems/cvrp/cvrp.h"
 #include "problems/vrptw/vrptw.h"
+#if USE_ROUTING
 #if USE_LIBOSRM
 #include "routing/libosrm_wrapper.h"
 #endif
 #include "routing/ors_wrapper.h"
 #include "routing/osrm_routed_wrapper.h"
 #include "routing/valhalla_wrapper.h"
+#endif
 #include "structures/vroom/input/input.h"
 #include "utils/helpers.h"
 
@@ -57,6 +59,7 @@ void Input::set_geometry(bool geometry) {
   _geometry = geometry;
 }
 
+#if USE_ROUTING
 void Input::add_routing_wrapper(const std::string& profile) {
   assert(std::find_if(_routing_wrappers.begin(),
                       _routing_wrappers.end(),
@@ -108,6 +111,7 @@ void Input::add_routing_wrapper(const std::string& profile) {
   } break;
   }
 }
+#endif
 
 void Input::check_job(Job& job) {
   // Ensure delivery size consistency.
@@ -645,6 +649,7 @@ void Input::set_matrices(unsigned nb_thread) {
   for (const auto& profile : _profiles) {
     thread_profiles[t_rank % nb_buckets].push_back(profile);
     ++t_rank;
+    #if USE_ROUTING
     if (_durations_matrices.find(profile) == _durations_matrices.end()) {
       // Durations matrix has not been manually set, create routing
       // wrapper and empty matrix to allow for concurrent modification
@@ -658,6 +663,7 @@ void Input::set_matrices(unsigned nb_thread) {
         add_routing_wrapper(profile);
       }
     }
+    #endif
   }
 
   std::exception_ptr ep = nullptr;

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -77,9 +77,7 @@ private:
   void set_vehicle_steps_ranks();
   void set_matrices(unsigned nb_thread);
 
-  #if USE_ROUTING
   void add_routing_wrapper(const std::string& profile);
-  #endif
 
 public:
   std::vector<Job> jobs;

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -77,7 +77,9 @@ private:
   void set_vehicle_steps_ranks();
   void set_matrices(unsigned nb_thread);
 
+  #if USE_ROUTING
   void add_routing_wrapper(const std::string& profile);
+  #endif
 
 public:
   std::vector<Job> jobs;


### PR DESCRIPTION
- Allows the compile to take place without ASIO
- Optimization still works if using a custom cost matrix
- Default compilation behaviour should be identical to previous
- To compile, just run `USE_ROUTING=false make`

## Issue

Fixes https://github.com/VROOM-Project/vroom/issues/675
