### PR TITLE
Fix erasing fixed cost in `vrptw::PDShift` target gain.

### DIFF
--- a/src/problems/vrptw/operators/pd_shift.cpp
+++ b/src/problems/vrptw/operators/pd_shift.cpp
@@ -60,7 +60,7 @@ void PDShift::compute_gain() {
 
   if (rs.eval != NO_EVAL) {
     _valid = true;
-    t_gain = -rs.eval;
+    t_gain -= rs.eval;
     stored_gain = s_gain + t_gain;
     _best_t_p_rank = rs.pickup_rank;
     _best_t_d_rank = rs.delivery_rank;


### PR DESCRIPTION
## Issue

Fixes #855 

## Tasks

 - [x] Do not overwrite existing `t_gain` value potentially containing fixed cost in `vrptw::PDShift`
 - [x] review
