### PR TITLE
Adjust for optional Location in `LibosrmWrapper`

### DIFF
--- a/src/routing/libosrm_wrapper.cpp
+++ b/src/routing/libosrm_wrapper.cpp
@@ -107,9 +107,11 @@ void LibosrmWrapper::add_route_info(Route& route) const {
         ++(number_breaks_after.back());
       }
     } else {
-      params.coordinates
-        .emplace_back(osrm::util::FloatLongitude({step.location.lon()}),
-                      osrm::util::FloatLatitude({step.location.lat()}));
+      assert(step.location.has_value());
+      const auto& loc = step.location.value();
+      assert(loc.has_coordinates());
+      params.coordinates.emplace_back(osrm::util::FloatLongitude({loc.lon()}),
+                                      osrm::util::FloatLatitude({loc.lat()}));
       number_breaks_after.push_back(0);
     }
   }


### PR DESCRIPTION
## Issue

#877

This is a fix on top of #937 since I missed some required changes, breaking the `master` CI build https://github.com/VROOM-Project/vroom/actions/runs/5376747556/jobs/9754318591

## Tasks

 - [x] adjust the `LibosrmWrapper` code
 - [x] review
