### PR TITLE
Extend CI strategy to include g++ and clang++ installed on Ubuntu 22.04

### DIFF
--- a/.github/workflows/vroom.yml
+++ b/.github/workflows/vroom.yml
@@ -16,8 +16,24 @@ jobs:
   vroom:
     strategy:
       matrix:
-        cxx: ['g++-9', 'clang++-10']
-    runs-on: ubuntu-20.04
+        config:
+          - {
+              os: ubuntu-20.04,
+              cxx: 'g++-9'
+            }
+          - {
+              os: ubuntu-20.04,
+              cxx: 'clang++-10'
+            }
+          - {
+              os: ubuntu-22.04,
+              cxx: 'g++'
+            }
+          - {
+              os: ubuntu-22.04,
+              cxx: 'clang++'
+            }
+    runs-on: ${{ matrix.config.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -28,12 +44,12 @@ jobs:
       - name: Build vroom
         run: make
         env:
-          CXX: ${{ matrix.cxx }}
+          CXX: ${{ matrix.config.cxx }}
         working-directory: src
       - name: Validate output
         run: diff <(bin/vroom -i docs/example_2.json  | jq '.routes[].steps[]' --sort-keys) <(jq '.routes[].steps[]' --sort-keys docs/example_2_sol.json)
       - name: Build libvroom example
         run: make
         env:
-          CXX: ${{ matrix.cxx }}
+          CXX: ${{ matrix.config.cxx }}
         working-directory: libvroom_examples

--- a/.github/workflows/vroom.yml
+++ b/.github/workflows/vroom.yml
@@ -16,24 +16,8 @@ jobs:
   vroom:
     strategy:
       matrix:
-        config:
-          - {
-              os: ubuntu-20.04,
-              cxx: 'g++-9'
-            }
-          - {
-              os: ubuntu-20.04,
-              cxx: 'clang++-10'
-            }
-          - {
-              os: ubuntu-22.04,
-              cxx: 'g++'
-            }
-          - {
-              os: ubuntu-22.04,
-              cxx: 'clang++'
-            }
-    runs-on: ${{ matrix.config.os }}
+        cxx: ['g++-11', 'clang++-14']
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -44,12 +28,12 @@ jobs:
       - name: Build vroom
         run: make
         env:
-          CXX: ${{ matrix.config.cxx }}
+          CXX: ${{ matrix.cxx }}
         working-directory: src
       - name: Validate output
         run: diff <(bin/vroom -i docs/example_2.json  | jq '.routes[].steps[]' --sort-keys) <(jq '.routes[].steps[]' --sort-keys docs/example_2_sol.json)
       - name: Build libvroom example
         run: make
         env:
-          CXX: ${{ matrix.config.cxx }}
+          CXX: ${{ matrix.cxx }}
         working-directory: libvroom_examples

--- a/.github/workflows/vroom_libosrm.yml
+++ b/.github/workflows/vroom_libosrm.yml
@@ -19,8 +19,8 @@ jobs:
   libosrm:
     strategy:
       matrix:
-        cxx: ['g++-9', 'clang++-10']
-    runs-on: ubuntu-20.04
+        cxx: ['g++-11', 'clang++-14']
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/vroom_libosrm.yml
+++ b/.github/workflows/vroom_libosrm.yml
@@ -14,7 +14,7 @@ on:
       - '.github/workflows/vroom_libosrm.yml'
       - '**libosrm_wrapper**'
 env:
-  osrm-tag: v5.26.0
+  osrm-tag: v5.27.1
 jobs:
   libosrm:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support for `max_travel_time` at vehicle level (#273)
 - Advertise `libvroom` in README and wiki (#42)
+- CI builds now include clang++ and g++ on Ubuntu 22.04 (#816)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Support for `max_travel_time` at vehicle level (#273)
 - Advertise `libvroom` in README and wiki (#42)
-- CI builds now include clang++ and g++ on Ubuntu 22.04 (#816)
+- CI builds now use clang++ 14 and g++ 11 on Ubuntu 22.04 (#816)
 
 ### Changed
 


### PR DESCRIPTION
## Issue #816

I added Ubuntu 22.04 to the CI build matrix using both g++ and clang++, but without specifying their versions. According to [this table](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md) Ubuntu 22.04 image on GitHub includes clang++ 12, 13, and 14 and g++ 9, 10, and 11. Without specifying version the latest one is used (that is, clang++14 and g++11).

## Tasks

 - [x] Update `CHANGELOG.md` (remove if irrelevant)
 - [x] review
