### PR TITLE
Use capacity bounds for LS operator pruning

### DIFF
--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -873,6 +873,9 @@ void LocalSearch<Route,
           continue;
         }
 
+        const auto t_deliveries_sum = _sol[s_t.second].job_deliveries_sum();
+        const auto t_pickups_sum = _sol[s_t.second].job_pickups_sum();
+
         for (unsigned s_rank = 0; s_rank < _sol[s_t.first].size(); ++s_rank) {
           if (_sol_state.node_gains[s_t.first][s_rank] <=
               best_gains[s_t.first][s_t.second]) {
@@ -886,6 +889,14 @@ void LocalSearch<Route,
               !_input.vehicle_ok_with_job(s_t.second, s_job_rank)) {
             // Don't try moving (part of) a shipment or an
             // incompatible job.
+            continue;
+          }
+
+          const auto& s_pickup = _input.jobs[s_job_rank].pickup;
+          const auto& s_delivery = _input.jobs[s_job_rank].delivery;
+
+          if (!(t_deliveries_sum + s_delivery <= v_t.capacity) or
+              !(t_pickups_sum + s_pickup <= v_t.capacity)) {
             continue;
           }
 

--- a/src/structures/vroom/raw_route.cpp
+++ b/src/structures/vroom/raw_route.cpp
@@ -222,7 +222,7 @@ bool RawRoute::is_valid_addition_for_capacity_inclusion(
   return valid;
 }
 
-Amount RawRoute::get_startup_load() const {
+Amount RawRoute::job_deliveries_sum() const {
   return _current_loads[0];
 }
 

--- a/src/structures/vroom/raw_route.cpp
+++ b/src/structures/vroom/raw_route.cpp
@@ -226,6 +226,10 @@ Amount RawRoute::job_deliveries_sum() const {
   return _current_loads[0];
 }
 
+Amount RawRoute::job_pickups_sum() const {
+  return _fwd_pickups.back();
+}
+
 Amount RawRoute::pickup_in_range(Index i, Index j) const {
   if (i == j) {
     return Amount(_current_loads[0].size());

--- a/src/structures/vroom/raw_route.h
+++ b/src/structures/vroom/raw_route.h
@@ -105,7 +105,7 @@ public:
                                                 const Index first_rank,
                                                 const Index last_rank) const;
 
-  Amount get_startup_load() const;
+  Amount job_deliveries_sum() const;
 
   // Get sum of pickups (resp. deliveries) for all jobs in the range
   // [i, j).

--- a/src/structures/vroom/raw_route.h
+++ b/src/structures/vroom/raw_route.h
@@ -107,6 +107,8 @@ public:
 
   Amount job_deliveries_sum() const;
 
+  Amount job_pickups_sum() const;
+
   // Get sum of pickups (resp. deliveries) for all jobs in the range
   // [i, j).
   Amount pickup_in_range(Index i, Index j) const;

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -392,7 +392,7 @@ inline Solution format_solution(const Input& input,
 #ifndef NDEBUG
     std::unordered_set<Index> expected_delivery_ranks;
 #endif
-    Amount current_load = raw_routes[i].get_startup_load();
+    Amount current_load = raw_routes[i].job_deliveries_sum();
     assert(current_load <= v.capacity);
 
     // Steps for current route.
@@ -615,7 +615,7 @@ inline Route format_route(const Input& input,
 #ifndef NDEBUG
   std::unordered_set<Index> expected_delivery_ranks;
 #endif
-  Amount current_load = tw_r.get_startup_load();
+  Amount current_load = tw_r.job_deliveries_sum();
   assert(current_load <= v.capacity);
 
   // Steps for current route.


### PR DESCRIPTION
## Issue

Fixes #709.

## Tasks

 - [ ] Expose delivery/pickup sums across jobs for all routes
 - [ ] Prune `Relocate` moves
 - [ ] Prune `OrOpt` moves
 - [ ] Prune `CrossExchange` moves
 - [ ] Prune `MixedExchange` moves
 - [ ] Prune `TwoOpt` moves
 - [ ] Prune `ReverseTwoOpt` moves
 - [ ] Prune `RouteExchange` moves
 - [ ] Prune `SwapStar` moves
 - [ ] Prune `UnassignedExchange` moves
 - [ ] Update `CHANGELOG.md` (remove if irrelevant)
 - [ ] review
