### PR TITLE
Fix regret underflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Update `ssl_send_and_receive` to throw RoutingExceptions (#770)
 - Timeout not observed with multiple long heuristics per thread (#792)
 - Wrong validity check range in `vrptw::MixedExchange` (#821)
+- Underflow in insertion regrets (#831)
 
 ## [v1.12.0] - 2022-05-31
 

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -449,8 +449,8 @@ T dynamic_vehicle_choice(const Input& input, INIT init, double lambda) {
     // (resp. jobs_second_min_costs[j]) holds the min cost
     // (resp. second min cost) of picking the job in an empty route
     // for any remaining vehicle.
-    std::vector<SignedCost> jobs_min_costs(input.jobs.size(),
-                                           std::numeric_limits<Cost>::max());
+    std::vector<SignedCost>
+      jobs_min_costs(input.jobs.size(), std::numeric_limits<SignedCost>::max());
     std::vector<SignedCost>
       jobs_second_min_costs(input.jobs.size(),
                             std::numeric_limits<Cost>::max());
@@ -498,7 +498,8 @@ T dynamic_vehicle_choice(const Input& input, INIT init, double lambda) {
     // Once current vehicle is decided, regrets[j] holds the min cost
     // of picking the job in an empty route for other remaining
     // vehicles.
-    std::vector<Cost> regrets(input.jobs.size(), input.get_cost_upper_bound());
+    std::vector<SignedCost> regrets(input.jobs.size(),
+                                    input.get_cost_upper_bound());
     for (const auto job_rank : unassigned) {
       if (jobs_min_costs[job_rank] < evals[job_rank][v_rank].cost) {
         regrets[job_rank] = jobs_min_costs[job_rank];

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -191,8 +191,9 @@ void LocalSearch<Route,
         continue;
       }
 
-      auto smallest = _input.get_cost_upper_bound();
-      auto second_smallest = _input.get_cost_upper_bound();
+      // Implicit cast to signed value.
+      SignedCost smallest = _input.get_cost_upper_bound();
+      SignedCost second_smallest = _input.get_cost_upper_bound();
       std::size_t smallest_idx = std::numeric_limits<std::size_t>::max();
 
       for (std::size_t i = 0; i < routes.size(); ++i) {


### PR DESCRIPTION
## Issue

Fixes #831 

## Tasks

 - [x] Switch regret to `SignedCost` in `try_job_additions`
 - [x] Switch regret to `SignedCost` in `dynamic` heuristic
 - [x] Update `CHANGELOG.md`
 - [x] review
