### PR TITLE
Improve `vrptw::PDShift`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add job id to error message for unreachable step (#946)
 - Reduce `compute_best_route_split_choice` complexity (#962)
 - `Eval::operator<` sorts on cost, then duration (#914)
+- Improved `vrptw::PDShift` implementation (#852)
 
 ### Fixed
 

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -2282,15 +2282,8 @@ void LocalSearch<Route,
         std::vector<Index> between_pd(_sol[v].route.begin() + r + 1,
                                       _sol[v].route.begin() + delivery_r);
 
-        Amount delivery = _input.zero_amount();
-        for (unsigned i = r + 1; i < delivery_r; ++i) {
-          const auto& job = _input.jobs[_sol[v].route[i]];
-          if (job.type == JOB_TYPE::SINGLE) {
-            delivery += job.delivery;
-          }
-        }
         _sol[v].replace(_input,
-                        delivery,
+                        _sol[v].delivery_in_range(r + 1, delivery_r),
                         between_pd.begin(),
                         between_pd.end(),
                         r,

--- a/src/problems/vrptw/operators/pd_shift.cpp
+++ b/src/problems/vrptw/operators/pd_shift.cpp
@@ -31,8 +31,6 @@ PDShift::PDShift(const Input& input,
                   static_cast<RawRoute&>(tw_t_route),
                   t_vehicle,
                   gain_threshold),
-    _source_without_pd(s_route.begin() + _s_p_rank + 1,
-                       s_route.begin() + _s_d_rank),
     _tw_s_route(tw_s_route),
     _tw_t_route(tw_t_route) {
 }
@@ -42,8 +40,8 @@ void PDShift::compute_gain() {
   bool is_valid_removal =
     _tw_s_route.is_valid_addition_for_tw(_input,
                                          _input.zero_amount(),
-                                         _source_without_pd.begin(),
-                                         _source_without_pd.end(),
+                                         s_route.begin() + _s_p_rank + 1,
+                                         s_route.begin() + _s_d_rank,
                                          _s_p_rank,
                                          _s_d_rank + 1);
   if (!is_valid_removal) {
@@ -85,10 +83,13 @@ void PDShift::apply() {
   if (_s_d_rank == _s_p_rank + 1) {
     _tw_s_route.remove(_input, _s_p_rank, 2);
   } else {
+    std::vector<Index> source_without_pd(s_route.begin() + _s_p_rank + 1,
+                                         s_route.begin() + _s_d_rank);
+
     _tw_s_route.replace(_input,
                         _tw_s_route.delivery_in_range(_s_p_rank + 1, _s_d_rank),
-                        _source_without_pd.begin(),
-                        _source_without_pd.end(),
+                        source_without_pd.begin(),
+                        source_without_pd.end(),
                         _s_p_rank,
                         _s_d_rank + 1);
   }

--- a/src/problems/vrptw/operators/pd_shift.cpp
+++ b/src/problems/vrptw/operators/pd_shift.cpp
@@ -85,15 +85,8 @@ void PDShift::apply() {
   if (_s_d_rank == _s_p_rank + 1) {
     _tw_s_route.remove(_input, _s_p_rank, 2);
   } else {
-    Amount delivery = _input.zero_amount();
-    for (unsigned i = _s_p_rank + 1; i < _s_d_rank; ++i) {
-      const auto& job = _input.jobs[s_route[i]];
-      if (job.type == JOB_TYPE::SINGLE) {
-        delivery += job.delivery;
-      }
-    }
     _tw_s_route.replace(_input,
-                        delivery,
+                        _tw_s_route.delivery_in_range(_s_p_rank + 1, _s_d_rank),
                         _source_without_pd.begin(),
                         _source_without_pd.end(),
                         _s_p_rank,

--- a/src/problems/vrptw/operators/pd_shift.h
+++ b/src/problems/vrptw/operators/pd_shift.h
@@ -16,7 +16,6 @@ namespace vroom::vrptw {
 
 class PDShift : public cvrp::PDShift {
 private:
-  std::vector<Index> _source_without_pd;
   TWRoute& _tw_s_route;
   TWRoute& _tw_t_route;
   Amount _best_t_delivery;


### PR DESCRIPTION
## Issue

Fixes #852

## Tasks

 - [x] Only generate `source_without_pd` upon applying `PDShift`
 - [x] Remove unnecessary loops that can be replaced by `delivery_in_range`
 - [x] Update `CHANGELOG.md`
 - [x] review
