### PR TITLE
Compatibility in heuristics regret values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Improved `vrptw::PDShift` implementation (#852)
 - Reserve `vector` capacity whenever possible (#915)
 - Refactor heuristics to be able to operate on a subset of jobs and vehicles (#837)
+- Account for vehicle/job compatibility in heuristic regrets values (#982)
 
 ### Fixed
 

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -470,9 +470,9 @@ Eval dynamic_vehicle_choice(const Input& input,
     // (resp. second min cost) of picking the job in an empty route
     // for any remaining vehicle.
     std::vector<Cost> jobs_min_costs(input.jobs.size(),
-                                     std::numeric_limits<Cost>::max());
+                                     input.get_cost_upper_bound());
     std::vector<Cost> jobs_second_min_costs(input.jobs.size(),
-                                            std::numeric_limits<Cost>::max());
+                                            input.get_cost_upper_bound());
     for (const auto job_rank : unassigned) {
       for (const auto v_rank : vehicles_ranks) {
         if (evals[job_rank][v_rank].cost <= jobs_min_costs[job_rank]) {

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -176,8 +176,12 @@ inline UserDuration scale_to_user_duration(Duration d) {
   return static_cast<UserDuration>(d / DURATION_FACTOR);
 }
 
-inline UserCost scale_to_user_cost(Cost d) {
-  return static_cast<UserCost>(d / (DURATION_FACTOR * COST_FACTOR));
+inline Cost scale_from_user_cost(UserCost c) {
+  return DURATION_FACTOR * COST_FACTOR * static_cast<Cost>(c);
+}
+
+inline UserCost scale_to_user_cost(Cost c) {
+  return static_cast<UserCost>(c / (DURATION_FACTOR * COST_FACTOR));
 }
 } // namespace utils
 

--- a/src/structures/vroom/eval.h
+++ b/src/structures/vroom/eval.h
@@ -73,6 +73,8 @@ struct Eval {
   }
 };
 
+constexpr Eval MAX_EVAL = {std::numeric_limits<Cost>::max(),
+                           std::numeric_limits<Duration>::max()};
 constexpr Eval NO_EVAL = {std::numeric_limits<Cost>::max(), 0};
 constexpr Eval NO_GAIN = {std::numeric_limits<Cost>::min(), 0};
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -990,7 +990,7 @@ void Input::set_matrices(unsigned nb_thread) {
           cost_bound_m.lock();
           _cost_upper_bound =
             std::max(_cost_upper_bound,
-                     utils::scale_from_user_duration(current_bound));
+                     utils::scale_from_user_cost(current_bound));
           cost_bound_m.unlock();
         } else {
           // Durations matrix will be used for costs.
@@ -998,7 +998,9 @@ void Input::set_matrices(unsigned nb_thread) {
           cost_bound_m.lock();
           _cost_upper_bound =
             std::max(_cost_upper_bound,
-                     utils::scale_from_user_duration(current_bound));
+                     // TODO scale based on max factor for this profile.
+                     DEFAULT_COST_PER_HOUR *
+                       utils::scale_from_user_duration(current_bound));
           cost_bound_m.unlock();
         }
       }

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -1002,11 +1002,15 @@ void Input::set_matrices(unsigned nb_thread) {
         } else {
           // Durations matrix will be used for costs.
           const UserCost current_bound = check_cost_bound(durations_m->second);
+
+          auto search = _max_cost_per_hour.find(profile);
+          assert(search != _max_cost_per_hour.end());
+          const auto max_cost_per_hour_for_profile = search->second;
+
           cost_bound_m.lock();
           _cost_upper_bound =
             std::max(_cost_upper_bound,
-                     // TODO scale based on max factor for this profile.
-                     DEFAULT_COST_PER_HOUR *
+                     max_cost_per_hour_for_profile *
                        utils::scale_from_user_duration(current_bound));
           cost_bound_m.unlock();
         }

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -718,7 +718,8 @@ void Input::set_jobs_vehicles_evals() {
   // in an empty route from vehicle at rank v.
   _jobs_vehicles_evals =
     std::vector<std::vector<Eval>>(jobs.size(),
-                                   std::vector<Eval>(vehicles.size()));
+                                   std::vector<Eval>(vehicles.size(),
+                                                     MAX_EVAL));
 
   for (std::size_t j = 0; j < jobs.size(); ++j) {
     Index j_index = jobs[j].index();
@@ -733,6 +734,11 @@ void Input::set_jobs_vehicles_evals() {
 
     for (std::size_t v = 0; v < vehicles.size(); ++v) {
       const auto& vehicle = vehicles[v];
+
+      if (!vehicle_ok_with_job(v, j)) {
+        continue;
+      }
+
       auto& current_eval = _jobs_vehicles_evals[j][v];
 
       current_eval = is_pickup ? vehicle.eval(j_index, last_job_index) : Eval();

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -376,6 +376,13 @@ void Input::add_vehicle(const Vehicle& vehicle) {
   }
 
   _profiles.insert(current_v.profile);
+
+  auto search = _max_cost_per_hour.find(current_v.profile);
+  if (search == _max_cost_per_hour.end()) {
+    _max_cost_per_hour.insert({current_v.profile, current_v.costs.per_hour});
+  } else {
+    search->second = std::max(search->second, current_v.costs.per_hour);
+  }
 }
 
 void Input::set_durations_matrix(const std::string& profile,

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -52,6 +52,7 @@ private:
   std::unordered_map<std::string, Matrix<UserDuration>> _durations_matrices;
   std::unordered_map<std::string, Matrix<UserDistance>> _distances_matrices;
   std::unordered_map<std::string, Matrix<UserCost>> _costs_matrices;
+  std::unordered_map<std::string, Cost> _max_cost_per_hour;
   Cost _cost_upper_bound{0};
   std::vector<Location> _locations;
   std::unordered_map<Location, Index> _locations_to_index;

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -29,7 +29,7 @@ struct VehicleCosts {
   const Cost per_hour;
 
   VehicleCosts(UserCost fixed = 0, UserCost per_hour = DEFAULT_COST_PER_HOUR)
-    : fixed(COST_FACTOR * utils::scale_from_user_duration(fixed)),
+    : fixed(utils::scale_from_user_cost(fixed)),
       per_hour(static_cast<Cost>(per_hour)){};
 
   friend bool operator==(const VehicleCosts& lhs, const VehicleCosts& rhs) {


### PR DESCRIPTION
## Issue

Fixes #982 

## Tasks

 - [x] Account for compatibility in `Input::set_jobs_vehicles_evals`
 - [x] Adjust usage in dynamic heuristic
 - [x] Improve internal upper bound scaling
 - [x] Update `CHANGELOG.md`
 - [ ] review
