### PR TITLE
Filter out `max travel time` situation for TSP solving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Internal matrix problem with inconsistent `location_index` and `location` values (#909)
 - Silent fail on invalid output file (#553)
+- `max_travel_time` parameter not taken into account in edge case (#884)
 
 ## [v1.13.0] - 2023-01-31
 

--- a/src/problems/cvrp/cvrp.cpp
+++ b/src/problems/cvrp/cvrp.cpp
@@ -146,7 +146,8 @@ Solution CVRP::solve(unsigned exploration_level,
   if (_input.vehicles.size() == 1 and !_input.has_skills() and
       _input.zero_amount().size() == 0 and !_input.has_shipments() and
       (_input.jobs.size() <= _input.vehicles[0].max_tasks) and
-      _input.vehicles[0].steps.empty()) {
+      _input.vehicles[0].steps.empty() and
+      !_input.vehicles[0].has_max_travel_time()) {
     // This is a plain TSP, no need to go through the trouble below.
     std::vector<Index> job_ranks(_input.jobs.size());
     std::iota(job_ranks.begin(), job_ranks.end(), 0);

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -76,6 +76,8 @@ constexpr unsigned MAX_EXPLORATION_LEVEL = 5;
 
 constexpr unsigned DEFAULT_EXPLORATION_LEVEL = 5;
 constexpr unsigned DEFAULT_THREADS_NUMBER = 4;
+constexpr Duration DEFAULT_MAX_TRAVEL_TIME =
+  std::numeric_limits<Duration>::max();
 
 // Available routing engines.
 enum class ROUTER { OSRM, LIBOSRM, ORS, VALHALLA };

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -43,7 +43,7 @@ Vehicle::Vehicle(Id id,
     max_tasks(max_tasks),
     max_travel_time(max_travel_time.has_value()
                       ? utils::scale_from_user_duration(max_travel_time.value())
-                      : std::numeric_limits<Duration>::max()),
+                      : DEFAULT_MAX_TRAVEL_TIME),
     has_break_max_load(
       std::any_of(breaks.cbegin(), breaks.cend(), [](const auto& b) {
         return b.max_load.has_value();

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -110,6 +110,10 @@ struct Vehicle {
     return d <= max_travel_time;
   }
 
+  bool has_max_travel_time() const {
+    return max_travel_time != std::numeric_limits<Duration>::max();
+  }
+
   Index break_rank(Id id) const;
 };
 

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -111,7 +111,7 @@ struct Vehicle {
   }
 
   bool has_max_travel_time() const {
-    return max_travel_time != std::numeric_limits<Duration>::max();
+    return max_travel_time != DEFAULT_MAX_TRAVEL_TIME;
   }
 
   Index break_rank(Id id) const;


### PR DESCRIPTION
## Issue

Fixes #884

## Tasks

 - [x] Do not use TSP solving code when a `max_travel_time` constraint apply
 - [x] Update `CHANGELOG.md`
 - [x] review
