### PR TITLE
Named constants for default number of threads and exploration level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add message on invalid routing response (#764)
 - Consistent exception type on invalid profile (#771)
 - Pass zero amount directly instead of its size (#776)
+- Add named constants for default threads number and exploration level (#805)
 
 ### Fixed
 

--- a/libvroom_examples/libvroom.cpp
+++ b/libvroom_examples/libvroom.cpp
@@ -211,8 +211,8 @@ void run_example_with_osrm() {
   // - jobs 5 and 6 can be served by either one of the vehicles
 
   // Solve!
-  auto sol = problem_instance.solve(5,  // Exploration level.
-                                    4); // Use 4 threads.
+  auto sol = problem_instance.solve(vroom::DEFAULT_EXPLORATION_LEVEL,  // Exploration level.
+                                    vroom::DEFAULT_THREADS_NUMBER); // Use 4 threads.
 
   log_solution(sol, GEOMETRY);
 }
@@ -265,8 +265,8 @@ void run_example_with_custom_matrix() {
   }
 
   // Solve!
-  auto sol = problem_instance.solve(5,  // Exploration level.
-                                    4); // Use 4 threads.
+  auto sol = problem_instance.solve(vroom::DEFAULT_EXPLORATION_LEVEL,  // Exploration level.
+                                    vroom::DEFAULT_THREADS_NUMBER); // Use 4 threads.
 
   log_solution(sol, GEOMETRY);
 }

--- a/libvroom_examples/libvroom.cpp
+++ b/libvroom_examples/libvroom.cpp
@@ -211,8 +211,10 @@ void run_example_with_osrm() {
   // - jobs 5 and 6 can be served by either one of the vehicles
 
   // Solve!
-  auto sol = problem_instance.solve(vroom::DEFAULT_EXPLORATION_LEVEL,  // Exploration level.
-                                    vroom::DEFAULT_THREADS_NUMBER); // Use 4 threads.
+  auto sol =
+    problem_instance.solve(vroom::DEFAULT_EXPLORATION_LEVEL, // Exploration
+                                                             // level.
+                           vroom::DEFAULT_THREADS_NUMBER);   // Use 4 threads.
 
   log_solution(sol, GEOMETRY);
 }
@@ -265,8 +267,10 @@ void run_example_with_custom_matrix() {
   }
 
   // Solve!
-  auto sol = problem_instance.solve(vroom::DEFAULT_EXPLORATION_LEVEL,  // Exploration level.
-                                    vroom::DEFAULT_THREADS_NUMBER); // Use 4 threads.
+  auto sol =
+    problem_instance.solve(vroom::DEFAULT_EXPLORATION_LEVEL, // Exploration
+                                                             // level.
+                           vroom::DEFAULT_THREADS_NUMBER);   // Use 4 threads.
 
   log_solution(sol, GEOMETRY);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,11 +73,11 @@ int main(int argc, char** argv) {
      cxxopts::value<std::string>(router_arg)->default_value("osrm"))
     ("t,threads",
      "number of available threads",
-     cxxopts::value<unsigned>(cl_args.nb_threads)->default_value("4"))
+     cxxopts::value<unsigned>(cl_args.nb_threads)->default_value(std::to_string(vroom::DEFAULT_THREADS_NUMBER)))
     ("v,version", "output version information and exit")
     ("x,explore",
      "exploration level to use (0..5)",
-     cxxopts::value<unsigned>(cl_args.exploration_level)->default_value("5"))
+     cxxopts::value<unsigned>(cl_args.exploration_level)->default_value(std::to_string(vroom::DEFAULT_EXPLORATION_LEVEL)))
     ("stdin",
      "optional input positional arg",
      cxxopts::value<std::string>(cl_args.input));

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -60,6 +60,9 @@ const std::string DEFAULT_PROFILE = "car";
 constexpr Priority MAX_PRIORITY = 100;
 constexpr double MAX_SPEED_FACTOR = 5.0;
 
+constexpr unsigned DEFAULT_EXPLORATION_LEVEL = 5;
+constexpr unsigned DEFAULT_THREADS_NUMBER = 4;
+
 // Available routing engines.
 enum class ROUTER { OSRM, LIBOSRM, ORS, VALHALLA };
 

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -29,6 +29,9 @@ using Servers = std::unordered_map<std::string, Server>;
 
 class VRP;
 
+constexpr unsigned DEFAULT_EXPLORATION_LEVEL = 5;
+constexpr unsigned DEFAULT_THREADS_NUMBER = 4;
+
 class Input {
 private:
   TimePoint _start_loading;

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -29,9 +29,6 @@ using Servers = std::unordered_map<std::string, Server>;
 
 class VRP;
 
-constexpr unsigned DEFAULT_EXPLORATION_LEVEL = 5;
-constexpr unsigned DEFAULT_THREADS_NUMBER = 4;
-
 class Input {
 private:
   TimePoint _start_loading;


### PR DESCRIPTION
## Issue #805

Added named constants for default threads number and default exploration level.

## Tasks

 - [x] Update `CHANGELOG.md` (remove if irrelevant)
 - [x] review
