### PR TITLE
Fix breaks `location_index`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Internal matrix problem with inconsistent `location_index` and `location` values (#909)
 - Silent fail on invalid output file (#553)
+- Meaningless `location_index` provided in output for break steps (#877)
 
 ## [v1.13.0] - 2023-01-31
 

--- a/libvroom_examples/libvroom.cpp
+++ b/libvroom_examples/libvroom.cpp
@@ -42,8 +42,10 @@ void log_solution(const vroom::Solution& sol, bool geometry) {
       case vroom::STEP_TYPE::BREAK:
         type = "Break";
         break;
-      case vroom::STEP_TYPE::JOB:
-        switch (step.job_type) {
+      case vroom::STEP_TYPE::JOB: {
+        assert(step.job_type.has_value());
+
+        switch (step.job_type.value()) {
         case vroom::JOB_TYPE::SINGLE:
           type = "Job";
           break;
@@ -56,6 +58,7 @@ void log_solution(const vroom::Solution& sol, bool geometry) {
         }
         break;
       }
+      }
       std::cout << type;
 
       // Add job/pickup/delivery/break ids.
@@ -65,8 +68,11 @@ void log_solution(const vroom::Solution& sol, bool geometry) {
       }
 
       // Add location if known.
-      if (step.location.has_coordinates()) {
-        std::cout << " - " << step.location.lon() << ";" << step.location.lat();
+      if (step.location.has_value()) {
+        const auto& loc = step.location.value();
+        if (loc.has_coordinates()) {
+          std::cout << " - " << loc.lon() << ";" << loc.lat();
+        }
       }
 
       std::cout << " - arrival: " << step.arrival;

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -895,8 +895,12 @@ template <class T> T initial_routes(const Input& input) {
     // Startup load is the sum of deliveries for (single) jobs.
     Amount single_jobs_deliveries(input.zero_amount());
     for (const auto& step : vehicle.steps) {
-      if (step.type == STEP_TYPE::JOB and step.job_type == JOB_TYPE::SINGLE) {
-        single_jobs_deliveries += input.jobs[step.rank].delivery;
+      if (step.type == STEP_TYPE::JOB) {
+        assert(step.job_type.has_value());
+
+        if (step.job_type.value() == JOB_TYPE::SINGLE) {
+          single_jobs_deliveries += input.jobs[step.rank].delivery;
+        }
       }
     }
     if (!(single_jobs_deliveries <= vehicle.capacity)) {
@@ -923,7 +927,8 @@ template <class T> T initial_routes(const Input& input) {
                              std::to_string(vehicle.id) + ".");
       }
 
-      switch (step.job_type) {
+      assert(step.job_type.has_value());
+      switch (step.job_type.value()) {
       case JOB_TYPE::SINGLE: {
         current_load += job.pickup;
         current_load -= job.delivery;

--- a/src/algorithms/validation/choose_ETA.cpp
+++ b/src/algorithms/validation/choose_ETA.cpp
@@ -1108,8 +1108,12 @@ Route choose_ETA(const Input& input,
   // Startup load is the sum of deliveries for (single) jobs.
   Amount current_load(input.zero_amount());
   for (const auto& step : steps) {
-    if (step.type == STEP_TYPE::JOB and step.job_type == JOB_TYPE::SINGLE) {
-      current_load += input.jobs[step.rank].delivery;
+    if (step.type == STEP_TYPE::JOB) {
+      assert(step.job_type.has_value());
+
+      if (step.job_type.value() == JOB_TYPE::SINGLE) {
+        current_load += input.jobs[step.rank].delivery;
+      }
     }
   }
 

--- a/src/routing/http_wrapper.cpp
+++ b/src/routing/http_wrapper.cpp
@@ -201,7 +201,8 @@ void HttpWrapper::add_route_info(Route& route) const {
         ++(number_breaks_after.back());
       }
     } else {
-      non_break_locations.push_back(step.location);
+      assert(step.location.has_value());
+      non_break_locations.push_back(step.location.value());
       number_breaks_after.push_back(0);
     }
   }

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -721,7 +721,8 @@ void Input::set_vehicle_steps_ranks() {
       }
 
       if (step.type == STEP_TYPE::JOB) {
-        switch (step.job_type) {
+        assert(step.job_type.has_value());
+        switch (step.job_type.value()) {
         case JOB_TYPE::SINGLE: {
           auto search = job_id_to_rank.find(step.id);
           if (search == job_id_to_rank.end()) {

--- a/src/structures/vroom/input/vehicle_step.cpp
+++ b/src/structures/vroom/input/vehicle_step.cpp
@@ -28,18 +28,12 @@ ForcedService::ForcedService(const std::optional<UserDuration>& at,
 }
 
 VehicleStep::VehicleStep(STEP_TYPE type, ForcedService&& forced_service)
-  : id(0),
-    type(type),
-    job_type(JOB_TYPE::SINGLE),
-    forced_service(std::move(forced_service)) {
+  : id(0), type(type), forced_service(std::move(forced_service)) {
   assert(type == STEP_TYPE::START or type == STEP_TYPE::END);
 }
 
 VehicleStep::VehicleStep(STEP_TYPE type, Id id, ForcedService&& forced_service)
-  : id(id),
-    type(type),
-    job_type(JOB_TYPE::SINGLE),
-    forced_service(std::move(forced_service)) {
+  : id(id), type(type), forced_service(std::move(forced_service)) {
   assert(type == STEP_TYPE::BREAK);
 }
 

--- a/src/structures/vroom/input/vehicle_step.h
+++ b/src/structures/vroom/input/vehicle_step.h
@@ -29,7 +29,7 @@ struct ForcedService {
 struct VehicleStep {
   const Id id;
   const STEP_TYPE type;
-  const JOB_TYPE job_type;
+  const std::optional<JOB_TYPE> job_type;
   const ForcedService forced_service;
 
   // Stores rank of current step (in input.jobs vector for a

--- a/src/structures/vroom/solution/step.cpp
+++ b/src/structures/vroom/solution/step.cpp
@@ -14,7 +14,6 @@ namespace vroom {
 // Used for start and end steps.
 Step::Step(STEP_TYPE type, Location location, Amount load)
   : step_type(type),
-    job_type(JOB_TYPE::SINGLE), // Dummy init.
     location(location),
     id(0),
     setup(0),
@@ -40,7 +39,6 @@ Step::Step(const Job& job, const UserDuration setup, Amount load)
 
 Step::Step(const Break& b, Amount load)
   : step_type(STEP_TYPE::BREAK),
-    job_type(JOB_TYPE::SINGLE), // Dummy value.
     id(b.id),
     setup(0),
     service(utils::scale_to_user_duration(b.service)),

--- a/src/structures/vroom/solution/step.cpp
+++ b/src/structures/vroom/solution/step.cpp
@@ -41,7 +41,6 @@ Step::Step(const Job& job, const UserDuration setup, Amount load)
 Step::Step(const Break& b, Amount load)
   : step_type(STEP_TYPE::BREAK),
     job_type(JOB_TYPE::SINGLE), // Dummy value.
-    location(0),                // Dummy value.
     id(b.id),
     setup(0),
     service(utils::scale_to_user_duration(b.service)),

--- a/src/structures/vroom/solution/step.h
+++ b/src/structures/vroom/solution/step.h
@@ -22,7 +22,7 @@ namespace vroom {
 struct Step {
   const STEP_TYPE step_type;
   const JOB_TYPE job_type;
-  const Location location;
+  const std::optional<Location> location;
   const Id id;
   UserDuration setup;
   UserDuration service;

--- a/src/structures/vroom/solution/step.h
+++ b/src/structures/vroom/solution/step.h
@@ -21,7 +21,7 @@ namespace vroom {
 
 struct Step {
   const STEP_TYPE step_type;
-  const JOB_TYPE job_type;
+  const std::optional<JOB_TYPE> job_type;
   const std::optional<Location> location;
   const Id id;
   UserDuration setup;

--- a/src/utils/output_json.cpp
+++ b/src/utils/output_json.cpp
@@ -307,12 +307,15 @@ rapidjson::Value to_json(const Step& s,
                                        allocator);
   }
 
-  if (s.location.has_coordinates()) {
-    json_step.AddMember("location", to_json(s.location, allocator), allocator);
-  }
+  if (s.location.has_value()) {
+    const auto& loc = s.location.value();
+    if (loc.has_coordinates()) {
+      json_step.AddMember("location", to_json(loc, allocator), allocator);
+    }
 
-  if (s.location.user_index()) {
-    json_step.AddMember("location_index", s.location.index(), allocator);
+    if (loc.user_index()) {
+      json_step.AddMember("location_index", loc.index(), allocator);
+    }
   }
 
   if (s.step_type == STEP_TYPE::JOB or s.step_type == STEP_TYPE::BREAK) {

--- a/src/utils/output_json.cpp
+++ b/src/utils/output_json.cpp
@@ -284,8 +284,9 @@ rapidjson::Value to_json(const Step& s,
   case STEP_TYPE::BREAK:
     str_type = "break";
     break;
-  case STEP_TYPE::JOB:
-    switch (s.job_type) {
+  case STEP_TYPE::JOB: {
+    assert(s.job_type.has_value());
+    switch (s.job_type.value()) {
     case JOB_TYPE::SINGLE:
       str_type = "job";
       break;
@@ -297,6 +298,7 @@ rapidjson::Value to_json(const Step& s,
       break;
     }
     break;
+  }
   }
   json_step["type"].SetString(str_type.c_str(), str_type.size(), allocator);
 


### PR DESCRIPTION
## Issue

fixes #877 

## Tasks

 - [x] Make `Step::location` optional
 - [x] Only serialize `location[_index]` based on existing value
 - [x] While we're at it refactor various `job_type` members to be optional instead of holding dummy `JOB_TYPE::SINGLE` values
 - [x] Update `CHANGELOG.md`
 - [x] review
