### PR TITLE
allow a host to have a path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Recommendation on how to cite in publications (#943)
+- Support for URL path in host (#966)
 
 ### Changed
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -27,6 +27,7 @@ if type clang-format-14 2> /dev/null ; then
 elif type clang-format 2> /dev/null ; then
     # Clang format found, but need to check version
     CLANG_FORMAT=clang-format
+    V=$(clang-format --version)
     if [[ $V != *14.0* ]] ; then
         echo "clang-format is not 14.0 (returned ${V})"
         exit 1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
     .set_tab_expansion()
     .add_options("Solving")
     ("a,host",
-     "host for the routing profile",
+     "host for the routing profile, optionally with a URL path, e.g 'routing.openstreetmap.de/routed-car'",
      cxxopts::value<std::vector<std::string>>(host_args)->default_value({vroom::DEFAULT_PROFILE + ":0.0.0.0"}))
     ("c,choose-eta",
      "choose ETA for custom routes and report violations",

--- a/src/routing/ors_wrapper.cpp
+++ b/src/routing/ors_wrapper.cpp
@@ -44,7 +44,7 @@ std::string OrsWrapper::build_query(const std::vector<Location>& locations,
   body += "}";
 
   // Building query for ORS
-  std::string query = "POST /ors/v2/" + service + "/" + profile;
+  std::string query = "POST /" + _server.path + "ors/v2/" + service + "/" + profile;
 
   query += " HTTP/1.0\r\n";
   query += "Accept: */*\r\n";

--- a/src/routing/osrm_routed_wrapper.cpp
+++ b/src/routing/osrm_routed_wrapper.cpp
@@ -27,7 +27,7 @@ OsrmRoutedWrapper::build_query(const std::vector<Location>& locations,
                                const std::string& service,
                                const std::string& extra_args) const {
   // Building query for osrm-routed
-  std::string query = "GET /" + service;
+  std::string query = "GET /" + _server.path + service;
 
   query += "/v1/" + profile + "/";
 

--- a/src/routing/valhalla_wrapper.cpp
+++ b/src/routing/valhalla_wrapper.cpp
@@ -30,7 +30,7 @@ ValhallaWrapper::ValhallaWrapper(const std::string& profile,
 std::string ValhallaWrapper::get_matrix_query(
   const std::vector<Location>& locations) const {
   // Building matrix query for Valhalla.
-  std::string query = "GET /" + _matrix_service + "?json=";
+  std::string query = "GET /" + _server.path + _matrix_service + "?json=";
 
   // List locations.
   std::string all_locations;
@@ -56,7 +56,7 @@ std::string
 ValhallaWrapper::get_route_query(const std::vector<Location>& locations,
                                  const std::string& extra_args) const {
   // Building matrix query for Valhalla.
-  std::string query = "GET /" + _route_service + "?json={\"locations\":[";
+  std::string query = "GET /" + _server.path + _route_service + "?json={\"locations\":[";
 
   for (auto const& location : locations) {
     query += "{\"lon\":" + std::to_string(location.lon()) + "," +

--- a/src/structures/cl_args.cpp
+++ b/src/structures/cl_args.cpp
@@ -17,6 +17,7 @@ void update_host(Servers& servers, const std::string& value) {
   // Determine profile and host from a "car:0.0.0.0"-like value.
   std::string profile = DEFAULT_PROFILE;
   std::string host;
+  std::string path = "";
 
   auto index = value.find(':');
   if (index == std::string::npos) {
@@ -26,13 +27,27 @@ void update_host(Servers& servers, const std::string& value) {
     host = value.substr(index + 1);
   }
 
+  // remove any trailing slash
+  if (host.find('/') == host.length() - 1) {
+    host.pop_back();
+  }
+
+  // pull out a path if any and append a trailing slash for query building
+  index = host.find('/');
+  if (index != std::string::npos) {
+    path = host.substr(index + 1) + "/";
+    host = host.substr(0, index);
+  }
+
   auto existing_profile = servers.find(profile);
   if (existing_profile != servers.end()) {
     existing_profile->second.host = host;
+    existing_profile->second.path = path;
   } else {
     auto add_result = servers.emplace(profile, Server());
     assert(add_result.second);
     add_result.first->second.host = host;
+    add_result.first->second.path = path;
   }
 }
 

--- a/src/structures/cl_args.cpp
+++ b/src/structures/cl_args.cpp
@@ -27,16 +27,18 @@ void update_host(Servers& servers, const std::string& value) {
     host = value.substr(index + 1);
   }
 
-  // remove any trailing slash
-  if (host.find('/') == host.length() - 1) {
-    host.pop_back();
-  }
+  if (!host.empty()) {
+    // remove any trailing slash
+    if (host.back() == '/') {
+      host.pop_back();
+    }
 
-  // pull out a path if any and append a trailing slash for query building
-  index = host.find('/');
-  if (index != std::string::npos) {
-    path = host.substr(index + 1) + "/";
-    host = host.substr(0, index);
+    // pull out a path if any and append a trailing slash for query building
+    index = host.find('/');
+    if (index != std::string::npos) {
+      path = host.substr(index + 1) + "/";
+      host = host.substr(0, index);
+    }
   }
 
   auto existing_profile = servers.find(profile);

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -86,12 +86,13 @@ enum class ROUTER { OSRM, LIBOSRM, ORS, VALHALLA };
 struct Server {
   std::string host;
   std::string port;
+  std::string path;
 
-  Server() : host("0.0.0.0"), port("5000") {
+  Server() : host("0.0.0.0"), port("5000"), path("") {
   }
 
   Server(std::string host, std::string port)
-    : host(std::move(host)), port(std::move(port)) {
+    : host(std::move(host)), port(std::move(port)), path("") {
   }
 };
 


### PR DESCRIPTION
## Issue

fixes #966 

Now this can be done (note, we're robust to (non-)existing trailing slash in the path):
```
vroom -i docs/example_3.json -r osrm -a car:routing.openstreetmap.de/routed-car/ -p car:443 -c
```

## Tasks

 - [x] Update `CHANGELOG.md` (remove if irrelevant)
 - [x] review
