### PR TITLE
Add max travel time violations in plan mode

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -415,6 +415,7 @@ Possible violation causes are:
 - "skills" if the vehicle does not hold all required skills for a task
 - "precedence" if a `shipment` precedence constraint is not met (`pickup` without matching `delivery`, `delivery` before/without matching `pickup`)
 - "missing_break" if a vehicle break has been omitted in its custom route
+- "max_travel_time" if the vehicle has more travel time than its `max_travel_time` value
 
 Note on violations: reporting only really makes sense when using `-c`
 to choose ETA for custom routes described in input using the `steps`

--- a/src/algorithms/validation/choose_ETA.cpp
+++ b/src/algorithms/validation/choose_ETA.cpp
@@ -1237,6 +1237,11 @@ Route choose_ETA(const Input& input,
         current.violations.types.insert(VIOLATION::MAX_TASKS);
         v_types.insert(VIOLATION::MAX_TASKS);
       }
+      if (!v.ok_for_travel_time(
+            utils::scale_from_user_duration(user_duration))) {
+        current.violations.types.insert(VIOLATION::MAX_TRAVEL_TIME);
+        v_types.insert(VIOLATION::MAX_TRAVEL_TIME);
+      }
 
       switch (job.type) {
       case JOB_TYPE::SINGLE:
@@ -1323,6 +1328,11 @@ Route choose_ETA(const Input& input,
         current.violations.types.insert(VIOLATION::LOAD);
         v_types.insert(VIOLATION::LOAD);
       }
+      if (!v.ok_for_travel_time(
+            utils::scale_from_user_duration(user_duration))) {
+        current.violations.types.insert(VIOLATION::MAX_TRAVEL_TIME);
+        v_types.insert(VIOLATION::MAX_TRAVEL_TIME);
+      }
 
       previous_start = service_start;
       previous_action = b.service;
@@ -1330,7 +1340,7 @@ Route choose_ETA(const Input& input,
       ++task_rank;
       break;
     }
-    case STEP_TYPE::END:
+    case STEP_TYPE::END: {
       const auto arrival = previous_start + previous_action + previous_travel;
       assert(arrival == v_end);
 
@@ -1360,7 +1370,14 @@ Route choose_ETA(const Input& input,
         end_step.violations.types.insert(VIOLATION::LOAD);
         v_types.insert(VIOLATION::LOAD);
       }
+      if (!v.ok_for_travel_time(
+            utils::scale_from_user_duration(user_duration))) {
+        end_step.violations.types.insert(VIOLATION::MAX_TRAVEL_TIME);
+        v_types.insert(VIOLATION::MAX_TRAVEL_TIME);
+      }
+
       break;
+    }
     }
   }
 

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -135,7 +135,8 @@ enum class VIOLATION {
   MAX_TASKS,
   SKILLS,
   PRECEDENCE,
-  MISSING_BREAK
+  MISSING_BREAK,
+  MAX_TRAVEL_TIME
 };
 
 enum OperatorName {

--- a/src/utils/output_json.cpp
+++ b/src/utils/output_json.cpp
@@ -50,6 +50,9 @@ get_violations(const Violations& violations,
     case VIOLATION::MISSING_BREAK:
       cause = "missing_break";
       break;
+    case VIOLATION::MAX_TRAVEL_TIME:
+      cause = "max_travel_time";
+      break;
     }
 
     json_violation.AddMember("cause", rapidjson::Value(), allocator);


### PR DESCRIPTION
## Issue

Fixes #835

## Tasks

 - [x] Add new violation type
 - [x] Check for `max_travel_time` violation upon route creation in plan mode
 - [x] Update `docs/API.md`
 - [x] review
