### PR TITLE
Handle vehicle max travel time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Support for `max_travel_time` at vehicle level (#273)
 - Advertise `libvroom` in README and wiki (#42)
 
 ### Changed

--- a/docs/API.md
+++ b/docs/API.md
@@ -115,6 +115,7 @@ A `vehicle` object has the following properties:
 | [`breaks`] | an array of `break` objects |
 | [`speed_factor`] | a double value in the range `(0, 5]` used to scale **all** vehicle travel times (defaults to 1.), the respected precision is limited to two digits after the decimal point |
 | [`max_tasks`] | an integer defining the maximum number of tasks in a route for this vehicle |
+| [`max_travel_time`] | an integer defining the maximum travel time for this vehicle |
 | [`steps`] | an array of `vehicle_step` objects describing a custom route for this vehicle |
 
 A `break` object has the following properties:

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -121,6 +121,8 @@ template <class T> T basic(const Input& input, INIT init, double lambda) {
 
     const auto& vehicle = input.vehicles[v_rank];
 
+    Duration current_route_duration = 0;
+
     if (init != INIT::NONE) {
       // Initialize current route with the "best" valid job.
       bool init_ok = false;
@@ -166,6 +168,10 @@ template <class T> T basic(const Input& input, INIT init, double lambda) {
         }
 
         bool is_valid =
+          (evals[job_rank][v_rank].duration <= vehicle.max_travel_time);
+
+        is_valid =
+          is_valid &&
           current_r
             .is_valid_addition_for_capacity(input,
                                             input.jobs[job_rank].pickup,
@@ -227,6 +233,7 @@ template <class T> T basic(const Input& input, INIT init, double lambda) {
           unassigned.erase(best_job_rank);
           unassigned.erase(best_job_rank + 1);
         }
+        current_route_duration += evals[best_job_rank][v_rank].duration;
       }
     }
 
@@ -238,6 +245,7 @@ template <class T> T basic(const Input& input, INIT init, double lambda) {
       Index best_r = 0;
       Index best_pickup_r = 0;
       Index best_delivery_r = 0;
+      Duration best_duration_addition = 0;
 
       for (const auto job_rank : unassigned) {
         if (!input.vehicle_ok_with_job(v_rank, job_rank)) {
@@ -262,6 +270,8 @@ template <class T> T basic(const Input& input, INIT init, double lambda) {
               lambda * static_cast<double>(regrets[v][job_rank]);
 
             if (current_cost < best_cost and
+                (current_route_duration + current_add.duration <=
+                 vehicle.max_travel_time) and
                 current_r
                   .is_valid_addition_for_capacity(input,
                                                   input.jobs[job_rank].pickup,
@@ -271,6 +281,7 @@ template <class T> T basic(const Input& input, INIT init, double lambda) {
               best_cost = current_cost;
               best_job_rank = job_rank;
               best_r = r;
+              best_duration_addition = current_add.duration;
             }
           }
         }
@@ -351,7 +362,11 @@ template <class T> T basic(const Input& input, INIT init, double lambda) {
                 modified_with_pd.push_back(job_rank + 1);
 
                 // Update best cost depending on validity.
-                bool valid =
+                bool valid = (current_route_duration + current_add.duration <=
+                              vehicle.max_travel_time);
+
+                valid =
+                  valid &&
                   current_r
                     .is_valid_addition_for_capacity_inclusion(input,
                                                               modified_delivery,
@@ -377,6 +392,7 @@ template <class T> T basic(const Input& input, INIT init, double lambda) {
                   best_job_rank = job_rank;
                   best_pickup_r = pickup_r;
                   best_delivery_r = delivery_r;
+                  best_duration_addition = current_add.duration;
                 }
               }
             }
@@ -406,6 +422,8 @@ template <class T> T basic(const Input& input, INIT init, double lambda) {
           unassigned.erase(best_job_rank + 1);
           keep_going = true;
         }
+
+        current_route_duration += best_duration_addition;
       }
     }
   }

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -168,10 +168,7 @@ template <class T> T basic(const Input& input, INIT init, double lambda) {
         }
 
         bool is_valid =
-          (evals[job_rank][v_rank].duration <= vehicle.max_travel_time);
-
-        is_valid =
-          is_valid &&
+          (evals[job_rank][v_rank].duration <= vehicle.max_travel_time) &&
           current_r
             .is_valid_addition_for_capacity(input,
                                             input.jobs[job_rank].pickup,
@@ -362,11 +359,9 @@ template <class T> T basic(const Input& input, INIT init, double lambda) {
                 modified_with_pd.push_back(job_rank + 1);
 
                 // Update best cost depending on validity.
-                bool valid = (current_route_duration + current_add.duration <=
-                              vehicle.max_travel_time);
-
-                valid =
-                  valid &&
+                bool valid =
+                  (current_route_duration + current_add.duration <=
+                   vehicle.max_travel_time) &&
                   current_r
                     .is_valid_addition_for_capacity_inclusion(input,
                                                               modified_delivery,
@@ -566,10 +561,7 @@ T dynamic_vehicle_choice(const Input& input, INIT init, double lambda) {
         }
 
         bool is_valid =
-          (evals[job_rank][v_rank].duration <= vehicle.max_travel_time);
-
-        is_valid =
-          is_valid &&
+          (evals[job_rank][v_rank].duration <= vehicle.max_travel_time) &&
           current_r
             .is_valid_addition_for_capacity(input,
                                             input.jobs[job_rank].pickup,
@@ -761,11 +753,9 @@ T dynamic_vehicle_choice(const Input& input, INIT init, double lambda) {
                 modified_with_pd.push_back(job_rank + 1);
 
                 // Update best cost depending on validity.
-                bool valid = (current_route_duration + current_add.duration <=
-                              vehicle.max_travel_time);
-
-                valid =
-                  valid &&
+                bool valid =
+                  (current_route_duration + current_add.duration <=
+                   vehicle.max_travel_time) &&
                   current_r
                     .is_valid_addition_for_capacity_inclusion(input,
                                                               modified_delivery,
@@ -774,10 +764,7 @@ T dynamic_vehicle_choice(const Input& input, INIT init, double lambda) {
                                                               modified_with_pd
                                                                 .end(),
                                                               pickup_r,
-                                                              delivery_r);
-
-                valid =
-                  valid &&
+                                                              delivery_r) &&
                   current_r.is_valid_addition_for_tw(input,
                                                      modified_with_pd.begin(),
                                                      modified_with_pd.end(),

--- a/src/algorithms/local_search/insertion_search.h
+++ b/src/algorithms/local_search/insertion_search.h
@@ -81,6 +81,7 @@ RouteInsertion compute_best_insertion_pd(const Input& input,
   RouteInsertion result = empty_insert;
   const auto& current_job = input.jobs[j];
   const auto& v_target = input.vehicles[v];
+  const auto target_travel_time = sol_state.route_evals[v].duration;
 
   if (!input.vehicle_ok_with_job(v, j)) {
     return result;
@@ -119,7 +120,7 @@ RouteInsertion compute_best_insertion_pd(const Input& input,
     Eval p_add =
       utils::addition_cost(input, j, v_target, route.route, pickup_r);
     if (p_add > result.eval) {
-      // Even without delivery insertion more expensive then current best
+      // Even without delivery insertion more expensive than current best.
       continue;
     }
 
@@ -158,7 +159,8 @@ RouteInsertion compute_best_insertion_pd(const Input& input,
         pd_eval = p_add + d_adds[delivery_r];
       }
 
-      if (pd_eval < result.eval) {
+      if (pd_eval < result.eval &&
+          target_travel_time + pd_eval.duration <= v_target.max_travel_time) {
         modified_with_pd.push_back(j + 1);
 
         // Update best cost depending on validity.
@@ -184,6 +186,7 @@ RouteInsertion compute_best_insertion_pd(const Input& input,
       }
     }
   }
+
   assert(result.eval <= cost_threshold);
   if (result.eval == cost_threshold) {
     result.eval = NO_EVAL;

--- a/src/algorithms/local_search/insertion_search.h
+++ b/src/algorithms/local_search/insertion_search.h
@@ -28,17 +28,18 @@ compute_best_insertion_single(const Input& input,
   const auto& v_target = input.vehicles[v];
 
   if (input.vehicle_ok_with_job(v, j)) {
-
     for (Index rank = sol_state.insertion_ranks_begin[v][j];
          rank < sol_state.insertion_ranks_end[v][j];
          ++rank) {
       Eval current_eval =
         utils::addition_cost(input, j, v_target, route.route, rank);
-      if (current_eval.cost < result.eval.cost and
+      if (current_eval.cost < result.eval.cost &&
+          (sol_state.route_evals[v].duration + current_eval.duration <=
+           v_target.max_travel_time) &&
           route.is_valid_addition_for_capacity(input,
                                                current_job.pickup,
                                                current_job.delivery,
-                                               rank) and
+                                               rank) &&
           route.is_valid_addition_for_tw(input, j, rank)) {
         result = {current_eval, rank, 0, 0};
       }

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -1496,6 +1496,16 @@ void LocalSearch<Route,
             continue;
           }
 
+          const auto& v_s = _input.vehicles[s_t.first];
+          const auto s_travel_time = _sol_state.route_evals[s_t.first].duration;
+          const auto s_removal_duration_gain =
+            _sol_state.pd_gains[s_t.first][s_p_rank].duration;
+          if (s_travel_time > v_s.max_travel_time + s_removal_duration_gain) {
+            // Removing shipment from source route actually breaks
+            // max_travel_time constraint in source.
+            continue;
+          }
+
 #ifdef LOG_LS_OPERATORS
           ++tried_moves[OperatorName::PDShift];
 #endif

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -1652,7 +1652,10 @@ void LocalSearch<Route,
                         });
       for (auto v_rank : update_candidates) {
         _sol_state.update_route_eval(_sol[v_rank].route, v_rank);
+
         assert(_sol[v_rank].size() <= _input.vehicles[v_rank].max_tasks);
+        assert(_sol_state.route_evals[v_rank].duration <=
+               _input.vehicles[v_rank].max_travel_time);
       }
       const auto new_eval =
         std::accumulate(update_candidates.begin(),

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -284,8 +284,8 @@ void LocalSearch<Route,
                                  _sol[best_route]);
       }
 #ifndef NDEBUG
-      // Update cost after addition.
-      _sol_state.update_route_cost(_sol[best_route].route, best_route);
+      // Update evaluation after addition.
+      _sol_state.update_route_eval(_sol[best_route].route, best_route);
 #endif
     }
   } while (job_added);
@@ -1643,25 +1643,25 @@ void LocalSearch<Route,
 
 #ifndef NDEBUG
       // Update route costs.
-      const auto previous_cost =
+      const auto previous_eval =
         std::accumulate(update_candidates.begin(),
                         update_candidates.end(),
-                        0,
+                        Eval(),
                         [&](auto sum, auto c) {
-                          return sum + _sol_state.route_costs[c];
+                          return sum + _sol_state.route_evals[c];
                         });
       for (auto v_rank : update_candidates) {
-        _sol_state.update_route_cost(_sol[v_rank].route, v_rank);
+        _sol_state.update_route_eval(_sol[v_rank].route, v_rank);
         assert(_sol[v_rank].size() <= _input.vehicles[v_rank].max_tasks);
       }
-      const auto new_cost =
+      const auto new_eval =
         std::accumulate(update_candidates.begin(),
                         update_candidates.end(),
-                        0,
+                        Eval(),
                         [&](auto sum, auto c) {
-                          return sum + _sol_state.route_costs[c];
+                          return sum + _sol_state.route_evals[c];
                         });
-      assert(new_cost + best_gain.cost == previous_cost);
+      assert(new_eval + best_gain == previous_eval);
 #endif
 
       for (auto v_rank : update_candidates) {

--- a/src/algorithms/local_search/operator.cpp
+++ b/src/algorithms/local_search/operator.cpp
@@ -23,6 +23,18 @@ Eval Operator::gain() {
   return stored_gain;
 }
 
+bool Operator::is_valid_for_source_max_travel_time() const {
+  const auto& s_v = _input.vehicles[s_vehicle];
+  const auto s_travel_time = _sol_state.route_evals[s_vehicle].duration;
+  return s_travel_time <= s_v.max_travel_time + s_gain.duration;
+}
+
+bool Operator::is_valid_for_target_max_travel_time() const {
+  const auto& t_v = _input.vehicles[t_vehicle];
+  const auto t_travel_time = _sol_state.route_evals[t_vehicle].duration;
+  return t_travel_time <= t_v.max_travel_time + t_gain.duration;
+}
+
 std::vector<Index> Operator::required_unassigned() const {
   return std::vector<Index>();
 }

--- a/src/algorithms/local_search/operator.cpp
+++ b/src/algorithms/local_search/operator.cpp
@@ -35,6 +35,15 @@ bool Operator::is_valid_for_target_max_travel_time() const {
   return t_travel_time <= t_v.max_travel_time + t_gain.duration;
 }
 
+bool Operator::is_valid_for_max_travel_time() const {
+  assert(s_vehicle == t_vehicle);
+  assert(gain_computed);
+
+  const auto& s_v = _input.vehicles[s_vehicle];
+  const auto s_travel_time = _sol_state.route_evals[s_vehicle].duration;
+  return s_travel_time <= s_v.max_travel_time + stored_gain.duration;
+}
+
 std::vector<Index> Operator::required_unassigned() const {
   return std::vector<Index>();
 }

--- a/src/algorithms/local_search/operator.h
+++ b/src/algorithms/local_search/operator.h
@@ -45,6 +45,9 @@ protected:
 
   bool is_valid_for_target_max_travel_time() const;
 
+  // Used for internal operators only.
+  bool is_valid_for_max_travel_time() const;
+
 public:
   Operator(OperatorName name,
            const Input& input,

--- a/src/algorithms/local_search/operator.h
+++ b/src/algorithms/local_search/operator.h
@@ -41,6 +41,10 @@ protected:
 
   virtual void compute_gain() = 0;
 
+  bool is_valid_for_source_max_travel_time() const;
+
+  bool is_valid_for_target_max_travel_time() const;
+
 public:
   Operator(OperatorName name,
            const Input& input,

--- a/src/algorithms/local_search/operator.h
+++ b/src/algorithms/local_search/operator.h
@@ -35,6 +35,8 @@ protected:
   const Index t_rank;
 
   bool gain_computed;
+  Eval s_gain;
+  Eval t_gain;
   Eval stored_gain;
 
   virtual void compute_gain() = 0;

--- a/src/problems/cvrp/operators/cross_exchange.cpp
+++ b/src/problems/cvrp/operators/cross_exchange.cpp
@@ -228,6 +228,8 @@ void CrossExchange::compute_gain() {
 }
 
 bool CrossExchange::is_valid() {
+  assert(_gain_upper_bound_computed);
+
   auto target_pickup = _input.jobs[t_route[t_rank]].pickup +
                        _input.jobs[t_route[t_rank + 1]].pickup;
   auto target_delivery = _input.jobs[t_route[t_rank]].delivery +

--- a/src/problems/cvrp/operators/cross_exchange.cpp
+++ b/src/problems/cvrp/operators/cross_exchange.cpp
@@ -240,9 +240,13 @@ bool CrossExchange::is_valid() {
                                                              s_rank + 2);
 
   if (valid) {
+    const auto& s_v = _input.vehicles[s_vehicle];
+    const auto s_travel_time = _sol_state.route_evals[s_vehicle].duration;
+
     // Keep target edge direction when inserting in source route.
     auto t_start = t_route.begin() + t_rank;
     s_is_normal_valid =
+      (s_travel_time <= s_v.max_travel_time + _normal_s_gain.duration) and
       source.is_valid_addition_for_capacity_inclusion(_input,
                                                       target_delivery,
                                                       t_start,
@@ -254,6 +258,7 @@ bool CrossExchange::is_valid() {
       // Reverse target edge direction when inserting in source route.
       auto t_reverse_start = t_route.rbegin() + t_route.size() - 2 - t_rank;
       s_is_reverse_valid =
+        (s_travel_time <= s_v.max_travel_time + _reversed_s_gain.duration) and
         source.is_valid_addition_for_capacity_inclusion(_input,
                                                         target_delivery,
                                                         t_reverse_start,
@@ -278,9 +283,13 @@ bool CrossExchange::is_valid() {
                                                            t_rank + 2);
 
   if (valid) {
+    const auto& t_v = _input.vehicles[t_vehicle];
+    const auto t_travel_time = _sol_state.route_evals[t_vehicle].duration;
+
     // Keep source edge direction when inserting in target route.
     auto s_start = s_route.begin() + s_rank;
     t_is_normal_valid =
+      (t_travel_time <= t_v.max_travel_time + _normal_t_gain.duration) and
       target.is_valid_addition_for_capacity_inclusion(_input,
                                                       source_delivery,
                                                       s_start,
@@ -292,6 +301,7 @@ bool CrossExchange::is_valid() {
       // Reverse source edge direction when inserting in target route.
       auto s_reverse_start = s_route.rbegin() + s_route.size() - 2 - s_rank;
       t_is_reverse_valid =
+        (t_travel_time <= t_v.max_travel_time + _reversed_t_gain.duration) and
         target.is_valid_addition_for_capacity_inclusion(_input,
                                                         source_delivery,
                                                         s_reverse_start,

--- a/src/problems/cvrp/operators/intra_cross_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_cross_exchange.cpp
@@ -233,25 +233,24 @@ bool IntraCrossExchange::is_valid() {
                                                     _first_rank,
                                                     _last_rank);
 
-  const auto s_normal_t_reverse_duration =
-    _reversed_s_gain.duration + _normal_t_gain.duration;
+  std::swap(_moved_jobs[0], _moved_jobs[1]);
 
-  if (s_travel_time <= s_v.max_travel_time + s_normal_t_reverse_duration) {
-    std::swap(_moved_jobs[0], _moved_jobs[1]);
+  if (check_t_reverse) {
+    const auto s_normal_t_reverse_duration =
+      _reversed_s_gain.duration + _normal_t_gain.duration;
 
-    if (check_t_reverse) {
-      s_normal_t_reverse_is_valid =
-        source.is_valid_addition_for_capacity_inclusion(_input,
-                                                        delivery,
-                                                        _moved_jobs.begin(),
-                                                        _moved_jobs.end(),
-                                                        _first_rank,
-                                                        _last_rank);
-    }
-
-    std::swap(_moved_jobs[_moved_jobs.size() - 2],
-              _moved_jobs[_moved_jobs.size() - 1]);
+    s_normal_t_reverse_is_valid =
+      (s_travel_time <= s_v.max_travel_time + s_normal_t_reverse_duration) &&
+      source.is_valid_addition_for_capacity_inclusion(_input,
+                                                      delivery,
+                                                      _moved_jobs.begin(),
+                                                      _moved_jobs.end(),
+                                                      _first_rank,
+                                                      _last_rank);
   }
+
+  std::swap(_moved_jobs[_moved_jobs.size() - 2],
+            _moved_jobs[_moved_jobs.size() - 1]);
 
   if (check_s_reverse and check_t_reverse) {
     const auto s_reversed_t_reversed_duration =
@@ -267,27 +266,26 @@ bool IntraCrossExchange::is_valid() {
                                                       _last_rank);
   }
 
-  const auto s_reverse_t_normal_duration =
-    _normal_s_gain.duration + _reversed_t_gain.duration;
+  std::swap(_moved_jobs[0], _moved_jobs[1]);
 
-  if (s_travel_time <= s_v.max_travel_time + s_reverse_t_normal_duration) {
-    std::swap(_moved_jobs[0], _moved_jobs[1]);
+  if (check_s_reverse) {
+    const auto s_reverse_t_normal_duration =
+      _normal_s_gain.duration + _reversed_t_gain.duration;
 
-    if (check_s_reverse) {
-      s_reverse_t_normal_is_valid =
-        source.is_valid_addition_for_capacity_inclusion(_input,
-                                                        delivery,
-                                                        _moved_jobs.begin(),
-                                                        _moved_jobs.end(),
-                                                        _first_rank,
-                                                        _last_rank);
-    }
-
-    // Reset to initial situation before potential application and TW
-    // checks.
-    std::swap(_moved_jobs[_moved_jobs.size() - 2],
-              _moved_jobs[_moved_jobs.size() - 1]);
+    s_reverse_t_normal_is_valid =
+      (s_travel_time <= s_v.max_travel_time + s_reverse_t_normal_duration) &&
+      source.is_valid_addition_for_capacity_inclusion(_input,
+                                                      delivery,
+                                                      _moved_jobs.begin(),
+                                                      _moved_jobs.end(),
+                                                      _first_rank,
+                                                      _last_rank);
   }
+
+  // Reset to initial situation before potential application and TW
+  // checks.
+  std::swap(_moved_jobs[_moved_jobs.size() - 2],
+            _moved_jobs[_moved_jobs.size() - 1]);
 
   return s_normal_t_normal_is_valid or s_normal_t_reverse_is_valid or
          s_reverse_t_reverse_is_valid or s_reverse_t_normal_is_valid;

--- a/src/problems/cvrp/operators/intra_cross_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_cross_exchange.cpp
@@ -233,10 +233,10 @@ bool IntraCrossExchange::is_valid() {
                                                     _first_rank,
                                                     _last_rank);
 
-  const auto s_normal_t_reversed_duration =
-    _normal_s_gain.duration + _reversed_t_gain.duration;
+  const auto s_normal_t_reverse_duration =
+    _reversed_s_gain.duration + _normal_t_gain.duration;
 
-  if (s_travel_time <= s_v.max_travel_time + s_normal_t_reversed_duration) {
+  if (s_travel_time <= s_v.max_travel_time + s_normal_t_reverse_duration) {
     std::swap(_moved_jobs[0], _moved_jobs[1]);
 
     if (check_t_reverse) {
@@ -267,10 +267,10 @@ bool IntraCrossExchange::is_valid() {
                                                       _last_rank);
   }
 
-  const auto s_reversed_t_normal_duration =
-    _reversed_s_gain.duration + _normal_t_gain.duration;
+  const auto s_reverse_t_normal_duration =
+    _normal_s_gain.duration + _reversed_t_gain.duration;
 
-  if (s_travel_time <= s_v.max_travel_time + s_reversed_t_normal_duration) {
+  if (s_travel_time <= s_v.max_travel_time + s_reverse_t_normal_duration) {
     std::swap(_moved_jobs[0], _moved_jobs[1]);
 
     if (check_s_reverse) {

--- a/src/problems/cvrp/operators/intra_cross_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_cross_exchange.cpp
@@ -215,9 +215,17 @@ void IntraCrossExchange::compute_gain() {
 }
 
 bool IntraCrossExchange::is_valid() {
-  auto delivery = source.delivery_in_range(_first_rank, _last_rank);
+  assert(_gain_upper_bound_computed);
+
+  const auto delivery = source.delivery_in_range(_first_rank, _last_rank);
+
+  const auto& s_v = _input.vehicles[s_vehicle];
+  const auto s_travel_time = _sol_state.route_evals[s_vehicle].duration;
+  const auto s_normal_t_normal_duration =
+    _normal_s_gain.duration + _normal_t_gain.duration;
 
   s_normal_t_normal_is_valid =
+    (s_travel_time <= s_v.max_travel_time + s_normal_t_normal_duration) and
     source.is_valid_addition_for_capacity_inclusion(_input,
                                                     delivery,
                                                     _moved_jobs.begin(),
@@ -225,23 +233,32 @@ bool IntraCrossExchange::is_valid() {
                                                     _first_rank,
                                                     _last_rank);
 
-  std::swap(_moved_jobs[0], _moved_jobs[1]);
+  const auto s_normal_t_reversed_duration =
+    _normal_s_gain.duration + _reversed_t_gain.duration;
 
-  if (check_t_reverse) {
-    s_normal_t_reverse_is_valid =
-      source.is_valid_addition_for_capacity_inclusion(_input,
-                                                      delivery,
-                                                      _moved_jobs.begin(),
-                                                      _moved_jobs.end(),
-                                                      _first_rank,
-                                                      _last_rank);
+  if (s_travel_time <= s_v.max_travel_time + s_normal_t_reversed_duration) {
+    std::swap(_moved_jobs[0], _moved_jobs[1]);
+
+    if (check_t_reverse) {
+      s_normal_t_reverse_is_valid =
+        source.is_valid_addition_for_capacity_inclusion(_input,
+                                                        delivery,
+                                                        _moved_jobs.begin(),
+                                                        _moved_jobs.end(),
+                                                        _first_rank,
+                                                        _last_rank);
+    }
+
+    std::swap(_moved_jobs[_moved_jobs.size() - 2],
+              _moved_jobs[_moved_jobs.size() - 1]);
   }
-
-  std::swap(_moved_jobs[_moved_jobs.size() - 2],
-            _moved_jobs[_moved_jobs.size() - 1]);
 
   if (check_s_reverse and check_t_reverse) {
+    const auto s_reversed_t_reversed_duration =
+      _reversed_s_gain.duration + _reversed_t_gain.duration;
     s_reverse_t_reverse_is_valid =
+      (s_travel_time <=
+       s_v.max_travel_time + s_reversed_t_reversed_duration) and
       source.is_valid_addition_for_capacity_inclusion(_input,
                                                       delivery,
                                                       _moved_jobs.begin(),
@@ -250,22 +267,27 @@ bool IntraCrossExchange::is_valid() {
                                                       _last_rank);
   }
 
-  std::swap(_moved_jobs[0], _moved_jobs[1]);
+  const auto s_reversed_t_normal_duration =
+    _reversed_s_gain.duration + _normal_t_gain.duration;
 
-  if (check_s_reverse) {
-    s_reverse_t_normal_is_valid =
-      source.is_valid_addition_for_capacity_inclusion(_input,
-                                                      delivery,
-                                                      _moved_jobs.begin(),
-                                                      _moved_jobs.end(),
-                                                      _first_rank,
-                                                      _last_rank);
+  if (s_travel_time <= s_v.max_travel_time + s_reversed_t_normal_duration) {
+    std::swap(_moved_jobs[0], _moved_jobs[1]);
+
+    if (check_s_reverse) {
+      s_reverse_t_normal_is_valid =
+        source.is_valid_addition_for_capacity_inclusion(_input,
+                                                        delivery,
+                                                        _moved_jobs.begin(),
+                                                        _moved_jobs.end(),
+                                                        _first_rank,
+                                                        _last_rank);
+    }
+
+    // Reset to initial situation before potential application and TW
+    // checks.
+    std::swap(_moved_jobs[_moved_jobs.size() - 2],
+              _moved_jobs[_moved_jobs.size() - 1]);
   }
-
-  // Reset to initial situation before potential application and TW
-  // checks.
-  std::swap(_moved_jobs[_moved_jobs.size() - 2],
-            _moved_jobs[_moved_jobs.size() - 1]);
 
   return s_normal_t_normal_is_valid or s_normal_t_reverse_is_valid or
          s_reverse_t_reverse_is_valid or s_reverse_t_normal_is_valid;

--- a/src/problems/cvrp/operators/intra_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_exchange.cpp
@@ -99,15 +99,14 @@ void IntraExchange::compute_gain() {
 }
 
 bool IntraExchange::is_valid() {
-  return source
-    .is_valid_addition_for_capacity_inclusion(_input,
-                                              source
-                                                .delivery_in_range(_first_rank,
-                                                                   _last_rank),
-                                              _moved_jobs.begin(),
-                                              _moved_jobs.end(),
-                                              _first_rank,
-                                              _last_rank);
+  return is_valid_for_max_travel_time() &&
+         source.is_valid_addition_for_capacity_inclusion(
+           _input,
+           source.delivery_in_range(_first_rank, _last_rank),
+           _moved_jobs.begin(),
+           _moved_jobs.end(),
+           _first_rank,
+           _last_rank);
 }
 
 void IntraExchange::apply() {

--- a/src/problems/cvrp/operators/intra_mixed_exchange.h
+++ b/src/problems/cvrp/operators/intra_mixed_exchange.h
@@ -20,7 +20,6 @@ private:
   bool _gain_upper_bound_computed;
   Eval _normal_s_gain;
   Eval _reversed_s_gain;
-  Eval _t_gain;
 
 protected:
   bool reverse_t_edge;

--- a/src/problems/cvrp/operators/intra_or_opt.h
+++ b/src/problems/cvrp/operators/intra_or_opt.h
@@ -18,7 +18,6 @@ namespace cvrp {
 class IntraOrOpt : public ls::Operator {
 private:
   bool _gain_upper_bound_computed;
-  Eval _s_gain;
   Eval _normal_t_gain;
   Eval _reversed_t_gain;
 

--- a/src/problems/cvrp/operators/intra_relocate.cpp
+++ b/src/problems/cvrp/operators/intra_relocate.cpp
@@ -61,23 +61,25 @@ void IntraRelocate::compute_gain() {
   if (s_rank < t_rank) {
     ++new_rank;
   }
-  Eval t_gain =
-    -utils::addition_cost(_input, s_route[s_rank], v_target, t_route, new_rank);
+  s_gain =
+    _sol_state.node_gains[s_vehicle][s_rank] -
+    utils::addition_cost(_input, s_route[s_rank], v_target, t_route, new_rank);
 
-  stored_gain = _sol_state.node_gains[s_vehicle][s_rank] + t_gain;
+  stored_gain = s_gain;
   gain_computed = true;
 }
 
 bool IntraRelocate::is_valid() {
-  return source
-    .is_valid_addition_for_capacity_inclusion(_input,
-                                              source
-                                                .delivery_in_range(_first_rank,
-                                                                   _last_rank),
-                                              _moved_jobs.begin(),
-                                              _moved_jobs.end(),
-                                              _first_rank,
-                                              _last_rank);
+  assert(gain_computed);
+
+  return is_valid_for_source_max_travel_time() &&
+         source.is_valid_addition_for_capacity_inclusion(
+           _input,
+           source.delivery_in_range(_first_rank, _last_rank),
+           _moved_jobs.begin(),
+           _moved_jobs.end(),
+           _first_rank,
+           _last_rank);
 }
 
 void IntraRelocate::apply() {

--- a/src/problems/cvrp/operators/intra_relocate.cpp
+++ b/src/problems/cvrp/operators/intra_relocate.cpp
@@ -61,18 +61,15 @@ void IntraRelocate::compute_gain() {
   if (s_rank < t_rank) {
     ++new_rank;
   }
-  s_gain =
+  stored_gain =
     _sol_state.node_gains[s_vehicle][s_rank] -
     utils::addition_cost(_input, s_route[s_rank], v_target, t_route, new_rank);
 
-  stored_gain = s_gain;
   gain_computed = true;
 }
 
 bool IntraRelocate::is_valid() {
-  assert(gain_computed);
-
-  return is_valid_for_source_max_travel_time() &&
+  return is_valid_for_max_travel_time() &&
          source.is_valid_addition_for_capacity_inclusion(
            _input,
            source.delivery_in_range(_first_rank, _last_rank),

--- a/src/problems/cvrp/operators/intra_two_opt.cpp
+++ b/src/problems/cvrp/operators/intra_two_opt.cpp
@@ -44,38 +44,37 @@ void IntraTwoOpt::compute_gain() {
 
   // Cost of reversing vehicle route between s_rank and t_rank
   // included.
-  s_gain += _sol_state.fwd_costs[s_vehicle][s_vehicle][t_rank];
-  s_gain -= _sol_state.fwd_costs[s_vehicle][s_vehicle][s_rank];
-  s_gain += _sol_state.bwd_costs[s_vehicle][s_vehicle][s_rank];
-  s_gain -= _sol_state.bwd_costs[s_vehicle][s_vehicle][t_rank];
+  stored_gain += _sol_state.fwd_costs[s_vehicle][s_vehicle][t_rank];
+  stored_gain -= _sol_state.fwd_costs[s_vehicle][s_vehicle][s_rank];
+  stored_gain += _sol_state.bwd_costs[s_vehicle][s_vehicle][s_rank];
+  stored_gain -= _sol_state.bwd_costs[s_vehicle][s_vehicle][t_rank];
 
   // Cost of going to t_rank first instead of s_rank.
   if (s_rank > 0) {
     Index previous_index = _input.jobs[s_route[s_rank - 1]].index();
-    s_gain += s_v.eval(previous_index, s_index);
-    s_gain -= s_v.eval(previous_index, t_index);
+    stored_gain += s_v.eval(previous_index, s_index);
+    stored_gain -= s_v.eval(previous_index, t_index);
   } else {
     if (s_v.has_start()) {
       Index start_index = s_v.start.value().index();
-      s_gain += s_v.eval(start_index, s_index);
-      s_gain -= s_v.eval(start_index, t_index);
+      stored_gain += s_v.eval(start_index, s_index);
+      stored_gain -= s_v.eval(start_index, t_index);
     }
   }
 
   // Cost of going from s_rank after instead of t_rank.
   if (t_rank < s_route.size() - 1) {
     Index next_index = _input.jobs[s_route[t_rank + 1]].index();
-    s_gain += s_v.eval(t_index, next_index);
-    s_gain -= s_v.eval(s_index, next_index);
+    stored_gain += s_v.eval(t_index, next_index);
+    stored_gain -= s_v.eval(s_index, next_index);
   } else {
     if (s_v.has_end()) {
       Index end_index = s_v.end.value().index();
-      s_gain += s_v.eval(t_index, end_index);
-      s_gain -= s_v.eval(s_index, end_index);
+      stored_gain += s_v.eval(t_index, end_index);
+      stored_gain -= s_v.eval(s_index, end_index);
     }
   }
 
-  stored_gain = s_gain;
   gain_computed = true;
 }
 
@@ -95,11 +94,9 @@ bool IntraTwoOpt::reversal_ok_for_shipments() const {
 }
 
 bool IntraTwoOpt::is_valid() {
-  assert(gain_computed);
-
   bool valid = !_input.has_shipments() or reversal_ok_for_shipments();
 
-  valid = valid && is_valid_for_source_max_travel_time();
+  valid = valid && is_valid_for_max_travel_time();
 
   if (valid) {
     auto rev_t = s_route.rbegin() + (s_route.size() - t_rank - 1);

--- a/src/problems/cvrp/operators/intra_two_opt.cpp
+++ b/src/problems/cvrp/operators/intra_two_opt.cpp
@@ -94,9 +94,8 @@ bool IntraTwoOpt::reversal_ok_for_shipments() const {
 }
 
 bool IntraTwoOpt::is_valid() {
-  bool valid = !_input.has_shipments() or reversal_ok_for_shipments();
-
-  valid = valid && is_valid_for_max_travel_time();
+  bool valid = (!_input.has_shipments() or reversal_ok_for_shipments()) &&
+               is_valid_for_max_travel_time();
 
   if (valid) {
     auto rev_t = s_route.rbegin() + (s_route.size() - t_rank - 1);

--- a/src/problems/cvrp/operators/mixed_exchange.cpp
+++ b/src/problems/cvrp/operators/mixed_exchange.cpp
@@ -176,13 +176,10 @@ void MixedExchange::compute_gain() {
 }
 
 bool MixedExchange::is_valid() {
-  const auto& t_v = _input.vehicles[t_vehicle];
-  const auto t_travel_time = _sol_state.route_evals[t_vehicle].duration;
+  assert(_gain_upper_bound_computed);
 
-  bool valid = (t_travel_time <= t_v.max_travel_time + t_gain.duration);
-
-  valid =
-    valid &&
+  bool valid =
+    is_valid_for_target_max_travel_time() &&
     target.is_valid_addition_for_capacity_margins(_input,
                                                   _input.jobs[s_route[s_rank]]
                                                     .pickup,

--- a/src/problems/cvrp/operators/mixed_exchange.h
+++ b/src/problems/cvrp/operators/mixed_exchange.h
@@ -20,7 +20,6 @@ private:
   bool _gain_upper_bound_computed;
   Eval _normal_s_gain;
   Eval _reversed_s_gain;
-  Eval _t_gain;
 
 protected:
   bool reverse_t_edge;

--- a/src/problems/cvrp/operators/or_opt.cpp
+++ b/src/problems/cvrp/operators/or_opt.cpp
@@ -108,7 +108,7 @@ Eval OrOpt::gain_upper_bound() {
   }
 
   // Gain for source vehicle, including cost of moved edge.
-  _s_gain =
+  s_gain =
     _sol_state.edge_gains[s_vehicle][s_rank] + s_v.eval(s_index, after_s_index);
 
   // Gain for target vehicle, including cost of moved edge.
@@ -120,14 +120,14 @@ Eval OrOpt::gain_upper_bound() {
 
   _gain_upper_bound_computed = true;
 
-  return _s_gain + std::max(_normal_t_gain, _reversed_t_gain);
+  return s_gain + std::max(_normal_t_gain, _reversed_t_gain);
 }
 
 void OrOpt::compute_gain() {
   assert(_gain_upper_bound_computed);
   assert(is_normal_valid or is_reverse_valid);
 
-  stored_gain = _s_gain;
+  stored_gain = s_gain;
 
   if (_reversed_t_gain > _normal_t_gain) {
     // Biggest potential gain is obtained when reversing edge.
@@ -151,21 +151,29 @@ void OrOpt::compute_gain() {
 }
 
 bool OrOpt::is_valid() {
+  const auto& s_v = _input.vehicles[s_vehicle];
+  const auto s_travel_time = _sol_state.route_evals[s_vehicle].duration;
+  bool valid = (s_travel_time <= s_v.max_travel_time + s_gain.duration);
+
   auto edge_pickup = _input.jobs[s_route[s_rank]].pickup +
                      _input.jobs[s_route[s_rank + 1]].pickup;
   auto edge_delivery = _input.jobs[s_route[s_rank]].delivery +
                        _input.jobs[s_route[s_rank + 1]].delivery;
 
-  bool valid = target.is_valid_addition_for_capacity(_input,
-                                                     edge_pickup,
-                                                     edge_delivery,
-                                                     t_rank);
+  valid = target.is_valid_addition_for_capacity(_input,
+                                                edge_pickup,
+                                                edge_delivery,
+                                                t_rank);
 
   if (valid) {
     // Keep edge direction.
     auto s_start = s_route.begin() + s_rank;
 
+    const auto& t_v = _input.vehicles[t_vehicle];
+    const auto t_travel_time = _sol_state.route_evals[t_vehicle].duration;
+
     is_normal_valid =
+      (t_travel_time <= t_v.max_travel_time + _normal_t_gain.duration) and
       target.is_valid_addition_for_capacity_inclusion(_input,
                                                       edge_delivery,
                                                       s_start,
@@ -176,6 +184,7 @@ bool OrOpt::is_valid() {
     // Reverse edge direction.
     auto s_reverse_start = s_route.rbegin() + s_route.size() - 2 - s_rank;
     is_reverse_valid =
+      (t_travel_time <= t_v.max_travel_time + _reversed_t_gain.duration) and
       target.is_valid_addition_for_capacity_inclusion(_input,
                                                       edge_delivery,
                                                       s_reverse_start,

--- a/src/problems/cvrp/operators/or_opt.cpp
+++ b/src/problems/cvrp/operators/or_opt.cpp
@@ -151,19 +151,18 @@ void OrOpt::compute_gain() {
 }
 
 bool OrOpt::is_valid() {
-  const auto& s_v = _input.vehicles[s_vehicle];
-  const auto s_travel_time = _sol_state.route_evals[s_vehicle].duration;
-  bool valid = (s_travel_time <= s_v.max_travel_time + s_gain.duration);
+  assert(_gain_upper_bound_computed);
 
   auto edge_pickup = _input.jobs[s_route[s_rank]].pickup +
                      _input.jobs[s_route[s_rank + 1]].pickup;
   auto edge_delivery = _input.jobs[s_route[s_rank]].delivery +
                        _input.jobs[s_route[s_rank + 1]].delivery;
 
-  valid = target.is_valid_addition_for_capacity(_input,
-                                                edge_pickup,
-                                                edge_delivery,
-                                                t_rank);
+  bool valid = is_valid_for_source_max_travel_time() &&
+               target.is_valid_addition_for_capacity(_input,
+                                                     edge_pickup,
+                                                     edge_delivery,
+                                                     t_rank);
 
   if (valid) {
     // Keep edge direction.

--- a/src/problems/cvrp/operators/or_opt.h
+++ b/src/problems/cvrp/operators/or_opt.h
@@ -18,7 +18,6 @@ namespace cvrp {
 class OrOpt : public ls::Operator {
 private:
   bool _gain_upper_bound_computed;
-  Eval _s_gain;
   Eval _normal_t_gain;
   Eval _reversed_t_gain;
 

--- a/src/problems/cvrp/operators/pd_shift.cpp
+++ b/src/problems/cvrp/operators/pd_shift.cpp
@@ -35,7 +35,6 @@ PDShift::PDShift(const Input& input,
              0),
     _s_p_rank(s_p_rank),
     _s_d_rank(s_d_rank),
-    _remove_gain(_sol_state.pd_gains[s_vehicle][_s_p_rank]),
     _valid(false) {
   assert(s_vehicle != t_vehicle);
   assert(s_route.size() >= 2);
@@ -43,21 +42,24 @@ PDShift::PDShift(const Input& input,
   assert(s_d_rank < s_route.size());
   assert(s_route.route[s_p_rank] + 1 == s_route.route[s_d_rank]);
 
+  s_gain = _sol_state.pd_gains[s_vehicle][_s_p_rank];
+  assert(_sol_state.route_evals[s_vehicle].duration <=
+         _input.vehicles[s_vehicle].max_travel_time + s_gain.duration);
   stored_gain = gain_threshold;
 }
 
 void PDShift::compute_gain() {
-  ls::RouteInsertion rs =
-    ls::compute_best_insertion_pd(_input,
-                                  _sol_state,
-                                  s_route[_s_p_rank],
-                                  t_vehicle,
-                                  target,
-                                  _remove_gain - stored_gain);
+  ls::RouteInsertion rs = ls::compute_best_insertion_pd(_input,
+                                                        _sol_state,
+                                                        s_route[_s_p_rank],
+                                                        t_vehicle,
+                                                        target,
+                                                        s_gain - stored_gain);
 
   if (rs.eval != NO_EVAL) {
     _valid = true;
-    stored_gain = _remove_gain - rs.eval;
+    t_gain = -rs.eval;
+    stored_gain = s_gain + t_gain;
     _best_t_p_rank = rs.pickup_rank;
     _best_t_d_rank = rs.delivery_rank;
   }

--- a/src/problems/cvrp/operators/pd_shift.h
+++ b/src/problems/cvrp/operators/pd_shift.h
@@ -19,7 +19,6 @@ class PDShift : public ls::Operator {
 protected:
   const Index _s_p_rank;
   const Index _s_d_rank;
-  const Eval _remove_gain;
   Index _best_t_p_rank;
   Index _best_t_d_rank;
   bool _valid;

--- a/src/problems/cvrp/operators/relocate.cpp
+++ b/src/problems/cvrp/operators/relocate.cpp
@@ -55,26 +55,14 @@ void Relocate::compute_gain() {
 
 bool Relocate::is_valid() {
   assert(gain_computed);
-
-  const auto& s_v = _input.vehicles[s_vehicle];
-  const auto s_travel_time = _sol_state.route_evals[s_vehicle].duration;
-  bool valid = (s_travel_time <= s_v.max_travel_time + s_gain.duration);
-
-  if (valid) {
-    const auto& t_v = _input.vehicles[t_vehicle];
-    const auto t_travel_time = _sol_state.route_evals[t_vehicle].duration;
-
-    valid = (t_travel_time <= t_v.max_travel_time + t_gain.duration);
-  }
-
-  valid =
-    valid &&
-    target.is_valid_addition_for_capacity(_input,
-                                          _input.jobs[s_route[s_rank]].pickup,
-                                          _input.jobs[s_route[s_rank]].delivery,
-                                          t_rank);
-
-  return valid;
+  return is_valid_for_source_max_travel_time() &&
+         is_valid_for_target_max_travel_time() &&
+         target
+           .is_valid_addition_for_capacity(_input,
+                                           _input.jobs[s_route[s_rank]].pickup,
+                                           _input.jobs[s_route[s_rank]]
+                                             .delivery,
+                                           t_rank);
 }
 
 void Relocate::apply() {

--- a/src/problems/cvrp/operators/reverse_two_opt.cpp
+++ b/src/problems/cvrp/operators/reverse_two_opt.cpp
@@ -156,6 +156,14 @@ bool ReverseTwoOpt::is_valid() {
                                                                  0,
                                                                  t_rank + 1);
 
+  const auto& s_v = _input.vehicles[s_vehicle];
+  const auto s_travel_time = _sol_state.route_evals[s_vehicle].duration;
+  valid = valid && (s_travel_time <= s_v.max_travel_time + s_gain.duration);
+
+  const auto& t_v = _input.vehicles[t_vehicle];
+  const auto t_travel_time = _sol_state.route_evals[t_vehicle].duration;
+  valid = valid && (t_travel_time <= t_v.max_travel_time + t_gain.duration);
+
   valid =
     valid && source.is_valid_addition_for_capacity_inclusion(_input,
                                                              t_delivery,

--- a/src/problems/cvrp/operators/reverse_two_opt.cpp
+++ b/src/problems/cvrp/operators/reverse_two_opt.cpp
@@ -47,7 +47,7 @@ void ReverseTwoOpt::compute_gain() {
   Index t_index = _input.jobs[t_route[t_rank]].index();
   Index last_s = _input.jobs[s_route.back()].index();
   Index first_t = _input.jobs[t_route.front()].index();
-  stored_gain = Eval();
+
   bool last_in_source = (s_rank == s_route.size() - 1);
   bool last_in_target = (t_rank == t_route.size() - 1);
 
@@ -56,25 +56,25 @@ void ReverseTwoOpt::compute_gain() {
   // t_rank, but reversed.
 
   // Add new source -> target edge.
-  stored_gain -= s_v.eval(s_index, t_index);
+  s_gain -= s_v.eval(s_index, t_index);
 
   // Cost of reversing target route portion. First remove forward cost
   // for beginning of target route as seen from target vehicle. Then
   // add backward cost for beginning of target route as seen from
   // source vehicle since it's the new source route end.
-  stored_gain += _sol_state.fwd_costs[t_vehicle][t_vehicle][t_rank];
-  stored_gain -= _sol_state.bwd_costs[t_vehicle][s_vehicle][t_rank];
+  t_gain += _sol_state.fwd_costs[t_vehicle][t_vehicle][t_rank];
+  s_gain -= _sol_state.bwd_costs[t_vehicle][s_vehicle][t_rank];
 
   if (!last_in_target) {
     // Spare next edge in target route.
     Index next_index = _input.jobs[t_route[t_rank + 1]].index();
-    stored_gain += t_v.eval(t_index, next_index);
+    t_gain += t_v.eval(t_index, next_index);
   }
 
   if (!last_in_source) {
     // Spare next edge in source route.
     Index next_index = _input.jobs[s_route[s_rank + 1]].index();
-    stored_gain += s_v.eval(s_index, next_index);
+    s_gain += s_v.eval(s_index, next_index);
 
     // Part of source route is moved to target route.
     Index next_s_index = _input.jobs[s_route[s_rank + 1]].index();
@@ -84,55 +84,56 @@ void ReverseTwoOpt::compute_gain() {
     // (subtracting intermediate cost to overall cost). Then add
     // backward cost for end of source route as seen from target
     // vehicle since it's the new target route start.
-    stored_gain += _sol_state.fwd_costs[s_vehicle][s_vehicle].back();
-    stored_gain -= _sol_state.fwd_costs[s_vehicle][s_vehicle][s_rank + 1];
-    stored_gain -= _sol_state.bwd_costs[s_vehicle][t_vehicle].back();
-    stored_gain += _sol_state.bwd_costs[s_vehicle][t_vehicle][s_rank + 1];
+    s_gain += _sol_state.fwd_costs[s_vehicle][s_vehicle].back();
+    s_gain -= _sol_state.fwd_costs[s_vehicle][s_vehicle][s_rank + 1];
+    t_gain -= _sol_state.bwd_costs[s_vehicle][t_vehicle].back();
+    t_gain += _sol_state.bwd_costs[s_vehicle][t_vehicle][s_rank + 1];
 
     if (last_in_target) {
       if (t_v.has_end()) {
         // Handle target route new end.
         auto end_t = t_v.end.value().index();
-        stored_gain += t_v.eval(t_index, end_t);
-        stored_gain -= t_v.eval(next_s_index, end_t);
+        t_gain += t_v.eval(t_index, end_t);
+        t_gain -= t_v.eval(next_s_index, end_t);
       }
     } else {
       // Add new target -> source edge.
       Index next_t_index = _input.jobs[t_route[t_rank + 1]].index();
-      stored_gain -= t_v.eval(next_s_index, next_t_index);
+      t_gain -= t_v.eval(next_s_index, next_t_index);
     }
   }
 
   if (s_v.has_end()) {
     // Update cost to source end because last job changed.
     auto end_s = s_v.end.value().index();
-    stored_gain += s_v.eval(last_s, end_s);
-    stored_gain -= s_v.eval(first_t, end_s);
+    s_gain += s_v.eval(last_s, end_s);
+    s_gain -= s_v.eval(first_t, end_s);
   }
 
   if (t_v.has_start()) {
     // Spare cost from target start because first job changed.
     auto start_t = t_v.start.value().index();
-    stored_gain += t_v.eval(start_t, first_t);
+    t_gain += t_v.eval(start_t, first_t);
     if (!last_in_source) {
-      stored_gain -= t_v.eval(start_t, last_s);
+      t_gain -= t_v.eval(start_t, last_s);
     } else {
       // No job from source route actually swapped to target route.
       if (!last_in_target) {
         // Going straight from start to next job in target route.
         Index next_index = _input.jobs[t_route[t_rank + 1]].index();
-        stored_gain -= t_v.eval(start_t, next_index);
+        t_gain -= t_v.eval(start_t, next_index);
       } else {
         // Emptying the whole target route here, so also gaining cost
         // to end if it exists.
         if (t_v.has_end()) {
           auto end_t = t_v.end.value().index();
-          stored_gain += t_v.eval(t_index, end_t);
+          t_gain += t_v.eval(t_index, end_t);
         }
       }
     }
   }
 
+  stored_gain = s_gain + t_gain;
   gain_computed = true;
 }
 

--- a/src/problems/cvrp/operators/route_exchange.cpp
+++ b/src/problems/cvrp/operators/route_exchange.cpp
@@ -39,58 +39,55 @@ void RouteExchange::compute_gain() {
   const auto& s_v = _input.vehicles[s_vehicle];
   const auto& t_v = _input.vehicles[t_vehicle];
 
-  Eval new_cost;
-  Eval previous_cost;
-
   if (s_route.size() > 0) {
     // Handle changes at route start.
     auto first_s_index = _input.jobs[s_route.front()].index();
     if (s_v.has_start()) {
-      previous_cost += s_v.eval(s_v.start.value().index(), first_s_index);
+      s_gain += s_v.eval(s_v.start.value().index(), first_s_index);
     }
     if (t_v.has_start()) {
-      new_cost += t_v.eval(t_v.start.value().index(), first_s_index);
+      t_gain -= t_v.eval(t_v.start.value().index(), first_s_index);
     }
 
     // Handle changes at route end.
     auto last_s_index = _input.jobs[s_route.back()].index();
     if (s_v.has_end()) {
-      previous_cost += s_v.eval(last_s_index, s_v.end.value().index());
+      s_gain += s_v.eval(last_s_index, s_v.end.value().index());
     }
     if (t_v.has_end()) {
-      new_cost += t_v.eval(last_s_index, t_v.end.value().index());
+      t_gain -= t_v.eval(last_s_index, t_v.end.value().index());
     }
 
     // Handle inner cost change for route.
-    previous_cost += _sol_state.fwd_costs[s_vehicle][s_vehicle].back();
-    new_cost += _sol_state.fwd_costs[s_vehicle][t_vehicle].back();
+    s_gain += _sol_state.fwd_costs[s_vehicle][s_vehicle].back();
+    t_gain -= _sol_state.fwd_costs[s_vehicle][t_vehicle].back();
   }
 
   if (t_route.size() > 0) {
     // Handle changes at route start.
     auto first_t_index = _input.jobs[t_route.front()].index();
     if (t_v.has_start()) {
-      previous_cost += t_v.eval(t_v.start.value().index(), first_t_index);
+      t_gain += t_v.eval(t_v.start.value().index(), first_t_index);
     }
     if (s_v.has_start()) {
-      new_cost += s_v.eval(s_v.start.value().index(), first_t_index);
+      s_gain -= s_v.eval(s_v.start.value().index(), first_t_index);
     }
 
     // Handle changes at route end.
     auto last_t_index = _input.jobs[t_route.back()].index();
     if (t_v.has_end()) {
-      previous_cost += t_v.eval(last_t_index, t_v.end.value().index());
+      t_gain += t_v.eval(last_t_index, t_v.end.value().index());
     }
     if (s_v.has_end()) {
-      new_cost += s_v.eval(last_t_index, s_v.end.value().index());
+      s_gain -= s_v.eval(last_t_index, s_v.end.value().index());
     }
 
     // Handle inner cost change for route.
-    previous_cost += _sol_state.fwd_costs[t_vehicle][t_vehicle].back();
-    new_cost += _sol_state.fwd_costs[t_vehicle][s_vehicle].back();
+    t_gain += _sol_state.fwd_costs[t_vehicle][t_vehicle].back();
+    s_gain -= _sol_state.fwd_costs[t_vehicle][s_vehicle].back();
   }
 
-  stored_gain = previous_cost - new_cost;
+  stored_gain = s_gain + t_gain;
   gain_computed = true;
 }
 

--- a/src/problems/cvrp/operators/route_exchange.cpp
+++ b/src/problems/cvrp/operators/route_exchange.cpp
@@ -92,7 +92,11 @@ void RouteExchange::compute_gain() {
 }
 
 bool RouteExchange::is_valid() {
-  return (source.max_load() <= _input.vehicles[t_vehicle].capacity) &&
+  assert(gain_computed);
+
+  return is_valid_for_source_max_travel_time() &&
+         is_valid_for_target_max_travel_time() &&
+         (source.max_load() <= _input.vehicles[t_vehicle].capacity) &&
          (target.max_load() <= _input.vehicles[s_vehicle].capacity);
 }
 

--- a/src/problems/cvrp/operators/two_opt.cpp
+++ b/src/problems/cvrp/operators/two_opt.cpp
@@ -47,7 +47,7 @@ void TwoOpt::compute_gain() {
   Index t_index = _input.jobs[t_route[t_rank]].index();
   Index last_s = _input.jobs[s_route.back()].index();
   Index last_t = _input.jobs[t_route.back()].index();
-  stored_gain = Eval();
+
   Index new_last_s = last_t;
   Index new_last_t = last_s;
 
@@ -59,31 +59,31 @@ void TwoOpt::compute_gain() {
   // the route. Otherwise remember that last job does not change.
   if (s_rank < s_route.size() - 1) {
     Index next_index = _input.jobs[s_route[s_rank + 1]].index();
-    stored_gain += s_v.eval(s_index, next_index);
-    stored_gain -= t_v.eval(t_index, next_index);
+    s_gain += s_v.eval(s_index, next_index);
+    t_gain -= t_v.eval(t_index, next_index);
 
     // Account for the change in cost across vehicles for the end of
     // source route. Cost of remaining route retrieved by subtracting
     // intermediate cost to overall cost.
-    stored_gain += _sol_state.fwd_costs[s_vehicle][s_vehicle].back();
-    stored_gain -= _sol_state.fwd_costs[s_vehicle][s_vehicle][s_rank + 1];
-    stored_gain -= _sol_state.fwd_costs[s_vehicle][t_vehicle].back();
-    stored_gain += _sol_state.fwd_costs[s_vehicle][t_vehicle][s_rank + 1];
+    s_gain += _sol_state.fwd_costs[s_vehicle][s_vehicle].back();
+    s_gain -= _sol_state.fwd_costs[s_vehicle][s_vehicle][s_rank + 1];
+    t_gain -= _sol_state.fwd_costs[s_vehicle][t_vehicle].back();
+    t_gain += _sol_state.fwd_costs[s_vehicle][t_vehicle][s_rank + 1];
   } else {
     new_last_t = t_index;
   }
   if (t_rank < t_route.size() - 1) {
     Index next_index = _input.jobs[t_route[t_rank + 1]].index();
-    stored_gain += t_v.eval(t_index, next_index);
-    stored_gain -= s_v.eval(s_index, next_index);
+    t_gain += t_v.eval(t_index, next_index);
+    s_gain -= s_v.eval(s_index, next_index);
 
     // Account for the change in cost across vehicles for the end of
     // target route. Cost of remaining route retrieved by subtracting
     // intermediate cost to overall cost.
-    stored_gain += _sol_state.fwd_costs[t_vehicle][t_vehicle].back();
-    stored_gain -= _sol_state.fwd_costs[t_vehicle][t_vehicle][t_rank + 1];
-    stored_gain -= _sol_state.fwd_costs[t_vehicle][s_vehicle].back();
-    stored_gain += _sol_state.fwd_costs[t_vehicle][s_vehicle][t_rank + 1];
+    t_gain += _sol_state.fwd_costs[t_vehicle][t_vehicle].back();
+    t_gain -= _sol_state.fwd_costs[t_vehicle][t_vehicle][t_rank + 1];
+    s_gain -= _sol_state.fwd_costs[t_vehicle][s_vehicle].back();
+    s_gain += _sol_state.fwd_costs[t_vehicle][s_vehicle][t_rank + 1];
   } else {
     new_last_s = s_index;
   }
@@ -92,15 +92,16 @@ void TwoOpt::compute_gain() {
   // different or none.
   if (s_v.has_end()) {
     auto end_s = s_v.end.value().index();
-    stored_gain += s_v.eval(last_s, end_s);
-    stored_gain -= s_v.eval(new_last_s, end_s);
+    s_gain += s_v.eval(last_s, end_s);
+    s_gain -= s_v.eval(new_last_s, end_s);
   }
   if (t_v.has_end()) {
     auto end_t = t_v.end.value().index();
-    stored_gain += t_v.eval(last_t, end_t);
-    stored_gain -= t_v.eval(new_last_t, end_t);
+    t_gain += t_v.eval(last_t, end_t);
+    t_gain -= t_v.eval(new_last_t, end_t);
   }
 
+  stored_gain = s_gain + t_gain;
   gain_computed = true;
 }
 

--- a/src/problems/cvrp/operators/two_opt.cpp
+++ b/src/problems/cvrp/operators/two_opt.cpp
@@ -106,44 +106,40 @@ void TwoOpt::compute_gain() {
 }
 
 bool TwoOpt::is_valid() {
+  assert(gain_computed);
+
   const auto& t_delivery = target.bwd_deliveries(t_rank);
   const auto& t_pickup = target.bwd_pickups(t_rank);
-
-  bool valid = source.is_valid_addition_for_capacity_margins(_input,
-                                                             t_pickup,
-                                                             t_delivery,
-                                                             s_rank + 1,
-                                                             s_route.size());
 
   const auto& s_delivery = source.bwd_deliveries(s_rank);
   const auto& s_pickup = source.bwd_pickups(s_rank);
 
-  valid =
-    valid && target.is_valid_addition_for_capacity_margins(_input,
-                                                           s_pickup,
-                                                           s_delivery,
+  return is_valid_for_source_max_travel_time() &&
+         is_valid_for_target_max_travel_time() &&
+         source.is_valid_addition_for_capacity_margins(_input,
+                                                       t_pickup,
+                                                       t_delivery,
+                                                       s_rank + 1,
+                                                       s_route.size()) &&
+         target.is_valid_addition_for_capacity_margins(_input,
+                                                       s_pickup,
+                                                       s_delivery,
+                                                       t_rank + 1,
+                                                       t_route.size()) &&
+         source.is_valid_addition_for_capacity_inclusion(_input,
+                                                         t_delivery,
+                                                         t_route.begin() +
                                                            t_rank + 1,
-                                                           t_route.size());
-
-  valid =
-    valid && source.is_valid_addition_for_capacity_inclusion(_input,
-                                                             t_delivery,
-                                                             t_route.begin() +
-                                                               t_rank + 1,
-                                                             t_route.end(),
-                                                             s_rank + 1,
-                                                             s_route.size());
-
-  valid =
-    valid && target.is_valid_addition_for_capacity_inclusion(_input,
-                                                             s_delivery,
-                                                             s_route.begin() +
-                                                               s_rank + 1,
-                                                             s_route.end(),
-                                                             t_rank + 1,
-                                                             t_route.size());
-
-  return valid;
+                                                         t_route.end(),
+                                                         s_rank + 1,
+                                                         s_route.size()) &&
+         target.is_valid_addition_for_capacity_inclusion(_input,
+                                                         s_delivery,
+                                                         s_route.begin() +
+                                                           s_rank + 1,
+                                                         s_route.end(),
+                                                         t_rank + 1,
+                                                         t_route.size());
 }
 
 void TwoOpt::apply() {

--- a/src/problems/cvrp/operators/unassigned_exchange.cpp
+++ b/src/problems/cvrp/operators/unassigned_exchange.cpp
@@ -59,9 +59,6 @@ void UnassignedExchange::compute_gain() {
 
   const Index u_index = _input.jobs[_u].index();
 
-  Eval s_gain;
-  Eval t_gain;
-
   if (t_rank == s_rank) {
     // Removed job is replaced by the unassigned one so there is no
     // new edge in place of removal.
@@ -69,34 +66,28 @@ void UnassignedExchange::compute_gain() {
 
     // No old edge to remove when adding unassigned job in place of
     // removed job.
-    Eval previous_cost;
-    Eval next_cost;
-
     if (t_rank == 0) {
       if (v.has_start()) {
-        previous_cost = v.eval(v.start.value().index(), u_index);
+        s_gain -= v.eval(v.start.value().index(), u_index);
       }
     } else {
-      previous_cost = v.eval(_input.jobs[s_route[t_rank - 1]].index(), u_index);
+      s_gain -= v.eval(_input.jobs[s_route[t_rank - 1]].index(), u_index);
     }
 
     if (t_rank == s_route.size() - 1) {
       if (v.has_end()) {
-        next_cost = v.eval(u_index, v.end.value().index());
+        s_gain -= v.eval(u_index, v.end.value().index());
       }
     } else {
-      next_cost = v.eval(u_index, _input.jobs[s_route[s_rank + 1]].index());
+      s_gain -= v.eval(u_index, _input.jobs[s_route[s_rank + 1]].index());
     }
-
-    t_gain = -previous_cost - next_cost;
   } else {
     // No common edge so both gains can be computed independently.
-    s_gain = _sol_state.node_gains[s_vehicle][s_rank];
-
-    t_gain = -utils::addition_cost(_input, _u, v, s_route, t_rank);
+    s_gain = _sol_state.node_gains[s_vehicle][s_rank] -
+             utils::addition_cost(_input, _u, v, s_route, t_rank);
   }
 
-  stored_gain = s_gain + t_gain;
+  stored_gain = s_gain;
   gain_computed = true;
 }
 
@@ -124,6 +115,18 @@ bool UnassignedExchange::is_valid() {
                                                           _moved_jobs.end(),
                                                           _first_rank,
                                                           _last_rank);
+
+  if (valid) {
+    // Check validity with regard to max_travel_time, requires valid
+    // gain value.
+    if (!gain_computed) {
+      // May happen that we don't check gain before validity if priority
+      // is improved.
+      this->compute_gain();
+    }
+
+    valid = is_valid_for_source_max_travel_time();
+  }
 
   return valid;
 }

--- a/src/problems/vrptw/operators/pd_shift.cpp
+++ b/src/problems/vrptw/operators/pd_shift.cpp
@@ -50,17 +50,17 @@ void PDShift::compute_gain() {
     return;
   }
 
-  ls::RouteInsertion rs =
-    ls::compute_best_insertion_pd(_input,
-                                  _sol_state,
-                                  s_route[_s_p_rank],
-                                  t_vehicle,
-                                  _tw_t_route,
-                                  _remove_gain - stored_gain);
+  ls::RouteInsertion rs = ls::compute_best_insertion_pd(_input,
+                                                        _sol_state,
+                                                        s_route[_s_p_rank],
+                                                        t_vehicle,
+                                                        _tw_t_route,
+                                                        s_gain - stored_gain);
 
   if (rs.eval != NO_EVAL) {
     _valid = true;
-    stored_gain = _remove_gain - rs.eval;
+    t_gain = -rs.eval;
+    stored_gain = s_gain + t_gain;
     _best_t_p_rank = rs.pickup_rank;
     _best_t_d_rank = rs.delivery_rank;
   }

--- a/src/structures/vroom/solution_indicators.h
+++ b/src/structures/vroom/solution_indicators.h
@@ -20,11 +20,11 @@ namespace utils {
 template <class Route> struct SolutionIndicators {
   Priority priority_sum;
   unsigned assigned;
-  Cost cost;
+  Eval eval;
   unsigned used_vehicles;
 
   SolutionIndicators()
-    : priority_sum(0), assigned(0), cost(0), used_vehicles(0) {
+    : priority_sum(0), assigned(0), eval(), used_vehicles(0) {
   }
 
   SolutionIndicators(const Input& input, const std::vector<Route>& sol)
@@ -34,7 +34,7 @@ template <class Route> struct SolutionIndicators {
       priority_sum += utils::priority_sum_for_route(input, r.route);
       assigned += r.route.size();
 
-      cost += utils::route_cost_for_vehicle(input, v_rank, r.route);
+      eval += utils::route_eval_for_vehicle(input, v_rank, r.route);
       ++v_rank;
 
       if (!r.empty()) {
@@ -53,11 +53,17 @@ template <class Route> struct SolutionIndicators {
         return true;
       }
       if (lhs.assigned == rhs.assigned) {
-        if (lhs.cost < rhs.cost) {
+        if (lhs.eval.cost < rhs.eval.cost) {
           return true;
         }
-        if (lhs.cost == rhs.cost and lhs.used_vehicles < rhs.used_vehicles) {
-          return true;
+        if (lhs.eval.cost == rhs.eval.cost) {
+          if (lhs.eval.duration < rhs.eval.duration) {
+            return true;
+          }
+          if (lhs.eval.duration == rhs.eval.duration and
+              lhs.used_vehicles < rhs.used_vehicles) {
+            return true;
+          }
         }
       }
     }

--- a/src/structures/vroom/solution_state.cpp
+++ b/src/structures/vroom/solution_state.cpp
@@ -38,12 +38,8 @@ SolutionState::SolutionState(const Input& input)
     insertion_ranks_begin(_nb_vehicles),
     insertion_ranks_end(_nb_vehicles),
     weak_insertion_ranks_begin(_nb_vehicles),
-    weak_insertion_ranks_end(_nb_vehicles)
-#ifndef NDEBUG
-    ,
-    route_evals(_nb_vehicles)
-#endif
-{
+    weak_insertion_ranks_end(_nb_vehicles),
+    route_evals(_nb_vehicles) {
 }
 
 template <class Route> void SolutionState::setup(const Route& r, Index v) {
@@ -54,9 +50,7 @@ template <class Route> void SolutionState::setup(const Route& r, Index v) {
   set_pd_matching_ranks(r.route, v);
   set_pd_gains(r.route, v);
   set_insertion_ranks(r, v);
-#ifndef NDEBUG
   update_route_eval(r.route, v);
-#endif
 }
 
 template <class Solution> void SolutionState::setup(const Solution& sol) {
@@ -615,12 +609,10 @@ void SolutionState::update_cheapest_job_rank_in_routes(
   }
 }
 
-#ifndef NDEBUG
 void SolutionState::update_route_eval(const std::vector<Index>& route,
                                       Index v) {
   route_evals[v] = route_eval_for_vehicle(_input, v, route);
 }
-#endif
 
 template void SolutionState::setup(const std::vector<RawRoute>&);
 template void SolutionState::setup(const std::vector<TWRoute>&);

--- a/src/structures/vroom/solution_state.cpp
+++ b/src/structures/vroom/solution_state.cpp
@@ -41,7 +41,7 @@ SolutionState::SolutionState(const Input& input)
     weak_insertion_ranks_end(_nb_vehicles)
 #ifndef NDEBUG
     ,
-    route_costs(_nb_vehicles)
+    route_evals(_nb_vehicles)
 #endif
 {
 }
@@ -55,7 +55,7 @@ template <class Route> void SolutionState::setup(const Route& r, Index v) {
   set_pd_gains(r.route, v);
   set_insertion_ranks(r, v);
 #ifndef NDEBUG
-  update_route_cost(r.route, v);
+  update_route_eval(r.route, v);
 #endif
 }
 
@@ -616,9 +616,9 @@ void SolutionState::update_cheapest_job_rank_in_routes(
 }
 
 #ifndef NDEBUG
-void SolutionState::update_route_cost(const std::vector<Index>& route,
+void SolutionState::update_route_eval(const std::vector<Index>& route,
                                       Index v) {
-  route_costs[v] = route_cost_for_vehicle(_input, v, route);
+  route_evals[v] = route_eval_for_vehicle(_input, v, route);
 }
 #endif
 

--- a/src/structures/vroom/solution_state.h
+++ b/src/structures/vroom/solution_state.h
@@ -113,7 +113,7 @@ public:
 
 #ifndef NDEBUG
   // Only used for assertion checks in debug mode.
-  std::vector<Cost> route_costs;
+  std::vector<Eval> route_evals;
 #endif
 
   SolutionState(const Input& input);
@@ -143,7 +143,7 @@ public:
   void set_insertion_ranks(const TWRoute& r, Index v);
 
 #ifndef NDEBUG
-  void update_route_cost(const std::vector<Index>& route, Index v);
+  void update_route_eval(const std::vector<Index>& route, Index v);
 #endif
 };
 

--- a/src/structures/vroom/solution_state.h
+++ b/src/structures/vroom/solution_state.h
@@ -111,10 +111,8 @@ public:
   std::vector<std::vector<Index>> weak_insertion_ranks_begin;
   std::vector<std::vector<Index>> weak_insertion_ranks_end;
 
-#ifndef NDEBUG
   // Only used for assertion checks in debug mode.
   std::vector<Eval> route_evals;
-#endif
 
   SolutionState(const Input& input);
 
@@ -142,9 +140,7 @@ public:
   void set_insertion_ranks(const RawRoute& r, Index v);
   void set_insertion_ranks(const TWRoute& r, Index v);
 
-#ifndef NDEBUG
   void update_route_eval(const std::vector<Index>& route, Index v);
-#endif
 };
 
 } // namespace utils

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -25,6 +25,7 @@ Vehicle::Vehicle(Id id,
                  const std::string& description,
                  double speed_factor,
                  const size_t max_tasks,
+                 const Duration max_travel_time,
                  const std::vector<VehicleStep>& input_steps)
   : id(id),
     start(start),
@@ -36,7 +37,8 @@ Vehicle::Vehicle(Id id,
     breaks(breaks),
     description(description),
     cost_wrapper(speed_factor),
-    max_tasks(max_tasks) {
+    max_tasks(max_tasks),
+    max_travel_time(max_travel_time) {
   if (!static_cast<bool>(start) and !static_cast<bool>(end)) {
     throw InputException("No start or end specified for vehicle " +
                          std::to_string(id) + '.');

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -36,7 +36,7 @@ struct Vehicle {
   const std::string description;
   CostWrapper cost_wrapper;
   size_t max_tasks;
-  Duration max_travel_time;
+  const Duration max_travel_time;
   std::vector<VehicleStep> steps;
   std::unordered_map<Id, Index> break_id_to_rank;
 

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -36,6 +36,7 @@ struct Vehicle {
   const std::string description;
   CostWrapper cost_wrapper;
   size_t max_tasks;
+  Duration max_travel_time;
   std::vector<VehicleStep> steps;
   std::unordered_map<Id, Index> break_id_to_rank;
 
@@ -51,6 +52,7 @@ struct Vehicle {
     const std::string& description = "",
     double speed_factor = 1.,
     const size_t max_tasks = std::numeric_limits<size_t>::max(),
+    const Duration max_travel_time = std::numeric_limits<Duration>::max(),
     const std::vector<VehicleStep>& input_steps = std::vector<VehicleStep>());
 
   bool has_start() const;

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -492,6 +492,7 @@ inline Solution format_solution(const Input& input,
     steps.back().arrival = ETA;
 
     assert(expected_delivery_ranks.empty());
+    assert(eval.duration <= v.max_travel_time);
 
     routes.emplace_back(v.id,
                         std::move(steps),
@@ -886,6 +887,7 @@ inline Route format_route(const Input& input,
          steps.front().arrival + duration + setup + service + forward_wt);
 
   assert(expected_delivery_ranks.empty());
+  assert(eval.duration <= v.max_travel_time);
 
   return Route(v.id,
                std::move(steps),

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -296,30 +296,30 @@ inline Priority priority_sum_for_route(const Input& input,
                          });
 }
 
-inline Cost route_cost_for_vehicle(const Input& input,
+inline Eval route_eval_for_vehicle(const Input& input,
                                    Index vehicle_rank,
                                    const std::vector<Index>& route) {
   const auto& v = input.vehicles[vehicle_rank];
-  Cost cost = 0;
+  Eval eval;
 
   if (route.size() > 0) {
     if (v.has_start()) {
-      cost +=
-        v.cost(v.start.value().index(), input.jobs[route.front()].index());
+      eval +=
+        v.eval(v.start.value().index(), input.jobs[route.front()].index());
     }
 
     Index previous = route.front();
     for (auto it = ++route.cbegin(); it != route.cend(); ++it) {
-      cost += v.cost(input.jobs[previous].index(), input.jobs[*it].index());
+      eval += v.eval(input.jobs[previous].index(), input.jobs[*it].index());
       previous = *it;
     }
 
     if (v.has_end()) {
-      cost += v.cost(input.jobs[route.back()].index(), v.end.value().index());
+      eval += v.eval(input.jobs[route.back()].index(), v.end.value().index());
     }
   }
 
-  return cost;
+  return eval;
 }
 
 inline void check_precedence(const Input& input,

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -105,7 +105,7 @@ inline Duration get_duration(const rapidjson::Value& object, const char* key) {
   return duration;
 }
 
-inline Duration get_priority(const rapidjson::Value& object) {
+inline Priority get_priority(const rapidjson::Value& object) {
   Priority priority = 0;
   if (object.HasMember("priority")) {
     if (!object["priority"].IsUint()) {
@@ -125,6 +125,17 @@ inline size_t get_max_tasks(const rapidjson::Value& object) {
     max_tasks = object["max_tasks"].GetUint();
   }
   return max_tasks;
+}
+
+inline Duration get_max_travel_time(const rapidjson::Value& object) {
+  Duration max_travel_time = std::numeric_limits<Duration>::max();
+  if (object.HasMember("max_travel_time")) {
+    if (!object["max_travel_time"].IsUint()) {
+      throw InputException("Invalid max_travel_time value.");
+    }
+    max_travel_time = object["max_travel_time"].GetUint();
+  }
+  return max_travel_time;
 }
 
 inline void check_id(const rapidjson::Value& v, const std::string& type) {
@@ -391,6 +402,7 @@ inline Vehicle get_vehicle(const rapidjson::Value& json_vehicle,
                  get_string(json_vehicle, "description"),
                  get_double(json_vehicle, "speed_factor"),
                  get_max_tasks(json_vehicle),
+                 get_max_travel_time(json_vehicle),
                  get_vehicle_steps(json_vehicle));
 }
 


### PR DESCRIPTION
## Issue

This PR aims at implementing #273, relying on the previous refactoring from #752.

## Tasks

 - [x] Store `max_travel_time` at vehicle level
 - [x] Parse new key in json input
 - [x] Make sure heuristic solutions comply with the new constraint
 - [x] Update `CrossExchange` validity check
 - [x] Update `IntraOrOpt` validity check
 - [x] Update `OrOpt` validity check
 - [x] Update `RouteExchange` validity check
 - [x] Update `IntraCrossExchange` validity check
 - [x] Update `IntraRelocate` validity check
 - [x] Update `PdShift` validity check
 - [x] Update `SwapStar` validity check
 - [x] Update `IntraExchange` validity check
 - [x] Update `IntraTwoOpt` validity check
 - [x] Update `Relocate` validity check
 - [x] Update `TwoOpt` validity check
 - [x] Update `IntraMixedExchange` validity check
 - [x] Update `MixedExchange` validity check
 - [x] Update `ReverseTwoOpt` validity check
 - [x] Update `UnassignedExchange` validity check
 - [x] Make sure `remove_from_route` comply with the new constraint
 - [x] Make sure `try_job_additions` comply with the new constraint
 - [x] Update `docs/API.md`
 - [x] Update `CHANGELOG.md`
 - [x] review
