### PR TITLE
decouple costs factor from speed factor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,9 @@ with the scope or aim of the project.
 
 ### Miscellaneous
 
-- Custom types use upper CamelCase (e.g. `LocalSearch`)
-- Variables and functions use lowercase with underscore (e.g. `addition_cost`)
-- Non-static private data members are prefixed with an underscore (e.g. `_matrix`)
+- Custom types use **PascalCase**
+- Variables and functions use **snake_case**
+- Non-static private data members use underscore-prefixed **_snake_case**
 
 ### Namespaces
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -114,6 +114,7 @@ A `vehicle` object has the following properties:
 | [`time_window`] | a `time_window` object describing working hours |
 | [`breaks`] | an array of `break` objects |
 | [`speed_factor`] | a double value in the range `(0, 5]` used to scale **all** vehicle travel times (defaults to 1.), the respected precision is limited to two digits after the decimal point |
+| [`costs_factor`] | a double value in the range `(0, 5]` used to scale **all** vehicle costs (defaults to 1.), the respected precision is limited to two digits after the decimal point |
 | [`max_tasks`] | an integer defining the maximum number of tasks in a route for this vehicle |
 | [`steps`] | an array of `vehicle_step` objects describing a custom route for this vehicle |
 

--- a/docs/example_2.json
+++ b/docs/example_2.json
@@ -3,7 +3,9 @@
     {
       "id":0,
       "start_index":0,
-      "end_index":3
+      "end_index":3,
+      "speed_factor": 0.5,
+      "costs_factor": 2
     }
   ],
   "jobs": [

--- a/docs/example_2_sol.json
+++ b/docs/example_2_sol.json
@@ -1,24 +1,28 @@
 {
   "code": 0,
   "summary": {
-    "cost": 5461,
+    "cost": 10922,
     "routes": 1,
     "unassigned": 0,
     "setup": 0,
     "service": 0,
-    "duration": 5461,
+    "duration": 10922,
     "waiting_time": 0,
     "priority": 0,
-    "violations": []
+    "violations": [],
+    "computing_times": {
+      "loading": 0,
+      "solving": 1
+    }
   },
   "unassigned": [],
   "routes": [
     {
       "vehicle": 0,
-      "cost": 5461,
+      "cost": 10922,
       "setup": 0,
       "service": 0,
-      "duration": 5461,
+      "duration": 10922,
       "waiting_time": 0,
       "priority": 0,
       "steps": [
@@ -34,26 +38,26 @@
         },
         {
           "type": "job",
-          "id": 1414,
           "location_index": 1,
+          "id": 1414,
           "setup": 0,
           "service": 0,
           "waiting_time": 0,
           "job": 1414,
-          "arrival": 2104,
-          "duration": 2104,
+          "arrival": 4208,
+          "duration": 4208,
           "violations": []
         },
         {
           "type": "job",
-          "id": 1515,
           "location_index": 2,
+          "id": 1515,
           "setup": 0,
           "service": 0,
           "waiting_time": 0,
           "job": 1515,
-          "arrival": 4359,
-          "duration": 4359,
+          "arrival": 8718,
+          "duration": 8718,
           "violations": []
         },
         {
@@ -62,8 +66,8 @@
           "setup": 0,
           "service": 0,
           "waiting_time": 0,
-          "arrival": 5461,
-          "duration": 5461,
+          "arrival": 10922,
+          "duration": 10922,
           "violations": []
         }
       ],

--- a/src/structures/vroom/cost_wrapper.cpp
+++ b/src/structures/vroom/cost_wrapper.cpp
@@ -13,22 +13,22 @@ All rights reserved (see LICENSE).
 
 namespace vroom {
 
-CostWrapper::CostWrapper(double speed_factor)
+CostWrapper::CostWrapper(double speed_factor, double costs_factor)
   : discrete_duration_factor(std::round(1 / speed_factor * DIVISOR)),
-    discrete_cost_factor(std::round(1 / speed_factor * DIVISOR)) {
+    discrete_costs_factor(std::round(costs_factor * DIVISOR)) {
   if (speed_factor <= 0 || speed_factor > MAX_SPEED_FACTOR) {
     throw InputException("Invalid speed factor: " +
                          std::to_string(speed_factor));
+  }
+  if (costs_factor <= 0 || costs_factor > MAX_SPEED_FACTOR) {
+    throw InputException("Invalid costs factor: " +
+                         std::to_string(costs_factor));
   }
 }
 
 void CostWrapper::set_durations_matrix(const Matrix<Duration>* matrix) {
   duration_matrix_size = matrix->size();
   duration_data = (*matrix)[0];
-}
-
-void CostWrapper::set_costs_factor(double cost_factor) {
-  discrete_cost_factor = std::round(cost_factor * DIVISOR);
 }
 
 void CostWrapper::set_costs_matrix(const Matrix<Cost>* matrix) {

--- a/src/structures/vroom/cost_wrapper.h
+++ b/src/structures/vroom/cost_wrapper.h
@@ -22,15 +22,14 @@ struct CostWrapper {
   std::size_t duration_matrix_size;
   const Duration* duration_data;
 
-  uint32_t discrete_cost_factor;
+  const uint32_t discrete_costs_factor;
   std::size_t cost_matrix_size;
   const Cost* cost_data;
 
-  CostWrapper(double speed_factor);
+  CostWrapper(double speed_factor, double costs_factor);
 
   void set_durations_matrix(const Matrix<Duration>* matrix);
 
-  void set_costs_factor(double cost_factor);
   void set_costs_matrix(const Matrix<Cost>* matrix);
 
   Duration duration(Index i, Index j) const {
@@ -40,7 +39,7 @@ struct CostWrapper {
 
   Cost cost(Index i, Index j) const {
     Cost c = cost_data[i * cost_matrix_size + j];
-    return (c * discrete_cost_factor) / DIVISOR;
+    return (c * discrete_costs_factor) / DIVISOR;
   }
 };
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -551,8 +551,6 @@ void Input::set_vehicles_costs() {
 
     auto c_m = _costs_matrices.find(vehicle.profile);
     if (c_m != _costs_matrices.end()) {
-      // No fancy scaling for costs, use plain custom costs matrix.
-      vehicle.cost_wrapper.set_costs_factor(1.);
       vehicle.cost_wrapper.set_costs_matrix(&(c_m->second));
     } else {
       vehicle.cost_wrapper.set_costs_matrix(&(d_m->second));

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -108,7 +108,9 @@ bool Vehicle::has_same_locations(const Vehicle& other) const {
 bool Vehicle::has_same_profile(const Vehicle& other) const {
   return (this->profile == other.profile) and
          (this->cost_wrapper.discrete_duration_factor ==
-          other.cost_wrapper.discrete_duration_factor);
+          other.cost_wrapper.discrete_duration_factor) and
+         (this->cost_wrapper.discrete_costs_factor ==
+          other.cost_wrapper.discrete_costs_factor);
 }
 
 Duration Vehicle::available_duration() const {

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -24,6 +24,7 @@ Vehicle::Vehicle(Id id,
                  const std::vector<Break>& breaks,
                  const std::string& description,
                  double speed_factor,
+                 double costs_factor,
                  const size_t max_tasks,
                  const std::vector<VehicleStep>& input_steps)
   : id(id),
@@ -35,7 +36,7 @@ Vehicle::Vehicle(Id id,
     tw(tw),
     breaks(breaks),
     description(description),
-    cost_wrapper(speed_factor),
+    cost_wrapper(speed_factor, costs_factor),
     max_tasks(max_tasks) {
   if (!static_cast<bool>(start) and !static_cast<bool>(end)) {
     throw InputException("No start or end specified for vehicle " +

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -50,6 +50,7 @@ struct Vehicle {
     const std::vector<Break>& breaks = std::vector<Break>(),
     const std::string& description = "",
     double speed_factor = 1.,
+    double costs_factor = 1.,
     const size_t max_tasks = std::numeric_limits<size_t>::max(),
     const std::vector<VehicleStep>& input_steps = std::vector<VehicleStep>());
 

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -390,6 +390,7 @@ inline Vehicle get_vehicle(const rapidjson::Value& json_vehicle,
                  get_vehicle_breaks(json_vehicle),
                  get_string(json_vehicle, "description"),
                  get_double(json_vehicle, "speed_factor"),
+                 get_double(json_vehicle, "costs_factor"),
                  get_max_tasks(json_vehicle),
                  get_vehicle_steps(json_vehicle));
 }


### PR DESCRIPTION
This is a breaking change since previous implementation was using `speed_factor` to scale `costs`, but only in case of missing `costs` matrix.

## Issue
Closes https://github.com/VROOM-Project/vroom/issues/767
Closes https://github.com/VROOM-Project/vroom/issues/783

## Tasks

 - [x] I did a thing
 - [x] Update `docs/API.md` (remove if irrelevant)
 - [ ] Update `CHANGELOG.md` (remove if irrelevant)
 - [ ] review

## Notes
Draft because I'm not sure about breaking change here and how to avoid it, may need help or green light on it. This would affect `CHANGELOG.md`