### PR TITLE
Use `std::chrono::milliseconds` for Timeout value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Use `std::chrono::milliseconds` for `Timeout` value (#728)
+
 ### Fixed
 
 - Mark `JobAmount` and `JobTime` comparison operators as `const` (#724)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,7 +97,10 @@ int main(int argc, char** argv) {
     try {
       if (!limit_arg.empty()) {
         // Internally timeout is in milliseconds.
-        cl_args.timeout = 1000 * std::stof(limit_arg);
+        const auto timeout = std::chrono::duration<double, std::milli>(
+          1000 * std::stof(limit_arg));
+        cl_args.timeout =
+          std::chrono::duration_cast<std::chrono::milliseconds>(timeout);
       }
     } catch (const std::exception& e) {
       throw cxxopts::OptionException("Argument '" + limit_arg +

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,7 +98,7 @@ int main(int argc, char** argv) {
       if (!limit_arg.empty()) {
         // Internally timeout is in milliseconds.
         cl_args.timeout = std::chrono::milliseconds(
-          static_cast<int>(1000 * std::stof(limit_arg)));
+          static_cast<std::chrono::milliseconds::rep>(1000 * std::stof(limit_arg)));
       }
     } catch (const std::exception& e) {
       throw cxxopts::OptionException("Argument '" + limit_arg +

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,10 +97,8 @@ int main(int argc, char** argv) {
     try {
       if (!limit_arg.empty()) {
         // Internally timeout is in milliseconds.
-        const auto timeout = std::chrono::duration<double, std::milli>(
-          1000 * std::stof(limit_arg));
-        cl_args.timeout =
-          std::chrono::duration_cast<std::chrono::milliseconds>(timeout);
+        cl_args.timeout = std::chrono::milliseconds(
+          static_cast<int>(1000 * std::stof(limit_arg)));
       }
     } catch (const std::exception& e) {
       throw cxxopts::OptionException("Argument '" + limit_arg +

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -44,7 +44,7 @@ using Coordinates = std::array<Coordinate, 2>;
 using OptionalCoordinates = std::optional<Coordinates>;
 using Skills = std::unordered_set<Skill>;
 using TimePoint = std::chrono::high_resolution_clock::time_point;
-using Timeout = std::optional<unsigned>;
+using Timeout = std::optional<std::chrono::milliseconds>;
 using Deadline = std::optional<TimePoint>;
 
 // Setting max value would cause trouble with further additions.

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -928,14 +928,14 @@ Solution Input::solve(unsigned exploration_level,
   _end_loading = std::chrono::high_resolution_clock::now();
 
   auto loading = std::chrono::duration_cast<std::chrono::milliseconds>(
-                   _end_loading - _start_loading)
-                   .count();
+                   _end_loading - _start_loading);
 
   // Decide time allocated for solving, 0 means only heuristics will
   // be applied.
   Timeout solve_time;
   if (timeout.has_value()) {
-    solve_time = (loading <= timeout.value()) ? (timeout.value() - loading) : 0;
+    solve_time = (loading <= timeout.value())
+      ? (timeout.value() - loading) : std::chrono::milliseconds(0);
   }
 
   // Solve.
@@ -947,7 +947,7 @@ Solution Input::solve(unsigned exploration_level,
                              (_has_initial_routes) ? h_init_routes : h_param);
 
   // Update timing info.
-  sol.summary.computing_times.loading = loading;
+  sol.summary.computing_times.loading = loading.count();
 
   _end_solving = std::chrono::high_resolution_clock::now();
   sol.summary.computing_times.solving =


### PR DESCRIPTION
## Issue #728 

This PR changes the type of `Timeout` to `std::optional<std::chrono::milliseconds>` making it more type-safe and the unit used obvious.

This is an enhancement mostly for those who use VROOM as a library.

## Tasks

 - [x] Update `CHANGELOG.md` (remove if irrelevant)
 - [ ] review
