### PR TITLE
Add internal 2 opt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `IntraTwoOpt` local search operator (#706)
 - `description` key for unassigned tasks in output, if provided (#403)
 - `location_index` key for unassigned tasks and each step, if provided (#625)
 - Shared target to makefile, for creating Position Independent Code (#617)

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -15,6 +15,7 @@ All rights reserved (see LICENSE).
 #include "problems/vrptw/operators/intra_mixed_exchange.h"
 #include "problems/vrptw/operators/intra_or_opt.h"
 #include "problems/vrptw/operators/intra_relocate.h"
+#include "problems/vrptw/operators/intra_two_opt.h"
 #include "problems/vrptw/operators/mixed_exchange.h"
 #include "problems/vrptw/operators/or_opt.h"
 #include "problems/vrptw/operators/pd_shift.h"
@@ -43,6 +44,7 @@ template <class Route,
           class IntraMixedExchange,
           class IntraRelocate,
           class IntraOrOpt,
+          class IntraTwoOpt,
           class PDShift,
           class RouteExchange>
 LocalSearch<Route,
@@ -59,6 +61,7 @@ LocalSearch<Route,
             IntraMixedExchange,
             IntraRelocate,
             IntraOrOpt,
+            IntraTwoOpt,
             PDShift,
             RouteExchange>::LocalSearch(const Input& input,
                                         std::vector<Route>& sol,
@@ -143,6 +146,7 @@ template <class Route,
           class IntraMixedExchange,
           class IntraRelocate,
           class IntraOrOpt,
+          class IntraTwoOpt,
           class PDShift,
           class RouteExchange>
 void LocalSearch<Route,
@@ -159,6 +163,7 @@ void LocalSearch<Route,
                  IntraMixedExchange,
                  IntraRelocate,
                  IntraOrOpt,
+                 IntraTwoOpt,
                  PDShift,
                  RouteExchange>::try_job_additions(const std::vector<Index>&
                                                      routes,
@@ -311,6 +316,7 @@ template <class Route,
           class IntraMixedExchange,
           class IntraRelocate,
           class IntraOrOpt,
+          class IntraTwoOpt,
           class PDShift,
           class RouteExchange>
 void LocalSearch<Route,
@@ -327,6 +333,7 @@ void LocalSearch<Route,
                  IntraMixedExchange,
                  IntraRelocate,
                  IntraOrOpt,
+                 IntraTwoOpt,
                  PDShift,
                  RouteExchange>::run_ls_step() {
   // Store best move involving a pair of routes.
@@ -1383,6 +1390,7 @@ template <class Route,
           class IntraMixedExchange,
           class IntraRelocate,
           class IntraOrOpt,
+          class IntraTwoOpt,
           class PDShift,
           class RouteExchange>
 void LocalSearch<Route,
@@ -1399,6 +1407,7 @@ void LocalSearch<Route,
                  IntraMixedExchange,
                  IntraRelocate,
                  IntraOrOpt,
+                 IntraTwoOpt,
                  PDShift,
                  RouteExchange>::run() {
   bool try_ls_step = true;
@@ -1495,6 +1504,7 @@ template <class Route,
           class IntraMixedExchange,
           class IntraRelocate,
           class IntraOrOpt,
+          class IntraTwoOpt,
           class PDShift,
           class RouteExchange>
 std::array<OperatorStats, OperatorName::MAX>
@@ -1512,6 +1522,7 @@ LocalSearch<Route,
             IntraMixedExchange,
             IntraRelocate,
             IntraOrOpt,
+            IntraTwoOpt,
             PDShift,
             RouteExchange>::get_stats() const {
   std::array<OperatorStats, OperatorName::MAX> stats;
@@ -1537,6 +1548,7 @@ template <class Route,
           class IntraMixedExchange,
           class IntraRelocate,
           class IntraOrOpt,
+          class IntraTwoOpt,
           class PDShift,
           class RouteExchange>
 Gain LocalSearch<Route,
@@ -1553,6 +1565,7 @@ Gain LocalSearch<Route,
                  IntraMixedExchange,
                  IntraRelocate,
                  IntraOrOpt,
+                 IntraTwoOpt,
                  PDShift,
                  RouteExchange>::job_route_cost(Index v_target,
                                                 Index v,
@@ -1606,6 +1619,7 @@ template <class Route,
           class IntraMixedExchange,
           class IntraRelocate,
           class IntraOrOpt,
+          class IntraTwoOpt,
           class PDShift,
           class RouteExchange>
 Gain LocalSearch<Route,
@@ -1622,6 +1636,7 @@ Gain LocalSearch<Route,
                  IntraMixedExchange,
                  IntraRelocate,
                  IntraOrOpt,
+                 IntraTwoOpt,
                  PDShift,
                  RouteExchange>::relocate_cost_lower_bound(Index v, Index r) {
   Gain best_bound = static_cast<Gain>(INFINITE_COST);
@@ -1652,6 +1667,7 @@ template <class Route,
           class IntraMixedExchange,
           class IntraRelocate,
           class IntraOrOpt,
+          class IntraTwoOpt,
           class PDShift,
           class RouteExchange>
 Gain LocalSearch<Route,
@@ -1668,6 +1684,7 @@ Gain LocalSearch<Route,
                  IntraMixedExchange,
                  IntraRelocate,
                  IntraOrOpt,
+                 IntraTwoOpt,
                  PDShift,
                  RouteExchange>::relocate_cost_lower_bound(Index v,
                                                            Index r1,
@@ -1702,6 +1719,7 @@ template <class Route,
           class IntraMixedExchange,
           class IntraRelocate,
           class IntraOrOpt,
+          class IntraTwoOpt,
           class PDShift,
           class RouteExchange>
 void LocalSearch<Route,
@@ -1718,6 +1736,7 @@ void LocalSearch<Route,
                  IntraMixedExchange,
                  IntraRelocate,
                  IntraOrOpt,
+                 IntraTwoOpt,
                  PDShift,
                  RouteExchange>::remove_from_routes() {
   // Store nearest job from and to any job in any route for constant
@@ -1841,6 +1860,7 @@ template <class Route,
           class IntraMixedExchange,
           class IntraRelocate,
           class IntraOrOpt,
+          class IntraTwoOpt,
           class PDShift,
           class RouteExchange>
 utils::SolutionIndicators LocalSearch<Route,
@@ -1857,6 +1877,7 @@ utils::SolutionIndicators LocalSearch<Route,
                                       IntraMixedExchange,
                                       IntraRelocate,
                                       IntraOrOpt,
+                                      IntraTwoOpt,
                                       PDShift,
                                       RouteExchange>::indicators() const {
   return _best_sol_indicators;
@@ -1876,6 +1897,7 @@ template class LocalSearch<TWRoute,
                            vrptw::IntraMixedExchange,
                            vrptw::IntraRelocate,
                            vrptw::IntraOrOpt,
+                           vrptw::IntraTwoOpt,
                            vrptw::PDShift,
                            vrptw::RouteExchange>;
 
@@ -1893,6 +1915,7 @@ template class LocalSearch<RawRoute,
                            cvrp::IntraMixedExchange,
                            cvrp::IntraRelocate,
                            cvrp::IntraOrOpt,
+                           cvrp::IntraTwoOpt,
                            cvrp::PDShift,
                            cvrp::RouteExchange>;
 

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -1117,6 +1117,34 @@ void LocalSearch<Route,
       }
     }
 
+    // IntraTwoOpt stuff
+    for (const auto& s_t : s_t_pairs) {
+      if (s_t.first != s_t.second or best_priorities[s_t.first] > 0 or
+          _sol[s_t.first].size() < 4) {
+        continue;
+      }
+      for (unsigned s_rank = 0; s_rank < _sol[s_t.first].size() - 2; ++s_rank) {
+        // TODO make sure we don't reverse a full shipment.
+        for (unsigned t_rank = s_rank + 2; t_rank < _sol[s_t.first].size();
+             ++t_rank) {
+#ifdef LOG_LS_OPERATORS
+          ++tried_moves[OperatorName::IntraTwoOpt];
+#endif
+          IntraTwoOpt r(_input,
+                        _sol_state,
+                        _sol[s_t.first],
+                        s_t.first,
+                        s_rank,
+                        t_rank);
+          auto& current_best = best_gains[s_t.first][s_t.second];
+          if (r.gain() > current_best and r.is_valid()) {
+            current_best = r.gain();
+            best_ops[s_t.first][s_t.first] = std::make_unique<IntraTwoOpt>(r);
+          }
+        }
+      }
+    }
+
     if (_input.has_shipments()) {
       // Move(s) that don't make sense for job-only instances.
 

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -1332,9 +1332,14 @@ void LocalSearch<Route,
         continue;
       }
       for (unsigned s_rank = 0; s_rank < _sol[s_t.first].size() - 2; ++s_rank) {
-        // TODO make sure we don't reverse a full shipment.
-        for (unsigned t_rank = s_rank + 2; t_rank < _sol[s_t.first].size();
-             ++t_rank) {
+        const auto s_job_rank = _sol[s_t.first].route[s_rank];
+        const auto end_s =
+          _sol_state.weak_insertion_ranks_end[s_t.first][s_job_rank];
+        assert(end_s != 0);
+        auto end_t_rank = std::min(static_cast<Index>(_sol[s_t.first].size()),
+                                   static_cast<Index>(end_s - 1));
+
+        for (unsigned t_rank = s_rank + 2; t_rank < end_t_rank; ++t_rank) {
 #ifdef LOG_LS_OPERATORS
           ++tried_moves[OperatorName::IntraTwoOpt];
 #endif

--- a/src/algorithms/local_search/local_search.h
+++ b/src/algorithms/local_search/local_search.h
@@ -29,6 +29,7 @@ template <class Route,
           class IntraMixedExchange,
           class IntraRelocate,
           class IntraOrOpt,
+          class IntraTwoOpt,
           class PDShift,
           class RouteExchange>
 class LocalSearch {

--- a/src/problems/cvrp/cvrp.cpp
+++ b/src/problems/cvrp/cvrp.cpp
@@ -19,6 +19,7 @@ All rights reserved (see LICENSE).
 #include "problems/cvrp/operators/intra_mixed_exchange.h"
 #include "problems/cvrp/operators/intra_or_opt.h"
 #include "problems/cvrp/operators/intra_relocate.h"
+#include "problems/cvrp/operators/intra_two_opt.h"
 #include "problems/cvrp/operators/mixed_exchange.h"
 #include "problems/cvrp/operators/or_opt.h"
 #include "problems/cvrp/operators/pd_shift.h"
@@ -51,6 +52,7 @@ using LocalSearch = ls::LocalSearch<RawRoute,
                                     cvrp::IntraMixedExchange,
                                     cvrp::IntraRelocate,
                                     cvrp::IntraOrOpt,
+                                    cvrp::IntraTwoOpt,
                                     cvrp::PDShift,
                                     cvrp::RouteExchange>;
 } // namespace cvrp

--- a/src/problems/cvrp/operators/intra_two_opt.cpp
+++ b/src/problems/cvrp/operators/intra_two_opt.cpp
@@ -7,6 +7,8 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <algorithm>
+
 #include "problems/cvrp/operators/intra_two_opt.h"
 
 namespace vroom {
@@ -93,7 +95,9 @@ bool IntraTwoOpt::is_valid() {
 }
 
 void IntraTwoOpt::apply() {
-  // TODO
+  std::reverse(s_route.begin() + s_rank, s_route.begin() + t_rank + 1);
+
+  source.update_amounts(_input);
 }
 
 std::vector<Index> IntraTwoOpt::addition_candidates() const {

--- a/src/problems/cvrp/operators/intra_two_opt.cpp
+++ b/src/problems/cvrp/operators/intra_two_opt.cpp
@@ -102,7 +102,6 @@ bool IntraTwoOpt::is_valid() {
     auto rev_s_next = s_route.rbegin() + (s_route.size() - s_rank);
 
     valid =
-      valid &&
       source
         .is_valid_addition_for_capacity_inclusion(_input,
                                                   source

--- a/src/problems/cvrp/operators/intra_two_opt.cpp
+++ b/src/problems/cvrp/operators/intra_two_opt.cpp
@@ -1,0 +1,97 @@
+/*
+
+This file is part of VROOM.
+
+Copyright (c) 2015-2022, Julien Coupey.
+All rights reserved (see LICENSE).
+
+*/
+
+#include "problems/cvrp/operators/intra_two_opt.h"
+
+namespace vroom {
+namespace cvrp {
+
+IntraTwoOpt::IntraTwoOpt(const Input& input,
+                         const utils::SolutionState& sol_state,
+                         RawRoute& s_route,
+                         Index s_vehicle,
+                         Index s_rank,
+                         Index t_rank)
+  : Operator(OperatorName::IntraTwoOpt,
+             input,
+             sol_state,
+             s_route,
+             s_vehicle,
+             s_rank,
+             s_route,
+             s_vehicle,
+             t_rank) {
+  // Assume s_rank < t_rank for symmetry reasons. Set aside cases
+  // where t_rank = s_rank + 1, as the move is also an intra_relocate.
+  assert(s_route.size() >= 3);
+  assert(s_rank < t_rank - 1);
+}
+
+void IntraTwoOpt::compute_gain() {
+  const auto& s_v = _input.vehicles[s_vehicle];
+
+  Index s_index = _input.jobs[s_route[s_rank]].index();
+  Index t_index = _input.jobs[t_route[t_rank]].index();
+  stored_gain = 0;
+
+  // Cost of reversing vehicle route between s_rank and t_rank
+  // included.
+  stored_gain += _sol_state.fwd_costs[s_vehicle][s_vehicle][t_rank];
+  stored_gain -= _sol_state.fwd_costs[s_vehicle][s_vehicle][s_rank];
+  stored_gain += _sol_state.bwd_costs[s_vehicle][s_vehicle][s_rank];
+  stored_gain -= _sol_state.bwd_costs[s_vehicle][s_vehicle][t_rank];
+
+  // Cost of going to t_rank first instead of s_rank.
+  if (s_rank > 0) {
+    Index previous_index = _input.jobs[s_route[s_rank - 1]].index();
+    stored_gain += s_v.cost(previous_index, s_index);
+    stored_gain -= s_v.cost(previous_index, t_index);
+  } else {
+    if (s_v.has_start()) {
+      Index start_index = s_v.start.value().index();
+      stored_gain += s_v.cost(start_index, s_index);
+      stored_gain -= s_v.cost(start_index, t_index);
+    }
+  }
+
+  // Cost of going from s_rank after instead of t_rank.
+  if (t_rank < s_route.size() - 1) {
+    Index next_index = _input.jobs[s_route[t_rank + 1]].index();
+    stored_gain += s_v.cost(t_index, next_index);
+    stored_gain -= s_v.cost(s_index, next_index);
+  } else {
+    if (s_v.has_end()) {
+      Index end_index = s_v.end.value().index();
+      stored_gain += s_v.cost(t_index, end_index);
+      stored_gain -= s_v.cost(s_index, end_index);
+    }
+  }
+
+  gain_computed = true;
+}
+
+bool IntraTwoOpt::is_valid() {
+  // TODO
+  return true;
+}
+
+void IntraTwoOpt::apply() {
+  // TODO
+}
+
+std::vector<Index> IntraTwoOpt::addition_candidates() const {
+  return {};
+}
+
+std::vector<Index> IntraTwoOpt::update_candidates() const {
+  return {s_vehicle};
+}
+
+} // namespace cvrp
+} // namespace vroom

--- a/src/problems/cvrp/operators/intra_two_opt.cpp
+++ b/src/problems/cvrp/operators/intra_two_opt.cpp
@@ -31,6 +31,7 @@ IntraTwoOpt::IntraTwoOpt(const Input& input,
   // where t_rank = s_rank + 1, as the move is also an intra_relocate.
   assert(s_route.size() >= 3);
   assert(s_rank < t_rank - 1);
+  assert(t_rank < s_route.size());
 }
 
 void IntraTwoOpt::compute_gain() {
@@ -77,8 +78,18 @@ void IntraTwoOpt::compute_gain() {
 }
 
 bool IntraTwoOpt::is_valid() {
-  // TODO
-  return true;
+  auto rev_t = s_route.rbegin() + (s_route.size() - t_rank - 1);
+  auto rev_s_next = s_route.rbegin() + (s_route.size() - s_rank);
+
+  return source
+    .is_valid_addition_for_capacity_inclusion(_input,
+                                              source.delivery_in_range(s_rank,
+                                                                       t_rank +
+                                                                         1),
+                                              rev_t,
+                                              rev_s_next,
+                                              s_rank,
+                                              t_rank + 1);
 }
 
 void IntraTwoOpt::apply() {

--- a/src/problems/cvrp/operators/intra_two_opt.h
+++ b/src/problems/cvrp/operators/intra_two_opt.h
@@ -27,6 +27,8 @@ public:
               Index s_rank,
               Index t_rank);
 
+  bool reversal_ok_for_shipments() const;
+
   virtual bool is_valid() override;
 
   virtual void apply() override;

--- a/src/problems/cvrp/operators/intra_two_opt.h
+++ b/src/problems/cvrp/operators/intra_two_opt.h
@@ -1,0 +1,42 @@
+#ifndef CVRP_INTRA_TWO_OPT_H
+#define CVRP_INTRA_TWO_OPT_H
+
+/*
+
+This file is part of VROOM.
+
+Copyright (c) 2015-2022, Julien Coupey.
+All rights reserved (see LICENSE).
+
+*/
+
+#include "algorithms/local_search/operator.h"
+
+namespace vroom {
+namespace cvrp {
+
+class IntraTwoOpt : public ls::Operator {
+protected:
+  virtual void compute_gain() override;
+
+public:
+  IntraTwoOpt(const Input& input,
+              const utils::SolutionState& sol_state,
+              RawRoute& s_route,
+              Index s_vehicle,
+              Index s_rank,
+              Index t_rank);
+
+  virtual bool is_valid() override;
+
+  virtual void apply() override;
+
+  virtual std::vector<Index> addition_candidates() const override;
+
+  virtual std::vector<Index> update_candidates() const override;
+};
+
+} // namespace cvrp
+} // namespace vroom
+
+#endif

--- a/src/problems/vrptw/operators/intra_two_opt.cpp
+++ b/src/problems/vrptw/operators/intra_two_opt.cpp
@@ -40,7 +40,14 @@ bool IntraTwoOpt::is_valid() {
 }
 
 void IntraTwoOpt::apply() {
-  // TODO
+  std::vector<Index> reversed(s_route.rbegin() + (s_route.size() - t_rank - 1),
+                              s_route.rbegin() + (s_route.size() - s_rank));
+
+  _tw_s_route.replace(_input,
+                      reversed.begin(),
+                      reversed.end(),
+                      s_rank,
+                      t_rank + 1);
 }
 
 } // namespace vrptw

--- a/src/problems/vrptw/operators/intra_two_opt.cpp
+++ b/src/problems/vrptw/operators/intra_two_opt.cpp
@@ -28,15 +28,20 @@ IntraTwoOpt::IntraTwoOpt(const Input& input,
 }
 
 bool IntraTwoOpt::is_valid() {
-  auto rev_t = s_route.rbegin() + (s_route.size() - t_rank - 1);
-  auto rev_s_next = s_route.rbegin() + (s_route.size() - s_rank);
+  bool valid = cvrp::IntraTwoOpt::is_valid();
 
-  return cvrp::IntraTwoOpt::is_valid() and
-         _tw_s_route.is_valid_addition_for_tw(_input,
-                                              rev_t,
-                                              rev_s_next,
-                                              s_rank,
-                                              t_rank + 1);
+  if (valid) {
+    auto rev_t = s_route.rbegin() + (s_route.size() - t_rank - 1);
+    auto rev_s_next = s_route.rbegin() + (s_route.size() - s_rank);
+
+    valid = _tw_s_route.is_valid_addition_for_tw(_input,
+                                                 rev_t,
+                                                 rev_s_next,
+                                                 s_rank,
+                                                 t_rank + 1);
+  }
+
+  return valid;
 }
 
 void IntraTwoOpt::apply() {

--- a/src/problems/vrptw/operators/intra_two_opt.cpp
+++ b/src/problems/vrptw/operators/intra_two_opt.cpp
@@ -28,8 +28,15 @@ IntraTwoOpt::IntraTwoOpt(const Input& input,
 }
 
 bool IntraTwoOpt::is_valid() {
-  // TODO
-  return true;
+  auto rev_t = s_route.rbegin() + (s_route.size() - t_rank - 1);
+  auto rev_s_next = s_route.rbegin() + (s_route.size() - s_rank);
+
+  return cvrp::IntraTwoOpt::is_valid() and
+         _tw_s_route.is_valid_addition_for_tw(_input,
+                                              rev_t,
+                                              rev_s_next,
+                                              s_rank,
+                                              t_rank + 1);
 }
 
 void IntraTwoOpt::apply() {

--- a/src/problems/vrptw/operators/intra_two_opt.cpp
+++ b/src/problems/vrptw/operators/intra_two_opt.cpp
@@ -1,0 +1,40 @@
+/*
+
+This file is part of VROOM.
+
+Copyright (c) 2015-2022, Julien Coupey.
+All rights reserved (see LICENSE).
+
+*/
+
+#include "problems/vrptw/operators/intra_two_opt.h"
+
+namespace vroom {
+namespace vrptw {
+
+IntraTwoOpt::IntraTwoOpt(const Input& input,
+                         const utils::SolutionState& sol_state,
+                         TWRoute& tw_s_route,
+                         Index s_vehicle,
+                         Index s_rank,
+                         Index t_rank)
+  : cvrp::IntraTwoOpt(input,
+                      sol_state,
+                      static_cast<RawRoute&>(tw_s_route),
+                      s_vehicle,
+                      s_rank,
+                      t_rank),
+    _tw_s_route(tw_s_route) {
+}
+
+bool IntraTwoOpt::is_valid() {
+  // TODO
+  return true;
+}
+
+void IntraTwoOpt::apply() {
+  // TODO
+}
+
+} // namespace vrptw
+} // namespace vroom

--- a/src/problems/vrptw/operators/intra_two_opt.h
+++ b/src/problems/vrptw/operators/intra_two_opt.h
@@ -1,0 +1,38 @@
+#ifndef VRPTW_INTRA_TWO_OPT_H
+#define VRPTW_INTRA_TWO_OPT_H
+
+/*
+
+This file is part of VROOM.
+
+Copyright (c) 2015-2022, Julien Coupey.
+All rights reserved (see LICENSE).
+
+*/
+
+#include "problems/cvrp/operators/intra_two_opt.h"
+
+namespace vroom {
+namespace vrptw {
+
+class IntraTwoOpt : public cvrp::IntraTwoOpt {
+private:
+  TWRoute& _tw_s_route;
+
+public:
+  IntraTwoOpt(const Input& input,
+              const utils::SolutionState& sol_state,
+              TWRoute& tw_s_route,
+              Index s_vehicle,
+              Index s_rank,
+              Index t_rank);
+
+  virtual bool is_valid() override;
+
+  virtual void apply() override;
+};
+
+} // namespace vrptw
+} // namespace vroom
+
+#endif

--- a/src/problems/vrptw/vrptw.cpp
+++ b/src/problems/vrptw/vrptw.cpp
@@ -18,6 +18,7 @@ All rights reserved (see LICENSE).
 #include "problems/vrptw/operators/intra_mixed_exchange.h"
 #include "problems/vrptw/operators/intra_or_opt.h"
 #include "problems/vrptw/operators/intra_relocate.h"
+#include "problems/vrptw/operators/intra_two_opt.h"
 #include "problems/vrptw/operators/mixed_exchange.h"
 #include "problems/vrptw/operators/or_opt.h"
 #include "problems/vrptw/operators/pd_shift.h"
@@ -50,6 +51,7 @@ using LocalSearch = ls::LocalSearch<TWRoute,
                                     vrptw::IntraMixedExchange,
                                     vrptw::IntraRelocate,
                                     vrptw::IntraOrOpt,
+                                    vrptw::IntraTwoOpt,
                                     vrptw::PDShift,
                                     vrptw::RouteExchange>;
 } // namespace vrptw

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -125,6 +125,7 @@ enum OperatorName {
   IntraMixedExchange,
   IntraRelocate,
   IntraOrOpt,
+  IntraTwoOpt,
   PDShift,
   RouteExchange,
   MAX

--- a/src/structures/vroom/solution_state.h
+++ b/src/structures/vroom/solution_state.h
@@ -104,7 +104,7 @@ public:
 
   // If job at rank i in route for vehicle v is a pickup
   // (resp. delivery), then matching_delivery_rank[v][i]
-  // (resp. _matching_pickup_rank[v][i]) stores the rank of the
+  // (resp. matching_pickup_rank[v][i]) stores the rank of the
   // matching delivery (resp. pickup).
   std::vector<std::vector<Index>> matching_delivery_rank;
   std::vector<std::vector<Index>> matching_pickup_rank;

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -72,6 +72,7 @@ const std::array<std::string, OperatorName::MAX>
                   "IntraMixedExchange",
                   "IntraRelocate",
                   "IntraOrOpt",
+                  "IntraTwoOpt",
                   "PDShift",
                   "RouteExchange"});
 


### PR DESCRIPTION
## Issue

Fixes #706 

## Tasks

 - [x] Implement `cvrp::IntraTwoOpt`
 - [x] Implement `vrptw::IntraTwoOpt`
 - [x] Add move to current LS pattern
 - [x] Make sure we don't reverse full shipments along the way
 - [x] Use insertion rank bounds from #696 for pruning
 - [x] Benchmark
 - [x] Update `CHANGELOG.md`
 - [x] review
