### PR TITLE
Include response in exception for invalid routing response

### DIFF
--- a/src/routing/http_wrapper.cpp
+++ b/src/routing/http_wrapper.cpp
@@ -70,11 +70,11 @@ std::string HttpWrapper::send_then_receive(const std::string& query) const {
   // Removing headers.
   auto start = response.find("{");
   if (start == std::string::npos) {
-    throw RoutingException("Invalid routing response.");
+    throw RoutingException("Invalid routing response: " + response);
   }
   auto end = response.rfind("}");
   if (end == std::string::npos) {
-    throw RoutingException("Invalid routing response.");
+    throw RoutingException("Invalid routing response: " + response);
   }
 
   std::string json_string = response.substr(start, end - start + 1);


### PR DESCRIPTION
## Issue

Issue : https://github.com/VROOM-Project/vroom/issues/764

This includes the response in the Routing Exception to allow clients of the application to identify what the issue is.

## Tasks

 - [ ] ...
 - [ ] Update `docs/API.md` (remove if irrelevant)
 - [ ] Update `CHANGELOG.md` (remove if irrelevant)
 - [ ] review
