### PR TITLE
Parallelise jobs to speed up CI

### DIFF
--- a/.github/workflows/vroom.yml
+++ b/.github/workflows/vroom.yml
@@ -26,14 +26,14 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install libasio-dev libglpk-dev jq
       - name: Build vroom
-        run: make
+        run: make -j
         env:
           CXX: ${{ matrix.cxx }}
         working-directory: src
       - name: Validate output
         run: diff <(bin/vroom -i docs/example_2.json  | jq '.routes[].steps[]' --sort-keys) <(jq '.routes[].steps[]' --sort-keys docs/example_2_sol.json)
       - name: Build libvroom example
-        run: make
+        run: make -j
         env:
           CXX: ${{ matrix.cxx }}
         working-directory: libvroom_examples


### PR DESCRIPTION
## Issue

I added `-j` to run all compilation jobs in parallel. The Linux GitHub runner machines have 2 cores, but also enough RAM to handle this.

## Tasks

 - [x] review
