### PR TITLE
Sort `Eval` objects first on cost, then duration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Switch to C++20 (#851)
 - Improved error messages for file-related IO errors (#553)
 - Add job id to error message for unreachable step (#946)
+- `Eval::operator<` sorts on cost, then duration (#914)
 
 ### Fixed
 

--- a/src/structures/vroom/eval.h
+++ b/src/structures/vroom/eval.h
@@ -52,7 +52,8 @@ struct Eval {
   }
 
   friend bool operator<(const Eval& lhs, const Eval& rhs) {
-    return lhs.cost < rhs.cost;
+    return lhs.cost < rhs.cost or
+           (lhs.cost == rhs.cost and lhs.duration < rhs.duration);
   }
 
   friend bool operator>(const Eval& lhs, const Eval& rhs) {


### PR DESCRIPTION
## Issue

Fixes #914.

## Tasks

 - [x] Adjust `Eval::operator<` implementation
 - [x] Make sure it makes a difference in the situation mentioned in #914
 - [x] Update `CHANGELOG.md`
 - [x] review
