### PR TITLE
Chrono cleanup

### DIFF
--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -71,7 +71,7 @@ LocalSearch<Route,
     _nb_vehicles(_input.vehicles.size()),
     _max_nb_jobs_removal(max_nb_jobs_removal),
     _deadline(timeout.has_value()
-                ? utils::now() + std::chrono::milliseconds(timeout.value())
+                ? utils::now() + timeout.value()
                 : Deadline()),
     _all_routes(_nb_vehicles),
     _sol_state(input),

--- a/src/problems/tsp/tsp.cpp
+++ b/src/problems/tsp/tsp.cpp
@@ -170,7 +170,7 @@ std::vector<Index> TSP::raw_solve(unsigned nb_threads,
   // Compute deadline including heuristic computing time.
   const Deadline deadline =
     timeout.has_value()
-      ? utils::now() + std::chrono::milliseconds(timeout.value())
+      ? utils::now() + timeout.value()
       : Deadline();
 
   // Applying heuristic.


### PR DESCRIPTION
## Issue

Since `Timeout` optionally contains `std::chrono::milliseconds` the constructor calls are no longer needed.

## Tasks

 - [ ] ...
 - [ ] review
