### PR TITLE
Enforce osrm snapping radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Recommendation on how to cite in publications (#943)
 - Store distance matrices (#956)
+- Default radius of 35km for OSRM snapping (#922)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Recommendation on how to cite in publications (#943)
+- Store distance matrices (#956)
 
 ### Changed
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -281,11 +281,12 @@ integers filed under the `profile` key, then under:
 
 - `durations` for a custom travel-time matrix that will be used for
   all checks against timing constraints;
+- `distances` for a custom distance matrix;
 - `costs` for a custom cost matrix that will be used within all route
   cost evaluations.
 
-If only the `durations` value is provided, it's implied that it should
-also be used for costs evaluations.
+If only the `durations` matrix is provided, internal costs are derived from
+durations based on vehicles `costs` properties.
 
 Example of describing different matrices for different vehicle
 profiles:

--- a/src/makefile
+++ b/src/makefile
@@ -36,7 +36,7 @@ else
 	ifeq ($(shell pkg-config --exists libosrm && echo 1),1)
 		LDLIBS += $(shell pkg-config --libs libosrm) -lboost_system -lboost_filesystem -lboost_iostreams -lboost_thread -lrt -ltbb
 		LIBOSRMFLAGS = $(shell pkg-config --cflags libosrm)
-		CXXFLAGS += $(filter-out -std=c++14, $(LIBOSRMFLAGS)) -D USE_LIBOSRM=true
+		CXXFLAGS += $(filter-out -std=c++17, $(LIBOSRMFLAGS)) -D USE_LIBOSRM=true
 	else
 		SRC := $(filter-out ./routing/libosrm_wrapper.cpp, $(SRC))
 	endif

--- a/src/routing/http_wrapper.cpp
+++ b/src/routing/http_wrapper.cpp
@@ -175,17 +175,21 @@ Matrices HttpWrapper::get_matrices(const std::vector<Location>& locs) const {
   std::vector<unsigned> nb_unfound_to_loc(m_size, 0);
 
   for (rapidjson::SizeType i = 0; i < m_size; ++i) {
-    const auto& line = json_result[_matrix_durations_key.c_str()][i];
-    assert(line.Size() == m_size);
-    for (rapidjson::SizeType j = 0; j < line.Size(); ++j) {
-      if (duration_value_is_null(line[j])) {
+    const auto& duration_line = json_result[_matrix_durations_key.c_str()][i];
+    const auto& distance_line = json_result[_matrix_distances_key.c_str()][i];
+    assert(duration_line.Size() == m_size);
+    assert(distance_line.Size() == m_size);
+    for (rapidjson::SizeType j = 0; j < m_size; ++j) {
+      if (duration_value_is_null(duration_line[j]) or
+          distance_value_is_null(distance_line[j])) {
         // No route found between i and j. Just storing info as we
         // don't know yet which location is responsible between i
         // and j.
         ++nb_unfound_from_loc[i];
         ++nb_unfound_to_loc[j];
       } else {
-        m.durations[i][j] = get_duration_value(line[j]);
+        m.durations[i][j] = get_duration_value(duration_line[j]);
+        m.distances[i][j] = get_distance_value(distance_line[j]);
       }
     }
   }

--- a/src/routing/http_wrapper.cpp
+++ b/src/routing/http_wrapper.cpp
@@ -23,13 +23,13 @@ HttpWrapper::HttpWrapper(const std::string& profile,
                          std::string matrix_service,
                          std::string matrix_durations_key,
                          std::string route_service,
-                         std::string extra_args)
+                         std::string routing_args)
   : Wrapper(profile),
     _server(std::move(server)),
     _matrix_service(std::move(matrix_service)),
     _matrix_durations_key(std::move(matrix_durations_key)),
     _route_service(std::move(route_service)),
-    _extra_args(std::move(extra_args)) {
+    _routing_args(std::move(routing_args)) {
 }
 
 std::string HttpWrapper::send_then_receive(const std::string& query) const {
@@ -207,8 +207,7 @@ void HttpWrapper::add_route_info(Route& route) const {
   }
   assert(!non_break_locations.empty());
 
-  std::string query =
-    build_query(non_break_locations, _route_service, _extra_args);
+  std::string query = build_query(non_break_locations, _route_service);
 
   std::string json_string = this->run_query(query);
 

--- a/src/routing/http_wrapper.cpp
+++ b/src/routing/http_wrapper.cpp
@@ -217,7 +217,7 @@ void HttpWrapper::add_route_info(Route& route) const {
   this->check_response(json_result, _route_service);
 
   // Total distance and route geometry.
-  route.distance = round_cost(get_total_distance(json_result));
+  route.distance = round_cost<UserDistance>(get_total_distance(json_result));
   route.geometry = get_geometry(json_result);
 
   auto nb_legs = get_legs_number(json_result);
@@ -244,17 +244,17 @@ void HttpWrapper::add_route_info(Route& route) const {
     for (unsigned b = 1; b <= number_breaks_after[i]; ++b) {
       auto& break_step = route.steps[steps_rank + b];
       if (next_duration == 0) {
-        break_step.distance = round_cost(sum_distance);
+        break_step.distance = round_cost<UserDistance>(sum_distance);
       } else {
-        break_step.distance =
-          round_cost(sum_distance +
-                     ((break_step.duration - step.duration) * next_distance) /
-                       next_duration);
+        break_step.distance = round_cost<UserDistance>(
+          sum_distance +
+          ((break_step.duration - step.duration) * next_distance) /
+            next_duration);
       }
     }
 
     sum_distance += next_distance;
-    next_step.distance = round_cost(sum_distance);
+    next_step.distance = round_cost<UserDistance>(sum_distance);
 
     steps_rank += number_breaks_after[i] + 1;
   }

--- a/src/routing/http_wrapper.cpp
+++ b/src/routing/http_wrapper.cpp
@@ -144,8 +144,7 @@ void HttpWrapper::parse_response(rapidjson::Document& json_result,
 #endif
 }
 
-Matrix<UserCost>
-HttpWrapper::get_matrix(const std::vector<Location>& locs) const {
+Matrices HttpWrapper::get_matrices(const std::vector<Location>& locs) const {
   std::string query = this->build_query(locs, _matrix_service);
   std::string json_string = this->run_query(query);
 
@@ -163,7 +162,7 @@ HttpWrapper::get_matrix(const std::vector<Location>& locs) const {
 
   // Build matrix while checking for unfound routes ('null' values) to
   // avoid unexpected behavior.
-  Matrix<UserCost> m(m_size);
+  Matrices m(m_size);
 
   std::vector<unsigned> nb_unfound_from_loc(m_size, 0);
   std::vector<unsigned> nb_unfound_to_loc(m_size, 0);
@@ -179,7 +178,7 @@ HttpWrapper::get_matrix(const std::vector<Location>& locs) const {
         ++nb_unfound_from_loc[i];
         ++nb_unfound_to_loc[j];
       } else {
-        m[i][j] = get_duration_value(line[j]);
+        m.durations[i][j] = get_duration_value(line[j]);
       }
     }
   }

--- a/src/routing/http_wrapper.cpp
+++ b/src/routing/http_wrapper.cpp
@@ -155,7 +155,7 @@ Matrices HttpWrapper::get_matrices(const std::vector<Location>& locs) const {
 
   rapidjson::Document json_result;
   this->parse_response(json_result, json_string);
-  this->check_response(json_result, _matrix_service);
+  this->check_response(json_result, locs, _matrix_service);
 
   if (!json_result.HasMember(_matrix_durations_key.c_str())) {
     throw RoutingException("Missing " + _matrix_durations_key + ".");
@@ -224,7 +224,9 @@ void HttpWrapper::add_route_info(Route& route) const {
 
   rapidjson::Document json_result;
   parse_response(json_result, json_string);
-  this->check_response(json_result, _route_service);
+  this->check_response(json_result,
+                       non_break_locations, // not supposed to be used
+                       _route_service);
 
   // Total distance and route geometry.
   route.distance = round_cost<UserDistance>(get_total_distance(json_result));

--- a/src/routing/http_wrapper.cpp
+++ b/src/routing/http_wrapper.cpp
@@ -22,12 +22,14 @@ HttpWrapper::HttpWrapper(const std::string& profile,
                          Server server,
                          std::string matrix_service,
                          std::string matrix_durations_key,
+                         std::string matrix_distances_key,
                          std::string route_service,
                          std::string routing_args)
   : Wrapper(profile),
     _server(std::move(server)),
     _matrix_service(std::move(matrix_service)),
     _matrix_durations_key(std::move(matrix_durations_key)),
+    _matrix_distances_key(std::move(matrix_distances_key)),
     _route_service(std::move(route_service)),
     _routing_args(std::move(routing_args)) {
 }
@@ -159,6 +161,11 @@ Matrices HttpWrapper::get_matrices(const std::vector<Location>& locs) const {
     throw RoutingException("Missing " + _matrix_durations_key + ".");
   }
   assert(json_result[_matrix_durations_key.c_str()].Size() == m_size);
+
+  if (!json_result.HasMember(_matrix_distances_key.c_str())) {
+    throw RoutingException("Missing " + _matrix_distances_key + ".");
+  }
+  assert(json_result[_matrix_distances_key.c_str()].Size() == m_size);
 
   // Build matrix while checking for unfound routes ('null' values) to
   // avoid unexpected behavior.

--- a/src/routing/http_wrapper.h
+++ b/src/routing/http_wrapper.h
@@ -29,14 +29,14 @@ protected:
   const std::string _matrix_service;
   const std::string _matrix_durations_key;
   const std::string _route_service;
-  const std::string _extra_args;
+  const std::string _routing_args;
 
   HttpWrapper(const std::string& profile,
               Server server,
               std::string matrix_service,
               std::string matrix_durations_key,
               std::string route_service,
-              std::string extra_args);
+              std::string routing_args);
 
   std::string run_query(const std::string& query) const;
 
@@ -44,8 +44,7 @@ protected:
                              const std::string& json_content);
 
   virtual std::string build_query(const std::vector<Location>& locations,
-                                  const std::string& service,
-                                  const std::string& extra_args = "") const = 0;
+                                  const std::string& service) const = 0;
 
   virtual void check_response(const rapidjson::Document& json_result,
                               const std::string& service) const = 0;

--- a/src/routing/http_wrapper.h
+++ b/src/routing/http_wrapper.h
@@ -56,8 +56,14 @@ protected:
   virtual bool
   duration_value_is_null(const rapidjson::Value& matrix_entry) const = 0;
 
+  virtual bool
+  distance_value_is_null(const rapidjson::Value& matrix_entry) const = 0;
+
   virtual UserDuration
   get_duration_value(const rapidjson::Value& matrix_entry) const = 0;
+
+  virtual UserDistance
+  get_distance_value(const rapidjson::Value& matrix_entry) const = 0;
 
   virtual double get_total_distance(const rapidjson::Value& result) const = 0;
 

--- a/src/routing/http_wrapper.h
+++ b/src/routing/http_wrapper.h
@@ -28,6 +28,7 @@ protected:
   const Server _server;
   const std::string _matrix_service;
   const std::string _matrix_durations_key;
+  const std::string _matrix_distances_key;
   const std::string _route_service;
   const std::string _routing_args;
 
@@ -35,6 +36,7 @@ protected:
               Server server,
               std::string matrix_service,
               std::string matrix_durations_key,
+              std::string matrix_distances_key,
               std::string route_service,
               std::string routing_args);
 

--- a/src/routing/http_wrapper.h
+++ b/src/routing/http_wrapper.h
@@ -49,6 +49,7 @@ protected:
                                   const std::string& service) const = 0;
 
   virtual void check_response(const rapidjson::Document& json_result,
+                              const std::vector<Location>& locs,
                               const std::string& service) const = 0;
 
   Matrices get_matrices(const std::vector<Location>& locs) const override;

--- a/src/routing/http_wrapper.h
+++ b/src/routing/http_wrapper.h
@@ -50,7 +50,7 @@ protected:
   virtual void check_response(const rapidjson::Document& json_result,
                               const std::string& service) const = 0;
 
-  Matrix<UserCost> get_matrix(const std::vector<Location>& locs) const override;
+  Matrices get_matrices(const std::vector<Location>& locs) const override;
 
   virtual bool
   duration_value_is_null(const rapidjson::Value& matrix_entry) const = 0;

--- a/src/routing/libosrm_wrapper.cpp
+++ b/src/routing/libosrm_wrapper.cpp
@@ -76,7 +76,8 @@ Matrices LibosrmWrapper::get_matrices(const std::vector<Location>& locs) const {
         ++nb_unfound_from_loc[i];
         ++nb_unfound_to_loc[j];
       } else {
-        auto cost = round_cost(el.get<osrm::json::Number>().value);
+        auto cost =
+          round_cost<UserDuration>(duration_el.get<osrm::json::Number>().value);
         m.durations[i][j] = cost;
       }
     }
@@ -129,8 +130,8 @@ void LibosrmWrapper::add_route_info(Route& route) const {
   auto& json_route = result_routes.values.at(0).get<osrm::json::Object>();
 
   // Total distance and route geometry.
-  route.distance =
-    round_cost(json_route.values["distance"].get<osrm::json::Number>().value);
+  route.distance = round_cost<UserDistance>(
+    json_route.values["distance"].get<osrm::json::Number>().value);
   route.geometry =
     std::move(json_route.values["geometry"].get<osrm::json::String>().value);
 
@@ -169,13 +170,13 @@ void LibosrmWrapper::add_route_info(Route& route) const {
     // non-breaks steps.
     for (unsigned b = 1; b <= number_breaks_after[i]; ++b) {
       auto& break_step = route.steps[steps_rank + b];
-      break_step.distance = round_cost(
+      break_step.distance = round_cost<UserDistance>(
         sum_distance + ((break_step.duration - step.duration) * next_distance) /
                          next_duration);
     }
 
     sum_distance += next_distance;
-    next_step.distance = round_cost(sum_distance);
+    next_step.distance = round_cost<UserDistance>(sum_distance);
 
     steps_rank += number_breaks_after[i] + 1;
   }

--- a/src/routing/libosrm_wrapper.cpp
+++ b/src/routing/libosrm_wrapper.cpp
@@ -32,8 +32,7 @@ LibosrmWrapper::LibosrmWrapper(const std::string& profile)
   : Wrapper(profile), _config(get_config(profile)), _osrm(_config) {
 }
 
-Matrix<UserCost>
-LibosrmWrapper::get_matrix(const std::vector<Location>& locs) const {
+Matrices LibosrmWrapper::get_matrices(const std::vector<Location>& locs) const {
   osrm::TableParameters params;
   for (auto const& location : locs) {
     assert(location.has_coordinates());
@@ -59,7 +58,7 @@ LibosrmWrapper::get_matrix(const std::vector<Location>& locs) const {
 
   // Build matrix while checking for unfound routes to avoid
   // unexpected behavior (OSRM raises 'null').
-  Matrix<UserCost> m(m_size);
+  Matrices m(m_size);
 
   std::vector<unsigned> nb_unfound_from_loc(m_size, 0);
   std::vector<unsigned> nb_unfound_to_loc(m_size, 0);
@@ -78,7 +77,7 @@ LibosrmWrapper::get_matrix(const std::vector<Location>& locs) const {
         ++nb_unfound_to_loc[j];
       } else {
         auto cost = round_cost(el.get<osrm::json::Number>().value);
-        m[i][j] = cost;
+        m.durations[i][j] = cost;
       }
     }
   }

--- a/src/routing/libosrm_wrapper.cpp
+++ b/src/routing/libosrm_wrapper.cpp
@@ -36,11 +36,14 @@ Matrices LibosrmWrapper::get_matrices(const std::vector<Location>& locs) const {
   osrm::TableParameters params;
   params.annotations = osrm::engine::api::TableParameters::AnnotationsType::All;
 
+  params.coordinates.reserve(locs.size());
+  params.radiuses.reserve(locs.size());
   for (auto const& location : locs) {
     assert(location.has_coordinates());
     params.coordinates
       .emplace_back(osrm::util::FloatLongitude({location.lon()}),
                     osrm::util::FloatLatitude({location.lat()}));
+    params.radiuses.emplace_back(DEFAULT_LIBOSRM_SNAPPING_RADIUS);
   }
 
   osrm::json::Object result;

--- a/src/routing/libosrm_wrapper.h
+++ b/src/routing/libosrm_wrapper.h
@@ -29,8 +29,8 @@ private:
 public:
   LibosrmWrapper(const std::string& profile);
 
-  virtual Matrix<UserCost>
-  get_matrix(const std::vector<Location>& locs) const override;
+  virtual Matrices
+  get_matrices(const std::vector<Location>& locs) const override;
 
   virtual void add_route_info(Route& route) const override;
 };

--- a/src/routing/ors_wrapper.cpp
+++ b/src/routing/ors_wrapper.cpp
@@ -61,6 +61,7 @@ std::string OrsWrapper::build_query(const std::vector<Location>& locations,
 }
 
 void OrsWrapper::check_response(const rapidjson::Document& json_result,
+                                const std::vector<Location>&,
                                 const std::string&) const {
   if (json_result.HasMember("error")) {
     throw RoutingException(

--- a/src/routing/ors_wrapper.cpp
+++ b/src/routing/ors_wrapper.cpp
@@ -42,6 +42,7 @@ std::string OrsWrapper::build_query(const std::vector<Location>& locations,
     body += "," + _routing_args;
   } else {
     assert(service == _matrix_service);
+    body += ",\"metrics\":[\"duration\",\"distance\"]";
   }
   body += "}";
 
@@ -72,9 +73,19 @@ bool OrsWrapper::duration_value_is_null(
   return matrix_entry.IsNull();
 }
 
+bool OrsWrapper::distance_value_is_null(
+  const rapidjson::Value& matrix_entry) const {
+  return matrix_entry.IsNull();
+}
+
 UserDuration
 OrsWrapper::get_duration_value(const rapidjson::Value& matrix_entry) const {
   return round_cost<UserDuration>(matrix_entry.GetDouble());
+}
+
+UserDistance
+OrsWrapper::get_distance_value(const rapidjson::Value& matrix_entry) const {
+  return round_cost<UserDistance>(matrix_entry.GetDouble());
 }
 
 double OrsWrapper::get_total_distance(const rapidjson::Value& result) const {

--- a/src/routing/ors_wrapper.cpp
+++ b/src/routing/ors_wrapper.cpp
@@ -72,7 +72,7 @@ bool OrsWrapper::duration_value_is_null(
 
 UserDuration
 OrsWrapper::get_duration_value(const rapidjson::Value& matrix_entry) const {
-  return round_cost(matrix_entry.GetDouble());
+  return round_cost<UserDuration>(matrix_entry.GetDouble());
 }
 
 double OrsWrapper::get_total_distance(const rapidjson::Value& result) const {

--- a/src/routing/ors_wrapper.cpp
+++ b/src/routing/ors_wrapper.cpp
@@ -16,6 +16,7 @@ OrsWrapper::OrsWrapper(const std::string& profile, const Server& server)
                 server,
                 "matrix",
                 "durations",
+                "distances",
                 "directions",
                 "\"geometry_simplify\":\"false\",\"continue_straight\":"
                 "\"false\"") {

--- a/src/routing/ors_wrapper.cpp
+++ b/src/routing/ors_wrapper.cpp
@@ -22,8 +22,7 @@ OrsWrapper::OrsWrapper(const std::string& profile, const Server& server)
 }
 
 std::string OrsWrapper::build_query(const std::vector<Location>& locations,
-                                    const std::string& service,
-                                    const std::string& extra_args) const {
+                                    const std::string& service) const {
   // Adding locations.
   std::string body = "{\"";
   if (service == "directions") {
@@ -38,8 +37,10 @@ std::string OrsWrapper::build_query(const std::vector<Location>& locations,
   }
   body.pop_back(); // Remove trailing ','.
   body += "]";
-  if (!extra_args.empty()) {
-    body += "," + extra_args;
+  if (service == _route_service) {
+    body += "," + _routing_args;
+  } else {
+    assert(service == _matrix_service);
   }
   body += "}";
 

--- a/src/routing/ors_wrapper.h
+++ b/src/routing/ors_wrapper.h
@@ -20,6 +20,7 @@ private:
                           const std::string& service) const override;
 
   void check_response(const rapidjson::Document& json_result,
+                      const std::vector<Location>& locs,
                       const std::string& service) const override;
 
   bool

--- a/src/routing/ors_wrapper.h
+++ b/src/routing/ors_wrapper.h
@@ -25,8 +25,14 @@ private:
   bool
   duration_value_is_null(const rapidjson::Value& matrix_entry) const override;
 
+  bool
+  distance_value_is_null(const rapidjson::Value& matrix_entry) const override;
+
   UserDuration
   get_duration_value(const rapidjson::Value& matrix_entry) const override;
+
+  UserDistance
+  get_distance_value(const rapidjson::Value& matrix_entry) const override;
 
   double get_total_distance(const rapidjson::Value& result) const override;
 

--- a/src/routing/ors_wrapper.h
+++ b/src/routing/ors_wrapper.h
@@ -17,8 +17,7 @@ namespace vroom::routing {
 class OrsWrapper : public HttpWrapper {
 private:
   std::string build_query(const std::vector<Location>& locations,
-                          const std::string& service,
-                          const std::string& extra_args) const override;
+                          const std::string& service) const override;
 
   void check_response(const rapidjson::Document& json_result,
                       const std::string& service) const override;

--- a/src/routing/osrm_routed_wrapper.cpp
+++ b/src/routing/osrm_routed_wrapper.cpp
@@ -65,7 +65,7 @@ bool OsrmRoutedWrapper::duration_value_is_null(
 
 UserDuration OsrmRoutedWrapper::get_duration_value(
   const rapidjson::Value& matrix_entry) const {
-  return round_cost(matrix_entry.GetDouble());
+  return round_cost<UserDuration>(matrix_entry.GetDouble());
 }
 
 double

--- a/src/routing/osrm_routed_wrapper.cpp
+++ b/src/routing/osrm_routed_wrapper.cpp
@@ -28,15 +28,22 @@ OsrmRoutedWrapper::build_query(const std::vector<Location>& locations,
                                const std::string& service) const {
   // Building query for osrm-routed
   std::string query = "GET /" + service;
-
   query += "/v1/" + profile + "/";
 
-  // Adding locations.
+  // Build query part for snapping restriction.
+  std::string radiuses = "radiuses=";
+  radiuses.reserve(9 + locations.size() *
+                         (DEFAULT_OSRM_SNAPPING_RADIUS.size() + 1));
+
+  // Adding locations and radiuses values.
   for (auto const& location : locations) {
     query += std::to_string(location.lon()) + "," +
              std::to_string(location.lat()) + ";";
+    radiuses += DEFAULT_OSRM_SNAPPING_RADIUS + ";";
   }
-  query.pop_back(); // Remove trailing ';'.
+  // Remove trailing ';'.
+  query.pop_back();
+  radiuses.pop_back();
 
   if (service == _route_service) {
     query += "?" + _routing_args;
@@ -44,6 +51,7 @@ OsrmRoutedWrapper::build_query(const std::vector<Location>& locations,
     assert(service == _matrix_service);
     query += "?annotations=duration,distance";
   }
+  query += "&" + radiuses;
 
   query += " HTTP/1.1\r\n";
   query += "Host: " + _server.host + "\r\n";

--- a/src/routing/osrm_routed_wrapper.cpp
+++ b/src/routing/osrm_routed_wrapper.cpp
@@ -24,8 +24,7 @@ OsrmRoutedWrapper::OsrmRoutedWrapper(const std::string& profile,
 
 std::string
 OsrmRoutedWrapper::build_query(const std::vector<Location>& locations,
-                               const std::string& service,
-                               const std::string& extra_args) const {
+                               const std::string& service) const {
   // Building query for osrm-routed
   std::string query = "GET /" + service;
 
@@ -38,8 +37,10 @@ OsrmRoutedWrapper::build_query(const std::vector<Location>& locations,
   }
   query.pop_back(); // Remove trailing ';'.
 
-  if (!extra_args.empty()) {
-    query += "?" + extra_args;
+  if (service == _route_service) {
+    query += "?" + _routing_args;
+  } else {
+    assert(service == _matrix_service);
   }
 
   query += " HTTP/1.1\r\n";

--- a/src/routing/osrm_routed_wrapper.cpp
+++ b/src/routing/osrm_routed_wrapper.cpp
@@ -65,20 +65,23 @@ void OsrmRoutedWrapper::check_response(const rapidjson::Document& json_result,
                                        const std::vector<Location>& locs,
                                        const std::string&) const {
   assert(json_result.HasMember("code"));
-  std::string code = json_result["code"].GetString();
+  const std::string code = json_result["code"].GetString();
   if (code != "Ok") {
-    std::string message = json_result["message"].GetString();
+    const std::string message = json_result["message"].GetString();
     const std::string snapping_error_base =
       "Could not find a matching segment for coordinate ";
     if (code == "NoSegment" and message.starts_with(snapping_error_base)) {
-      auto error_loc =
+      const auto error_loc =
         std::stoul(message.substr(snapping_error_base.size(),
                                   message.size() - snapping_error_base.size()));
-      auto coordinates = "[" + std::to_string(locs[error_loc].lon()) + "," +
-                         std::to_string(locs[error_loc].lat()) + "]";
-      throw RoutingException("Snapping error with location " + coordinates);
+      const auto coordinates = "[" + std::to_string(locs[error_loc].lon()) +
+                               "," + std::to_string(locs[error_loc].lat()) +
+                               "]";
+      throw RoutingException("Could not find route near location " +
+                             coordinates);
     }
 
+    // Other error in response.
     throw RoutingException(message);
   }
 }

--- a/src/routing/osrm_routed_wrapper.cpp
+++ b/src/routing/osrm_routed_wrapper.cpp
@@ -17,6 +17,7 @@ OsrmRoutedWrapper::OsrmRoutedWrapper(const std::string& profile,
                 server,
                 "table",
                 "durations",
+                "distances",
                 "route",
                 "alternatives=false&steps=false&overview=full&continue_"
                 "straight=false") {

--- a/src/routing/osrm_routed_wrapper.cpp
+++ b/src/routing/osrm_routed_wrapper.cpp
@@ -42,6 +42,7 @@ OsrmRoutedWrapper::build_query(const std::vector<Location>& locations,
     query += "?" + _routing_args;
   } else {
     assert(service == _matrix_service);
+    query += "?annotations=duration,distance";
   }
 
   query += " HTTP/1.1\r\n";
@@ -65,9 +66,19 @@ bool OsrmRoutedWrapper::duration_value_is_null(
   return matrix_entry.IsNull();
 }
 
+bool OsrmRoutedWrapper::distance_value_is_null(
+  const rapidjson::Value& matrix_entry) const {
+  return matrix_entry.IsNull();
+}
+
 UserDuration OsrmRoutedWrapper::get_duration_value(
   const rapidjson::Value& matrix_entry) const {
   return round_cost<UserDuration>(matrix_entry.GetDouble());
+}
+
+UserDistance OsrmRoutedWrapper::get_distance_value(
+  const rapidjson::Value& matrix_entry) const {
+  return round_cost<UserDistance>(matrix_entry.GetDouble());
 }
 
 double

--- a/src/routing/osrm_routed_wrapper.cpp
+++ b/src/routing/osrm_routed_wrapper.cpp
@@ -62,6 +62,7 @@ OsrmRoutedWrapper::build_query(const std::vector<Location>& locations,
 }
 
 void OsrmRoutedWrapper::check_response(const rapidjson::Document& json_result,
+                                       const std::vector<Location>& locs,
                                        const std::string&) const {
   assert(json_result.HasMember("code"));
   std::string code = json_result["code"].GetString();
@@ -71,9 +72,11 @@ void OsrmRoutedWrapper::check_response(const rapidjson::Document& json_result,
       "Could not find a matching segment for coordinate ";
     if (code == "NoSegment" and message.starts_with(snapping_error_base)) {
       auto error_loc =
-        message.substr(snapping_error_base.size(),
-                       message.size() - snapping_error_base.size());
-      throw RoutingException("Snapping error with location " + error_loc);
+        std::stoul(message.substr(snapping_error_base.size(),
+                                  message.size() - snapping_error_base.size()));
+      auto coordinates = "[" + std::to_string(locs[error_loc].lon()) + "," +
+                         std::to_string(locs[error_loc].lat()) + "]";
+      throw RoutingException("Snapping error with location " + coordinates);
     }
 
     throw RoutingException(message);

--- a/src/routing/osrm_routed_wrapper.h
+++ b/src/routing/osrm_routed_wrapper.h
@@ -20,6 +20,7 @@ private:
                           const std::string& service) const override;
 
   void check_response(const rapidjson::Document& json_result,
+                      const std::vector<Location>& locs,
                       const std::string& service) const override;
 
   bool

--- a/src/routing/osrm_routed_wrapper.h
+++ b/src/routing/osrm_routed_wrapper.h
@@ -25,8 +25,14 @@ private:
   bool
   duration_value_is_null(const rapidjson::Value& matrix_entry) const override;
 
+  bool
+  distance_value_is_null(const rapidjson::Value& matrix_entry) const override;
+
   UserDuration
   get_duration_value(const rapidjson::Value& matrix_entry) const override;
+
+  UserDistance
+  get_distance_value(const rapidjson::Value& matrix_entry) const override;
 
   double get_total_distance(const rapidjson::Value& result) const override;
 

--- a/src/routing/osrm_routed_wrapper.h
+++ b/src/routing/osrm_routed_wrapper.h
@@ -17,8 +17,7 @@ namespace vroom::routing {
 class OsrmRoutedWrapper : public HttpWrapper {
 private:
   std::string build_query(const std::vector<Location>& locations,
-                          const std::string& service,
-                          const std::string& extra_args) const override;
+                          const std::string& service) const override;
 
   void check_response(const rapidjson::Document& json_result,
                       const std::string& service) const override;

--- a/src/routing/valhalla_wrapper.cpp
+++ b/src/routing/valhalla_wrapper.cpp
@@ -23,6 +23,7 @@ ValhallaWrapper::ValhallaWrapper(const std::string& profile,
                 server,
                 "sources_to_targets",
                 "sources_to_targets",
+                "sources_to_targets",
                 "route",
                 R"("directions_type":"none")") {
 }

--- a/src/routing/valhalla_wrapper.cpp
+++ b/src/routing/valhalla_wrapper.cpp
@@ -124,10 +124,23 @@ bool ValhallaWrapper::duration_value_is_null(
   return matrix_entry["time"].IsNull();
 }
 
+bool ValhallaWrapper::distance_value_is_null(
+  const rapidjson::Value& matrix_entry) const {
+  assert(matrix_entry.HasMember("distance"));
+  return matrix_entry["distance"].IsNull();
+}
+
 UserDuration ValhallaWrapper::get_duration_value(
   const rapidjson::Value& matrix_entry) const {
   assert(matrix_entry["time"].IsUint());
   return matrix_entry["time"].GetUint();
+}
+
+UserDistance ValhallaWrapper::get_distance_value(
+  const rapidjson::Value& matrix_entry) const {
+  assert(matrix_entry["distance"].IsDouble());
+  return round_cost<UserDistance>(km_to_m *
+                                  matrix_entry["distance"].GetDouble());
 }
 
 double

--- a/src/routing/valhalla_wrapper.cpp
+++ b/src/routing/valhalla_wrapper.cpp
@@ -86,6 +86,7 @@ std::string ValhallaWrapper::build_query(const std::vector<Location>& locations,
 }
 
 void ValhallaWrapper::check_response(const rapidjson::Document& json_result,
+                                     const std::vector<Location>&,
                                      const std::string& service) const {
   assert(service == _matrix_service or service == _route_service);
 

--- a/src/routing/valhalla_wrapper.cpp
+++ b/src/routing/valhalla_wrapper.cpp
@@ -53,8 +53,7 @@ std::string ValhallaWrapper::get_matrix_query(
 }
 
 std::string
-ValhallaWrapper::get_route_query(const std::vector<Location>& locations,
-                                 const std::string& extra_args) const {
+ValhallaWrapper::get_route_query(const std::vector<Location>& locations) const {
   // Building matrix query for Valhalla.
   std::string query = "GET /" + _route_service + "?json={\"locations\":[";
 
@@ -66,9 +65,7 @@ ValhallaWrapper::get_route_query(const std::vector<Location>& locations,
   query.pop_back(); // Remove trailing ','.
 
   query += R"(],"costing":")" + profile + "\"";
-  if (!extra_args.empty()) {
-    query += "," + extra_args;
-  }
+  query += "," + _routing_args;
   query += "}";
 
   query += " HTTP/1.1\r\n";
@@ -80,12 +77,11 @@ ValhallaWrapper::get_route_query(const std::vector<Location>& locations,
 }
 
 std::string ValhallaWrapper::build_query(const std::vector<Location>& locations,
-                                         const std::string& service,
-                                         const std::string& extra_args) const {
+                                         const std::string& service) const {
   assert(service == _matrix_service or service == _route_service);
 
   return (service == _matrix_service) ? get_matrix_query(locations)
-                                      : get_route_query(locations, extra_args);
+                                      : get_route_query(locations);
 }
 
 void ValhallaWrapper::check_response(const rapidjson::Document& json_result,

--- a/src/routing/valhalla_wrapper.h
+++ b/src/routing/valhalla_wrapper.h
@@ -29,8 +29,14 @@ private:
   bool
   duration_value_is_null(const rapidjson::Value& matrix_entry) const override;
 
+  bool
+  distance_value_is_null(const rapidjson::Value& matrix_entry) const override;
+
   UserDuration
   get_duration_value(const rapidjson::Value& matrix_entry) const override;
+
+  UserDistance
+  get_distance_value(const rapidjson::Value& matrix_entry) const override;
 
   double get_total_distance(const rapidjson::Value& result) const override;
 

--- a/src/routing/valhalla_wrapper.h
+++ b/src/routing/valhalla_wrapper.h
@@ -24,6 +24,7 @@ private:
                           const std::string& service) const override;
 
   void check_response(const rapidjson::Document& json_result,
+                      const std::vector<Location>& locs,
                       const std::string& service) const override;
 
   bool

--- a/src/routing/valhalla_wrapper.h
+++ b/src/routing/valhalla_wrapper.h
@@ -18,12 +18,10 @@ class ValhallaWrapper : public HttpWrapper {
 private:
   std::string get_matrix_query(const std::vector<Location>& locations) const;
 
-  std::string get_route_query(const std::vector<Location>& locations,
-                              const std::string& extra_args = "") const;
+  std::string get_route_query(const std::vector<Location>& locations) const;
 
   std::string build_query(const std::vector<Location>& locations,
-                          const std::string& service,
-                          const std::string& extra_args) const override;
+                          const std::string& service) const override;
 
   void check_response(const rapidjson::Document& json_result,
                       const std::string& service) const override;

--- a/src/routing/wrapper.h
+++ b/src/routing/wrapper.h
@@ -23,8 +23,7 @@ struct Matrices {
   Matrix<UserDuration> durations;
   Matrix<UserDistance> distances;
 
-  Matrices(std::size_t n) : durations(n), distances(n) {
-  };
+  Matrices(std::size_t n) : durations(n), distances(n){};
 };
 
 class Wrapper {
@@ -32,8 +31,7 @@ class Wrapper {
 public:
   std::string profile;
 
-  virtual Matrix<UserCost>
-  get_matrix(const std::vector<Location>& locs) const = 0;
+  virtual Matrices get_matrices(const std::vector<Location>& locs) const = 0;
 
   virtual void add_route_info(Route& route) const = 0;
 

--- a/src/routing/wrapper.h
+++ b/src/routing/wrapper.h
@@ -19,6 +19,14 @@ All rights reserved (see LICENSE).
 
 namespace vroom::routing {
 
+struct Matrices {
+  Matrix<UserDuration> durations;
+  Matrix<UserDistance> distances;
+
+  Matrices(std::size_t n) : durations(n), distances(n) {
+  };
+};
+
 class Wrapper {
 
 public:

--- a/src/routing/wrapper.h
+++ b/src/routing/wrapper.h
@@ -70,7 +70,7 @@ protected:
     if (max_unfound_routes_for_a_loc > 0) {
       std::string error_msg = "Unfound route(s) ";
       error_msg += error_direction;
-      error_msg += "location [" + std::to_string(locs[error_loc].lon()) + ";" +
+      error_msg += "location [" + std::to_string(locs[error_loc].lon()) + "," +
                    std::to_string(locs[error_loc].lat()) + "]";
 
       throw RoutingException(error_msg);

--- a/src/routing/wrapper.h
+++ b/src/routing/wrapper.h
@@ -41,9 +41,9 @@ protected:
   Wrapper(std::string profile) : profile(std::move(profile)) {
   }
 
-  static UserCost round_cost(double value) {
+  template <typename T> static T round_cost(double value) {
     constexpr double round_increment = 0.5;
-    return static_cast<UserCost>(value + round_increment);
+    return static_cast<T>(value + round_increment);
   }
 
   static inline void

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -57,6 +57,7 @@ constexpr UserCost INFINITE_USER_COST =
   3 * (std::numeric_limits<UserCost>::max() / 4);
 
 const std::string DEFAULT_PROFILE = "car";
+const std::string DEFAULT_OSRM_SNAPPING_RADIUS = "35000";
 
 // Our internal time measure is the hundredth of a second.
 constexpr Duration DURATION_FACTOR = 100;

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -35,6 +35,7 @@ using Cost = int64_t;
 using Distance = uint32_t;
 using UserDuration = uint32_t;
 using Duration = int64_t;
+using UserDistance = uint32_t;
 using Coordinate = double;
 using Capacity = int64_t;
 using Skill = uint32_t;

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -58,6 +58,7 @@ constexpr UserCost INFINITE_USER_COST =
 
 const std::string DEFAULT_PROFILE = "car";
 const std::string DEFAULT_OSRM_SNAPPING_RADIUS = "35000";
+constexpr double DEFAULT_LIBOSRM_SNAPPING_RADIUS = 35000;
 
 // Our internal time measure is the hundredth of a second.
 constexpr Duration DURATION_FACTOR = 100;

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -32,7 +32,6 @@ using Id = uint64_t;
 using Index = uint16_t;
 using UserCost = uint32_t;
 using Cost = int64_t;
-using Distance = uint32_t;
 using UserDuration = uint32_t;
 using Duration = int64_t;
 using UserDistance = uint32_t;

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -7,6 +7,8 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <iostream>
+
 #include <mutex>
 #include <thread>
 
@@ -951,6 +953,47 @@ Solution Input::solve(unsigned exploration_level,
 
   set_matrices(nb_thread);
   set_vehicles_costs();
+
+  for (const auto& profile : _profiles) {
+    std::cout << "* Durations matrix for profile " << profile << std::endl;
+    assert(_durations_matrices.find(profile) != _durations_matrices.end());
+    const auto& duration_m = _durations_matrices.find(profile)->second;
+
+    for (std::size_t i = 0; i < duration_m.size(); ++i) {
+      for (std::size_t j = 0; j < duration_m.size(); ++j) {
+        std::cout << duration_m[i][j] << "\t";
+      }
+      std::cout << std::endl;
+    }
+
+    if (_distances_matrices.find(profile) != _distances_matrices.end()) {
+      std::cout << "* Distances matrix for profile " << profile << std::endl;
+
+      const auto& distance_m = _distances_matrices.find(profile)->second;
+
+      for (std::size_t i = 0; i < distance_m.size(); ++i) {
+        for (std::size_t j = 0; j < distance_m.size(); ++j) {
+          std::cout << distance_m[i][j] << "\t";
+        }
+        std::cout << std::endl;
+      }
+    }
+
+    if (_costs_matrices.find(profile) != _costs_matrices.end()) {
+      std::cout << "* Costs matrix for profile " << profile << std::endl;
+
+      const auto& distance_m = _costs_matrices.find(profile)->second;
+
+      for (std::size_t i = 0; i < distance_m.size(); ++i) {
+        for (std::size_t j = 0; j < distance_m.size(); ++j) {
+          std::cout << distance_m[i][j] << "\t";
+        }
+        std::cout << std::endl;
+      }
+    }
+  }
+
+  exit(0);
 
   // Fill vehicle/job compatibility matrices.
   set_skills_compatibility();

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -988,46 +988,46 @@ Solution Input::solve(unsigned exploration_level,
   set_matrices(nb_thread);
   set_vehicles_costs();
 
-  for (const auto& profile : _profiles) {
-    std::cout << "* Durations matrix for profile " << profile << std::endl;
-    assert(_durations_matrices.find(profile) != _durations_matrices.end());
-    const auto& duration_m = _durations_matrices.find(profile)->second;
+  // for (const auto& profile : _profiles) {
+  //   std::cout << "* Durations matrix for profile " << profile << std::endl;
+  //   assert(_durations_matrices.find(profile) != _durations_matrices.end());
+  //   const auto& duration_m = _durations_matrices.find(profile)->second;
 
-    for (std::size_t i = 0; i < duration_m.size(); ++i) {
-      for (std::size_t j = 0; j < duration_m.size(); ++j) {
-        std::cout << duration_m[i][j] << "\t";
-      }
-      std::cout << std::endl;
-    }
+  //   for (std::size_t i = 0; i < duration_m.size(); ++i) {
+  //     for (std::size_t j = 0; j < duration_m.size(); ++j) {
+  //       std::cout << duration_m[i][j] << "\t";
+  //     }
+  //     std::cout << std::endl;
+  //   }
 
-    if (_distances_matrices.find(profile) != _distances_matrices.end()) {
-      std::cout << "* Distances matrix for profile " << profile << std::endl;
+  //   if (_distances_matrices.find(profile) != _distances_matrices.end()) {
+  //     std::cout << "* Distances matrix for profile " << profile << std::endl;
 
-      const auto& distance_m = _distances_matrices.find(profile)->second;
+  //     const auto& distance_m = _distances_matrices.find(profile)->second;
 
-      for (std::size_t i = 0; i < distance_m.size(); ++i) {
-        for (std::size_t j = 0; j < distance_m.size(); ++j) {
-          std::cout << distance_m[i][j] << "\t";
-        }
-        std::cout << std::endl;
-      }
-    }
+  //     for (std::size_t i = 0; i < distance_m.size(); ++i) {
+  //       for (std::size_t j = 0; j < distance_m.size(); ++j) {
+  //         std::cout << distance_m[i][j] << "\t";
+  //       }
+  //       std::cout << std::endl;
+  //     }
+  //   }
 
-    if (_costs_matrices.find(profile) != _costs_matrices.end()) {
-      std::cout << "* Costs matrix for profile " << profile << std::endl;
+  //   if (_costs_matrices.find(profile) != _costs_matrices.end()) {
+  //     std::cout << "* Costs matrix for profile " << profile << std::endl;
 
-      const auto& distance_m = _costs_matrices.find(profile)->second;
+  //     const auto& distance_m = _costs_matrices.find(profile)->second;
 
-      for (std::size_t i = 0; i < distance_m.size(); ++i) {
-        for (std::size_t j = 0; j < distance_m.size(); ++j) {
-          std::cout << distance_m[i][j] << "\t";
-        }
-        std::cout << std::endl;
-      }
-    }
-  }
+  //     for (std::size_t i = 0; i < distance_m.size(); ++i) {
+  //       for (std::size_t j = 0; j < distance_m.size(); ++j) {
+  //         std::cout << distance_m[i][j] << "\t";
+  //       }
+  //       std::cout << std::endl;
+  //     }
+  //   }
+  // }
 
-  exit(0);
+  // exit(0);
 
   // Fill vehicle/job compatibility matrices.
   set_skills_compatibility();

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -386,6 +386,14 @@ void Input::set_durations_matrix(const std::string& profile,
   _durations_matrices.insert_or_assign(profile, m);
 }
 
+void Input::set_distances_matrix(const std::string& profile,
+                                 Matrix<UserDistance>&& m) {
+  if (m.size() == 0) {
+    throw InputException("Empty distances matrix for " + profile + " profile.");
+  }
+  _distances_matrices.insert_or_assign(profile, m);
+}
+
 void Input::set_costs_matrix(const std::string& profile, Matrix<UserCost>&& m) {
   if (m.size() == 0) {
     throw InputException("Empty costs matrix for " + profile + " profile.");

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -988,47 +988,6 @@ Solution Input::solve(unsigned exploration_level,
   set_matrices(nb_thread);
   set_vehicles_costs();
 
-  // for (const auto& profile : _profiles) {
-  //   std::cout << "* Durations matrix for profile " << profile << std::endl;
-  //   assert(_durations_matrices.find(profile) != _durations_matrices.end());
-  //   const auto& duration_m = _durations_matrices.find(profile)->second;
-
-  //   for (std::size_t i = 0; i < duration_m.size(); ++i) {
-  //     for (std::size_t j = 0; j < duration_m.size(); ++j) {
-  //       std::cout << duration_m[i][j] << "\t";
-  //     }
-  //     std::cout << std::endl;
-  //   }
-
-  //   if (_distances_matrices.find(profile) != _distances_matrices.end()) {
-  //     std::cout << "* Distances matrix for profile " << profile << std::endl;
-
-  //     const auto& distance_m = _distances_matrices.find(profile)->second;
-
-  //     for (std::size_t i = 0; i < distance_m.size(); ++i) {
-  //       for (std::size_t j = 0; j < distance_m.size(); ++j) {
-  //         std::cout << distance_m[i][j] << "\t";
-  //       }
-  //       std::cout << std::endl;
-  //     }
-  //   }
-
-  //   if (_costs_matrices.find(profile) != _costs_matrices.end()) {
-  //     std::cout << "* Costs matrix for profile " << profile << std::endl;
-
-  //     const auto& distance_m = _costs_matrices.find(profile)->second;
-
-  //     for (std::size_t i = 0; i < distance_m.size(); ++i) {
-  //       for (std::size_t j = 0; j < distance_m.size(); ++j) {
-  //         std::cout << distance_m[i][j] << "\t";
-  //       }
-  //       std::cout << std::endl;
-  //     }
-  //   }
-  // }
-
-  // exit(0);
-
   // Fill vehicle/job compatibility matrices.
   set_skills_compatibility();
   set_extra_compatibility();

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -50,6 +50,7 @@ private:
   bool _has_jobs{false};
   bool _has_shipments{false};
   std::unordered_map<std::string, Matrix<UserDuration>> _durations_matrices;
+  std::unordered_map<std::string, Matrix<UserDistance>> _distances_matrices;
   std::unordered_map<std::string, Matrix<UserCost>> _costs_matrices;
   Cost _cost_upper_bound{0};
   std::vector<Location> _locations;
@@ -110,6 +111,10 @@ public:
 
   void set_durations_matrix(const std::string& profile,
                             Matrix<UserDuration>&& m);
+
+  void set_distances_matrix(const std::string& profile,
+                            Matrix<UserDistance>&& m);
+
   void set_costs_matrix(const std::string& profile, Matrix<UserCost>&& m);
 
   const Amount& zero_amount() const {

--- a/src/structures/vroom/solution/route.h
+++ b/src/structures/vroom/solution/route.h
@@ -33,7 +33,7 @@ struct Route {
   Violations violations;
 
   std::string geometry;
-  Distance distance;
+  UserDistance distance;
 
   Route();
 

--- a/src/structures/vroom/solution/step.h
+++ b/src/structures/vroom/solution/step.h
@@ -32,7 +32,7 @@ struct Step {
   UserDuration arrival;
   UserDuration duration;
   UserDuration waiting_time;
-  Distance distance;
+  UserDistance distance;
 
   Violations violations;
 

--- a/src/structures/vroom/solution/summary.h
+++ b/src/structures/vroom/solution/summary.h
@@ -29,7 +29,7 @@ struct Summary {
 
   UserDuration duration;
   UserDuration waiting_time;
-  Distance distance;
+  UserDistance distance;
   ComputingTimes computing_times;
 
   Violations violations;

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -603,6 +603,11 @@ void parse(Input& input, const std::string& input_str, bool geometry) {
                                      get_matrix<UserDuration>(
                                        profile_entry.value["durations"]));
         }
+        if (profile_entry.value.HasMember("distances")) {
+          input.set_distances_matrix(profile_entry.name.GetString(),
+                                     get_matrix<UserDistance>(
+                                       profile_entry.value["distances"]));
+        }
         if (profile_entry.value.HasMember("costs")) {
           input.set_costs_matrix(profile_entry.name.GetString(),
                                  get_matrix<UserCost>(


### PR DESCRIPTION
## Issue

Implements #922. I've created a branch on top of the feature branch for #960 since I don't want to have to fix conflicts once this one get merged. This may overestimate the diff here.

## Tasks

 - [x] Add default value for snapping radius
 - [x] Handle `radiuses=` param in `osrm-routed` request
 - [x] Handle `radiuses` param when using libosrm
 - [x] Generate a meaningful routing error for `NoSegment` OSRM errors
 - [x] Update `CHANGELOG.md`
 - [x] review
