### PR TITLE
pyvroom: expose speed_factor and per_hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Exposed internal variables to get feature parity for pyvroom (#901)
 - Update GitHub Actions (#857)
 - Improve error messages (#848)
 - Add running `apt-get update` in CI jobs (#863)

--- a/src/structures/vroom/cost_wrapper.cpp
+++ b/src/structures/vroom/cost_wrapper.cpp
@@ -18,6 +18,7 @@ CostWrapper::CostWrapper(double speed_factor, Cost per_hour)
     discrete_cost_factor(
       std::round(1 / speed_factor * DURATION_FACTOR * per_hour)),
     _per_hour(per_hour),
+    _speed_factor(speed_factor),
     _cost_based_on_duration(true) {
   if (speed_factor <= 0 || speed_factor > MAX_SPEED_FACTOR) {
     throw InputException("Invalid speed factor: " +

--- a/src/structures/vroom/cost_wrapper.cpp
+++ b/src/structures/vroom/cost_wrapper.cpp
@@ -17,8 +17,8 @@ CostWrapper::CostWrapper(double speed_factor, Cost per_hour)
   : discrete_duration_factor(std::round(1 / speed_factor * DURATION_FACTOR)),
     discrete_cost_factor(
       std::round(1 / speed_factor * DURATION_FACTOR * per_hour)),
-    _per_hour(per_hour),
     _speed_factor(speed_factor),
+    _per_hour(per_hour),
     _cost_based_on_duration(true) {
   if (speed_factor <= 0 || speed_factor > MAX_SPEED_FACTOR) {
     throw InputException("Invalid speed factor: " +

--- a/src/structures/vroom/cost_wrapper.h
+++ b/src/structures/vroom/cost_wrapper.h
@@ -27,6 +27,7 @@ private:
 
   Cost _per_hour;
   bool _cost_based_on_duration;
+  const double _speed_factor;
 
 public:
   CostWrapper(double speed_factor, Cost per_hour);
@@ -53,6 +54,10 @@ public:
     return discrete_cost_factor *
            static_cast<Cost>(cost_data[i * cost_matrix_size + j]);
   }
+
+  double get_speed_factor() const { return _speed_factor;};
+
+  double get_per_hour() const { return _per_hour;};
 
   UserCost user_cost_from_user_duration(UserDuration d) const;
 };

--- a/src/structures/vroom/cost_wrapper.h
+++ b/src/structures/vroom/cost_wrapper.h
@@ -59,7 +59,7 @@ public:
     return _speed_factor;
   }
 
-  double get_per_hour() const {
+  Cost get_per_hour() const {
     return _per_hour;
   }
 

--- a/src/structures/vroom/cost_wrapper.h
+++ b/src/structures/vroom/cost_wrapper.h
@@ -25,9 +25,9 @@ private:
   std::size_t cost_matrix_size;
   const UserCost* cost_data;
 
+  const double _speed_factor;
   Cost _per_hour;
   bool _cost_based_on_duration;
-  const double _speed_factor;
 
 public:
   CostWrapper(double speed_factor, Cost per_hour);

--- a/src/structures/vroom/cost_wrapper.h
+++ b/src/structures/vroom/cost_wrapper.h
@@ -55,9 +55,13 @@ public:
            static_cast<Cost>(cost_data[i * cost_matrix_size + j]);
   }
 
-  double get_speed_factor() const { return _speed_factor;};
+  double get_speed_factor() const {
+    return _speed_factor;
+  }
 
-  double get_per_hour() const { return _per_hour;};
+  double get_per_hour() const {
+    return _per_hour;
+  }
 
   UserCost user_cost_from_user_duration(UserDuration d) const;
 };


### PR DESCRIPTION
I'm updating pyvroom to get feature pairity with version 1.13. To get there I need to expose the speed_factor attribute.

I'm also exposing per_hour, thought I do have it indirectly in other context, I think it is much cleaner if it is exposed it directly aswell.
