### PR TITLE
Fix off-by-one error in vrptw::MixedExchange validity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Mark `JobAmount` and `JobTime` comparison operators as `const` (#724)
 - Update `ssl_send_and_receive` to throw RoutingExceptions (#770)
 - Timeout not observed with multiple long heuristics per thread (#792)
+- Wrong validity check range in `vrptw::MixedExchange` (#821)
 
 ## [v1.12.0] - 2022-05-31
 

--- a/src/problems/vrptw/operators/mixed_exchange.cpp
+++ b/src/problems/vrptw/operators/mixed_exchange.cpp
@@ -42,7 +42,7 @@ bool MixedExchange::is_valid() {
                                                   s_route.begin() + s_rank,
                                                   s_route.begin() + s_rank + 1,
                                                   t_rank,
-                                                  t_rank + 1);
+                                                  t_rank + 2);
 
   if (valid) {
     // Keep target edge direction when inserting in source route.


### PR DESCRIPTION
## Issue

Fixes #821

## Tasks

 - [x] Fix range for `is_valid_addition_for_tw` call
 - [x] Update `CHANGELOG.md`
 - [x] review
