### PR TITLE
Fix crash with missing locations and only custom `costs` provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Timeout not observed with multiple long heuristics per thread (#792)
 - Wrong validity check range in `vrptw::MixedExchange` (#821)
 - Underflow in insertion regrets (#831)
+- Crash with missing location coordinates and only `costs` custom matrix (#826)
 
 ## [v1.12.0] - 2022-05-31
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -33,6 +33,7 @@ Input::Input(const io::Servers& servers, ROUTER router)
     _no_addition_yet(true),
     _has_skills(false),
     _has_TW(false),
+    _has_all_coordinates(true),
     _has_initial_routes(false),
     _homogeneous_locations(true),
     _homogeneous_profiles(true),
@@ -140,6 +141,9 @@ void Input::check_job(Job& job) {
       throw InputException("Missing location index.");
     }
   }
+
+  // Check whether all locations have coordinates.
+  _has_all_coordinates = _has_all_coordinates && job.location.has_coordinates();
 
   // Check for time-windows and skills.
   _has_TW = _has_TW || (!(job.tws.size() == 1) or !job.tws[0].is_default());
@@ -251,10 +255,12 @@ void Input::add_vehicle(const Vehicle& vehicle) {
   _has_skills = _has_skills || !current_v.skills.empty();
 
   bool has_location_index = false;
+  bool has_all_coordinates = true;
   if (current_v.has_start()) {
     auto& start_loc = current_v.start.value();
 
     has_location_index = start_loc.user_index();
+    has_all_coordinates = start_loc.has_coordinates();
 
     if (!start_loc.user_index()) {
       // Index of start in the matrices is not specified in input,
@@ -304,6 +310,7 @@ void Input::add_vehicle(const Vehicle& vehicle) {
     }
 
     has_location_index = end_loc.user_index();
+    has_all_coordinates = has_all_coordinates && end_loc.has_coordinates();
 
     if (!end_loc.user_index()) {
       // Index of this end in the matrix was not specified upon
@@ -351,6 +358,9 @@ void Input::add_vehicle(const Vehicle& vehicle) {
       throw InputException("Missing location index.");
     }
   }
+
+  // Check whether all locations have coordinates.
+  _has_all_coordinates = _has_all_coordinates && has_all_coordinates;
 
   _has_initial_routes = _has_initial_routes or !current_v.steps.empty();
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -63,6 +63,10 @@ void Input::add_routing_wrapper(const std::string& profile) {
   throw RoutingException("VROOM compiled without routing support.");
 #endif
 
+  if (!_has_all_coordinates) {
+    throw InputException("Missing coordinates for routing engine.");
+  }
+
   assert(std::find_if(_routing_wrappers.begin(),
                       _routing_wrappers.end(),
                       [&](const auto& wr) { return wr->profile == profile; }) ==

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -40,6 +40,7 @@ private:
   bool _no_addition_yet;
   bool _has_skills;
   bool _has_TW;
+  bool _has_all_coordinates;
   bool _has_custom_location_index;
   bool _has_initial_routes;
   bool _homogeneous_locations;


### PR DESCRIPTION
## Issue

Fixes #826 

## Tasks

 - [x] Store a flag to know whether all coordinates are provided
 - [x] Do not fire a routing wrapper call with missing coordinates
 - [x] Update `CHANGELOG.md`
 - [x] review
