### PR TITLE
Expose geometry

### DIFF
--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -44,6 +44,10 @@ void Input::set_geometry(bool geometry) {
   _geometry = geometry;
 }
 
+bool Input::get_geometry() {
+  return _geometry;
+}
+
 void Input::add_routing_wrapper(const std::string& profile) {
 #if !USE_ROUTING
   throw RoutingException("VROOM compiled without routing support.");

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -103,6 +103,8 @@ public:
 
   void set_geometry(bool geometry);
 
+  bool get_geometry();
+
   void add_job(const Job& job);
 
   void add_shipment(const Job& pickup, const Job& delivery);


### PR DESCRIPTION
## Issue

There has been a request for accessing the geometry attribute:
https://github.com/VROOM-Project/pyvroom/issues/95

The attribute is unaccessible on the vroom side, so this patch exposes it so it can be read from pyvroom.

## Tasks

 - [ ] review
