### PR TITLE
Add `max_distance` constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Support for `max_distance` at vehicle level (#354)
 - Recommendation on how to cite in publications (#943)
 - Store distance matrices (#956)
 - Default radius of 35km for OSRM snapping (#922)

--- a/docs/API.md
+++ b/docs/API.md
@@ -117,6 +117,7 @@ A `vehicle` object has the following properties:
 | [`speed_factor`] | a double value in the range `(0, 5]` used to scale **all** vehicle travel times (defaults to 1.), the respected precision is limited to two digits after the decimal point |
 | [`max_tasks`] | an integer defining the maximum number of tasks in a route for this vehicle |
 | [`max_travel_time`] | an integer defining the maximum travel time for this vehicle |
+| [`max_distance`] | an integer defining the maximum distance for this vehicle |
 | [`steps`] | an array of `vehicle_step` objects describing a custom route for this vehicle |
 
 A `cost` object has the following properties:

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -492,16 +492,12 @@ Eval dynamic_vehicle_choice(const Input& input,
       const auto chosen_vehicle =
         std::ranges::min_element(vehicles_ranks,
                                  [&](const auto lhs, const auto rhs) {
-                                   auto& v_lhs = input.vehicles[lhs];
-                                   auto& v_rhs = input.vehicles[rhs];
                                    return closest_jobs_count[lhs] >
                                             closest_jobs_count[rhs] ||
                                           (closest_jobs_count[lhs] ==
                                              closest_jobs_count[rhs] &&
-                                           (v_rhs.capacity < v_lhs.capacity ||
-                                            (v_lhs.capacity == v_rhs.capacity &&
-                                             v_lhs.tw.length >
-                                               v_rhs.tw.length)));
+                                           input.vehicles[lhs] <
+                                             input.vehicles[rhs]);
                                  });
       v_rank = *chosen_vehicle;
       vehicles_ranks.erase(chosen_vehicle);
@@ -519,11 +515,8 @@ Eval dynamic_vehicle_choice(const Input& input,
                                              closest_jobs_count[rhs] &&
                                            (v_lhs.costs < v_rhs.costs ||
                                             (v_lhs.costs == v_rhs.costs &&
-                                             (v_rhs.capacity < v_lhs.capacity ||
-                                              (v_lhs.capacity ==
-                                                 v_rhs.capacity &&
-                                               v_lhs.tw.length >
-                                                 v_rhs.tw.length)))));
+                                             input.vehicles[lhs] <
+                                               input.vehicles[rhs])));
                                  });
       v_rank = *chosen_vehicle;
       vehicles_ranks.erase(chosen_vehicle);

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -980,6 +980,10 @@ void initial_routes(const Input& input, std::vector<Route>& routes) {
       throw InputException("Route over max_travel_time for vehicle " +
                            std::to_string(vehicle.id) + ".");
     }
+    if (!vehicle.ok_for_distance(eval_sum.distance)) {
+      throw InputException("Route over max_distance for vehicle " +
+                           std::to_string(vehicle.id) + ".");
+    }
 
     if (vehicle.max_tasks < job_ranks.size()) {
       throw InputException("Too many tasks for vehicle " +

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -56,8 +56,8 @@ Eval basic(const Input& input,
     // Sort vehicles by increasing fixed cost, then same as above.
     std::ranges::stable_sort(vehicles_ranks,
                              [&](const auto lhs, const auto rhs) {
-                               auto& v_lhs = input.vehicles[lhs];
-                               auto& v_rhs = input.vehicles[rhs];
+                               const auto& v_lhs = input.vehicles[lhs];
+                               const auto& v_rhs = input.vehicles[rhs];
                                return v_lhs.costs < v_rhs.costs ||
                                       (v_lhs.costs == v_rhs.costs &&
                                        input.vehicles[lhs] <
@@ -507,16 +507,15 @@ Eval dynamic_vehicle_choice(const Input& input,
       const auto chosen_vehicle =
         std::ranges::min_element(vehicles_ranks,
                                  [&](const auto lhs, const auto rhs) {
-                                   auto& v_lhs = input.vehicles[lhs];
-                                   auto& v_rhs = input.vehicles[rhs];
+                                   const auto& v_lhs = input.vehicles[lhs];
+                                   const auto& v_rhs = input.vehicles[rhs];
                                    return closest_jobs_count[lhs] >
                                             closest_jobs_count[rhs] ||
                                           (closest_jobs_count[lhs] ==
                                              closest_jobs_count[rhs] &&
                                            (v_lhs.costs < v_rhs.costs ||
                                             (v_lhs.costs == v_rhs.costs &&
-                                             input.vehicles[lhs] <
-                                               input.vehicles[rhs])));
+                                             v_lhs < v_rhs)));
                                  });
       v_rank = *chosen_vehicle;
       vehicles_ranks.erase(chosen_vehicle);

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -426,7 +426,7 @@ Eval basic(const Input& input,
 
     if (!current_r.empty()) {
       sol_eval += current_route_eval;
-      sol_eval += Eval(vehicle.fixed_cost(), 0);
+      sol_eval += Eval(vehicle.fixed_cost());
     }
   }
 
@@ -876,7 +876,7 @@ Eval dynamic_vehicle_choice(const Input& input,
 
     if (!current_r.empty()) {
       sol_eval += current_route_eval;
-      sol_eval += Eval(vehicle.fixed_cost(), 0);
+      sol_eval += Eval(vehicle.fixed_cost());
     }
   }
 

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -477,7 +477,7 @@ Eval dynamic_vehicle_choice(const Input& input,
 
     // Pick vehicle that has the biggest number of compatible jobs
     // closest to him than to any other different vehicle.
-    std::vector<unsigned> closest_jobs_count(nb_vehicles, 0);
+    std::vector<unsigned> closest_jobs_count(input.vehicles.size(), 0);
     for (const auto job_rank : unassigned) {
       for (const auto v_rank : vehicles_ranks) {
         if (evals[job_rank][v_rank].cost == jobs_min_costs[job_rank]) {

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -44,20 +44,14 @@ Eval basic(const Input& input,
   std::copy(vehicles_begin, vehicles_end, std::back_inserter(vehicles_ranks));
 
   switch (sort) {
-  case SORT::CAPACITY:
-    // Sort vehicles by decreasing max number of tasks allowed, then
-    // capacity, then working hours length.
+  case SORT::CAPACITY: {
+    // Sort vehicles by decreasing "availability".
     std::ranges::stable_sort(vehicles_ranks,
                              [&](const auto lhs, const auto rhs) {
-                               auto& v_lhs = input.vehicles[lhs];
-                               auto& v_rhs = input.vehicles[rhs];
-                               return v_lhs.max_tasks > v_rhs.max_tasks ||
-                                      (v_lhs.max_tasks == v_rhs.max_tasks &&
-                                       (v_rhs.capacity < v_lhs.capacity ||
-                                        (v_lhs.capacity == v_rhs.capacity &&
-                                         v_lhs.tw.length > v_rhs.tw.length)));
+                               return input.vehicles[lhs] < input.vehicles[rhs];
                              });
     break;
+  }
   case SORT::COST:
     // Sort vehicles by increasing fixed cost, then same as above.
     std::ranges::stable_sort(vehicles_ranks,
@@ -66,12 +60,8 @@ Eval basic(const Input& input,
                                auto& v_rhs = input.vehicles[rhs];
                                return v_lhs.costs < v_rhs.costs ||
                                       (v_lhs.costs == v_rhs.costs &&
-                                       (v_lhs.max_tasks > v_rhs.max_tasks ||
-                                        (v_lhs.max_tasks == v_rhs.max_tasks &&
-                                         (v_rhs.capacity < v_lhs.capacity ||
-                                          (v_lhs.capacity == v_rhs.capacity &&
-                                           v_lhs.tw.length >
-                                             v_rhs.tw.length)))));
+                                       input.vehicles[lhs] <
+                                         input.vehicles[rhs]);
                              });
     break;
   }
@@ -80,7 +70,7 @@ Eval basic(const Input& input,
 
   // regrets[v][j] holds the min cost for reaching job j in an empty
   // route across all remaining vehicles **after** vehicle at rank v
-  // in vehicle_ranks.
+  // in vehicles_ranks.
   std::vector<std::vector<Cost>> regrets(nb_vehicles,
                                          std::vector<Cost>(input.jobs.size()));
 

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -154,7 +154,7 @@ Eval basic(const Input& input,
         }
 
         bool is_valid =
-          (vehicle.ok_for_travel_time(evals[job_rank][v_rank].duration)) &&
+          (vehicle.ok_for_range_bounds(evals[job_rank][v_rank])) &&
           current_r.is_valid_addition_for_capacity(input,
                                                    current_job.pickup,
                                                    current_job.delivery,
@@ -258,8 +258,8 @@ Eval basic(const Input& input,
               lambda * static_cast<double>(regrets[v][job_rank]);
 
             if (current_cost < best_cost &&
-                (vehicle.ok_for_travel_time(current_route_eval.duration +
-                                            current_eval.duration)) &&
+                (vehicle.ok_for_range_bounds(current_route_eval +
+                                             current_eval)) &&
                 current_r.is_valid_addition_for_capacity(input,
                                                          current_job.pickup,
                                                          current_job.delivery,
@@ -355,8 +355,8 @@ Eval basic(const Input& input,
 
                 // Update best cost depending on validity.
                 bool valid =
-                  (vehicle.ok_for_travel_time(current_route_eval.duration +
-                                              current_eval.duration)) &&
+                  (vehicle.ok_for_range_bounds(current_route_eval +
+                                               current_eval)) &&
                   current_r
                     .is_valid_addition_for_capacity_inclusion(input,
                                                               modified_delivery,
@@ -602,7 +602,7 @@ Eval dynamic_vehicle_choice(const Input& input,
         }
 
         bool is_valid =
-          (vehicle.ok_for_travel_time(evals[job_rank][v_rank].duration)) &&
+          (vehicle.ok_for_range_bounds(evals[job_rank][v_rank])) &&
           current_r.is_valid_addition_for_capacity(input,
                                                    current_job.pickup,
                                                    current_job.delivery,
@@ -707,8 +707,8 @@ Eval dynamic_vehicle_choice(const Input& input,
               lambda * static_cast<double>(regrets[job_rank]);
 
             if (current_cost < best_cost &&
-                (vehicle.ok_for_travel_time(current_route_eval.duration +
-                                            current_eval.duration)) &&
+                (vehicle.ok_for_range_bounds(current_route_eval +
+                                             current_eval)) &&
                 current_r.is_valid_addition_for_capacity(input,
                                                          current_job.pickup,
                                                          current_job.delivery,
@@ -804,8 +804,8 @@ Eval dynamic_vehicle_choice(const Input& input,
 
                 // Update best cost depending on validity.
                 bool valid =
-                  (vehicle.ok_for_travel_time(current_route_eval.duration +
-                                              current_eval.duration)) &&
+                  (vehicle.ok_for_range_bounds(current_route_eval +
+                                               current_eval)) &&
                   current_r
                     .is_valid_addition_for_capacity_inclusion(input,
                                                               modified_delivery,

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -44,7 +44,7 @@ Eval basic(const Input& input,
   std::copy(vehicles_begin, vehicles_end, std::back_inserter(vehicles_ranks));
 
   switch (sort) {
-  case SORT::CAPACITY: {
+  case SORT::AVAILABILITY: {
     // Sort vehicles by decreasing "availability".
     std::ranges::stable_sort(vehicles_ranks,
                              [&](const auto lhs, const auto rhs) {
@@ -488,7 +488,7 @@ Eval dynamic_vehicle_choice(const Input& input,
 
     Index v_rank;
 
-    if (sort == SORT::CAPACITY) {
+    if (sort == SORT::AVAILABILITY) {
       const auto chosen_vehicle =
         std::ranges::min_element(vehicles_ranks,
                                  [&](const auto lhs, const auto rhs) {

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -46,14 +46,14 @@ Eval basic(const Input& input,
   switch (sort) {
   case SORT::CAPACITY:
     // Sort vehicles by decreasing max number of tasks allowed, then
-    // capacity (not a total order), then working hours length.
+    // capacity, then working hours length.
     std::ranges::stable_sort(vehicles_ranks,
                              [&](const auto lhs, const auto rhs) {
                                auto& v_lhs = input.vehicles[lhs];
                                auto& v_rhs = input.vehicles[rhs];
                                return v_lhs.max_tasks > v_rhs.max_tasks ||
                                       (v_lhs.max_tasks == v_rhs.max_tasks &&
-                                       (v_rhs.capacity << v_lhs.capacity ||
+                                       (v_rhs.capacity < v_lhs.capacity ||
                                         (v_lhs.capacity == v_rhs.capacity &&
                                          v_lhs.tw.length > v_rhs.tw.length)));
                              });
@@ -68,7 +68,7 @@ Eval basic(const Input& input,
                                       (v_lhs.costs == v_rhs.costs &&
                                        (v_lhs.max_tasks > v_rhs.max_tasks ||
                                         (v_lhs.max_tasks == v_rhs.max_tasks &&
-                                         (v_rhs.capacity << v_lhs.capacity ||
+                                         (v_rhs.capacity < v_lhs.capacity ||
                                           (v_lhs.capacity == v_rhs.capacity &&
                                            v_lhs.tw.length >
                                              v_rhs.tw.length)))));
@@ -133,8 +133,8 @@ Eval basic(const Input& input,
         bool try_validity = false;
 
         if (init == INIT::HIGHER_AMOUNT) {
-          try_validity |= (higher_amount << current_job.pickup ||
-                           higher_amount << current_job.delivery);
+          try_validity |= (higher_amount < current_job.pickup ||
+                           higher_amount < current_job.delivery);
         }
         if (init == INIT::EARLIEST_DEADLINE) {
           Duration current_deadline =
@@ -183,10 +183,10 @@ Eval basic(const Input& input,
             assert(false);
             break;
           case INIT::HIGHER_AMOUNT:
-            if (higher_amount << current_job.pickup) {
+            if (higher_amount < current_job.pickup) {
               higher_amount = current_job.pickup;
             }
-            if (higher_amount << current_job.delivery) {
+            if (higher_amount < current_job.delivery) {
               higher_amount = current_job.delivery;
             }
             break;
@@ -508,7 +508,7 @@ Eval dynamic_vehicle_choice(const Input& input,
                                             closest_jobs_count[rhs] ||
                                           (closest_jobs_count[lhs] ==
                                              closest_jobs_count[rhs] &&
-                                           (v_rhs.capacity << v_lhs.capacity ||
+                                           (v_rhs.capacity < v_lhs.capacity ||
                                             (v_lhs.capacity == v_rhs.capacity &&
                                              v_lhs.tw.length >
                                                v_rhs.tw.length)));
@@ -518,18 +518,23 @@ Eval dynamic_vehicle_choice(const Input& input,
     } else {
       assert(sort == SORT::COST);
 
-      const auto chosen_vehicle = std::ranges::
-        min_element(vehicles_ranks, [&](const auto lhs, const auto rhs) {
-          auto& v_lhs = input.vehicles[lhs];
-          auto& v_rhs = input.vehicles[rhs];
-          return closest_jobs_count[lhs] > closest_jobs_count[rhs] ||
-                 (closest_jobs_count[lhs] == closest_jobs_count[rhs] &&
-                  (v_lhs.costs < v_rhs.costs ||
-                   (v_lhs.costs == v_rhs.costs &&
-                    (v_rhs.capacity << v_lhs.capacity ||
-                     (v_lhs.capacity == v_rhs.capacity &&
-                      v_lhs.tw.length > v_rhs.tw.length)))));
-        });
+      const auto chosen_vehicle =
+        std::ranges::min_element(vehicles_ranks,
+                                 [&](const auto lhs, const auto rhs) {
+                                   auto& v_lhs = input.vehicles[lhs];
+                                   auto& v_rhs = input.vehicles[rhs];
+                                   return closest_jobs_count[lhs] >
+                                            closest_jobs_count[rhs] ||
+                                          (closest_jobs_count[lhs] ==
+                                             closest_jobs_count[rhs] &&
+                                           (v_lhs.costs < v_rhs.costs ||
+                                            (v_lhs.costs == v_rhs.costs &&
+                                             (v_rhs.capacity < v_lhs.capacity ||
+                                              (v_lhs.capacity ==
+                                                 v_rhs.capacity &&
+                                               v_lhs.tw.length >
+                                                 v_rhs.tw.length)))));
+                                 });
       v_rank = *chosen_vehicle;
       vehicles_ranks.erase(chosen_vehicle);
     }
@@ -581,8 +586,8 @@ Eval dynamic_vehicle_choice(const Input& input,
         bool try_validity = false;
 
         if (init == INIT::HIGHER_AMOUNT) {
-          try_validity |= (higher_amount << current_job.pickup ||
-                           higher_amount << current_job.delivery);
+          try_validity |= (higher_amount < current_job.pickup ||
+                           higher_amount < current_job.delivery);
         }
         if (init == INIT::EARLIEST_DEADLINE) {
           Duration current_deadline =
@@ -632,10 +637,10 @@ Eval dynamic_vehicle_choice(const Input& input,
             assert(false);
             break;
           case INIT::HIGHER_AMOUNT:
-            if (higher_amount << current_job.pickup) {
+            if (higher_amount < current_job.pickup) {
               higher_amount = current_job.pickup;
             }
-            if (higher_amount << current_job.delivery) {
+            if (higher_amount < current_job.delivery) {
               higher_amount = current_job.delivery;
             }
             break;

--- a/src/algorithms/local_search/insertion_search.h
+++ b/src/algorithms/local_search/insertion_search.h
@@ -105,7 +105,7 @@ RouteInsertion compute_best_insertion_pd(const Input& input,
   for (unsigned d_rank = begin_d_rank; d_rank < end_d_rank; ++d_rank) {
     d_adds[d_rank] =
       utils::addition_cost(input, j + 1, v_target, route.route, d_rank);
-    if (d_adds[d_rank] > result.eval) {
+    if (result.eval < d_adds[d_rank]) {
       valid_delivery_insertions[d_rank] = false;
     } else {
       valid_delivery_insertions[d_rank] =
@@ -124,7 +124,7 @@ RouteInsertion compute_best_insertion_pd(const Input& input,
        ++pickup_r) {
     Eval p_add =
       utils::addition_cost(input, j, v_target, route.route, pickup_r);
-    if (p_add > result.eval) {
+    if (result.eval < p_add) {
       // Even without delivery insertion more expensive than current best.
       continue;
     }

--- a/src/algorithms/local_search/insertion_search.h
+++ b/src/algorithms/local_search/insertion_search.h
@@ -37,8 +37,8 @@ compute_best_insertion_single(const Input& input,
       Eval current_eval =
         utils::addition_cost(input, j, v_target, route.route, rank);
       if (current_eval.cost < result.eval.cost &&
-          v_target.ok_for_travel_time(sol_state.route_evals[v].duration +
-                                      current_eval.duration) &&
+          v_target.ok_for_range_bounds(sol_state.route_evals[v] +
+                                       current_eval) &&
           route.is_valid_addition_for_capacity(input,
                                                current_job.pickup,
                                                current_job.delivery,
@@ -87,7 +87,6 @@ RouteInsertion compute_best_insertion_pd(const Input& input,
   RouteInsertion result(input.get_amount_size());
   const auto& current_job = input.jobs[j];
   const auto& v_target = input.vehicles[v];
-  const auto target_travel_time = sol_state.route_evals[v].duration;
 
   if (!input.vehicle_ok_with_job(v, j)) {
     return result;
@@ -176,7 +175,7 @@ RouteInsertion compute_best_insertion_pd(const Input& input,
       }
 
       if (pd_eval < result.eval &&
-          v_target.ok_for_travel_time(target_travel_time + pd_eval.duration)) {
+          v_target.ok_for_range_bounds(sol_state.route_evals[v] + pd_eval)) {
         modified_with_pd.push_back(j + 1);
 
         // Update best cost depending on validity.

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -484,7 +484,7 @@ void LocalSearch<Route,
                 bool better_if_valid =
                   (best_priorities[s_t.first] < priority_gain) or
                   (best_priorities[s_t.first] == priority_gain and
-                   r.gain() > best_gains[s_t.first][s_t.first]);
+                   best_gains[s_t.first][s_t.first] < r.gain());
 
                 if (better_if_valid and r.is_valid()) {
                   best_priorities[s_t.first] = priority_gain;
@@ -628,8 +628,8 @@ void LocalSearch<Route,
                           !is_t_pickup);
 
           auto& current_best = best_gains[s_t.first][s_t.second];
-          if (r.gain_upper_bound() > current_best and r.is_valid() and
-              r.gain() > current_best) {
+          if (current_best < r.gain_upper_bound() and r.is_valid() and
+              current_best < r.gain()) {
             current_best = r.gain();
             best_ops[s_t.first][s_t.second] =
               std::make_unique<CrossExchange>(r);
@@ -743,8 +743,8 @@ void LocalSearch<Route,
                             !is_t_pickup);
 
             auto& current_best = best_gains[s_t.first][s_t.second];
-            if (r.gain_upper_bound() > current_best and r.is_valid() and
-                r.gain() > current_best) {
+            if (current_best < r.gain_upper_bound() and r.is_valid() and
+                current_best < r.gain()) {
               current_best = r.gain();
               best_ops[s_t.first][s_t.second] =
                 std::make_unique<MixedExchange>(r);
@@ -853,7 +853,7 @@ void LocalSearch<Route,
                    s_t.second,
                    t_rank);
 
-          if (r.gain() > best_gains[s_t.first][s_t.second] and r.is_valid()) {
+          if (best_gains[s_t.first][s_t.second] < r.gain() and r.is_valid()) {
             best_gains[s_t.first][s_t.second] = r.gain();
             best_ops[s_t.first][s_t.second] = std::make_unique<TwoOpt>(r);
           }
@@ -952,7 +952,7 @@ void LocalSearch<Route,
                           s_t.second,
                           t_rank);
 
-          if (r.gain() > best_gains[s_t.first][s_t.second] and r.is_valid()) {
+          if (best_gains[s_t.first][s_t.second] < r.gain() and r.is_valid()) {
             best_gains[s_t.first][s_t.second] = r.gain();
             best_ops[s_t.first][s_t.second] =
               std::make_unique<ReverseTwoOpt>(r);
@@ -1019,7 +1019,7 @@ void LocalSearch<Route,
                        s_t.second,
                        t_rank);
 
-            if (r.gain() > best_gains[s_t.first][s_t.second] and r.is_valid()) {
+            if (best_gains[s_t.first][s_t.second] < r.gain() and r.is_valid()) {
               best_gains[s_t.first][s_t.second] = r.gain();
               best_ops[s_t.first][s_t.second] = std::make_unique<Relocate>(r);
             }
@@ -1100,8 +1100,8 @@ void LocalSearch<Route,
                     t_rank);
 
             auto& current_best = best_gains[s_t.first][s_t.second];
-            if (r.gain_upper_bound() > current_best and r.is_valid() and
-                r.gain() > current_best) {
+            if (current_best < r.gain_upper_bound() and r.is_valid() and
+                current_best < r.gain()) {
               current_best = r.gain();
               best_ops[s_t.first][s_t.second] = std::make_unique<OrOpt>(r);
             }
@@ -1124,7 +1124,7 @@ void LocalSearch<Route,
 #endif
         TSPFix op(_input, _sol_state, _sol[s_t.first], s_t.first);
 
-        if (op.gain() > best_gains[s_t.first][s_t.second] and op.is_valid()) {
+        if (best_gains[s_t.first][s_t.second] < op.gain() and op.is_valid()) {
           best_gains[s_t.first][s_t.second] = op.gain();
           best_ops[s_t.first][s_t.second] = std::make_unique<TSPFix>(op);
         }
@@ -1176,7 +1176,7 @@ void LocalSearch<Route,
                           s_rank,
                           t_rank);
 
-          if (r.gain() > best_gains[s_t.first][s_t.first] and r.is_valid()) {
+          if (best_gains[s_t.first][s_t.first] < r.gain() and r.is_valid()) {
             best_gains[s_t.first][s_t.first] = r.gain();
             best_ops[s_t.first][s_t.first] = std::make_unique<IntraExchange>(r);
           }
@@ -1252,8 +1252,8 @@ void LocalSearch<Route,
                                !is_t_pickup);
 
           auto& current_best = best_gains[s_t.first][s_t.second];
-          if (r.gain_upper_bound() > current_best and r.is_valid() and
-              r.gain() > current_best) {
+          if (current_best < r.gain_upper_bound() and r.is_valid() and
+              current_best < r.gain()) {
             current_best = r.gain();
             best_ops[s_t.first][s_t.first] =
               std::make_unique<IntraCrossExchange>(r);
@@ -1325,8 +1325,8 @@ void LocalSearch<Route,
                                t_rank,
                                !is_t_pickup);
           auto& current_best = best_gains[s_t.first][s_t.second];
-          if (r.gain_upper_bound() > current_best and r.is_valid() and
-              r.gain() > current_best) {
+          if (current_best < r.gain_upper_bound() and r.is_valid() and
+              current_best < r.gain()) {
             current_best = r.gain();
             best_ops[s_t.first][s_t.first] =
               std::make_unique<IntraMixedExchange>(r);
@@ -1388,7 +1388,7 @@ void LocalSearch<Route,
                           s_rank,
                           t_rank);
 
-          if (r.gain() > best_gains[s_t.first][s_t.first] and r.is_valid()) {
+          if (best_gains[s_t.first][s_t.first] < r.gain() and r.is_valid()) {
             best_gains[s_t.first][s_t.first] = r.gain();
             best_ops[s_t.first][s_t.first] = std::make_unique<IntraRelocate>(r);
           }
@@ -1465,8 +1465,8 @@ void LocalSearch<Route,
                        t_rank,
                        !is_pickup);
           auto& current_best = best_gains[s_t.first][s_t.second];
-          if (r.gain_upper_bound() > current_best and r.is_valid() and
-              r.gain() > current_best) {
+          if (current_best < r.gain_upper_bound() and r.is_valid() and
+              current_best < r.gain()) {
             current_best = r.gain();
             best_ops[s_t.first][s_t.first] = std::make_unique<IntraOrOpt>(r);
           }
@@ -1499,7 +1499,7 @@ void LocalSearch<Route,
                         s_rank,
                         t_rank);
           auto& current_best = best_gains[s_t.first][s_t.second];
-          if (r.gain() > current_best and r.is_valid()) {
+          if (current_best < r.gain() and r.is_valid()) {
             current_best = r.gain();
             best_ops[s_t.first][s_t.first] = std::make_unique<IntraTwoOpt>(r);
           }
@@ -1572,7 +1572,7 @@ void LocalSearch<Route,
                       s_t.second,
                       best_gains[s_t.first][s_t.second]);
 
-          if (pdr.gain() > best_gains[s_t.first][s_t.second] and
+          if (best_gains[s_t.first][s_t.second] < pdr.gain() and
               pdr.is_valid()) {
             best_gains[s_t.first][s_t.second] = pdr.gain();
             best_ops[s_t.first][s_t.second] = std::make_unique<PDShift>(pdr);
@@ -1625,7 +1625,7 @@ void LocalSearch<Route,
                          _sol[s_t.second],
                          s_t.second);
 
-        if (re.gain() > best_gains[s_t.first][s_t.second] and re.is_valid()) {
+        if (best_gains[s_t.first][s_t.second] < re.gain() and re.is_valid()) {
           best_gains[s_t.first][s_t.second] = re.gain();
           best_ops[s_t.first][s_t.second] = std::make_unique<RouteExchange>(re);
         }
@@ -1653,7 +1653,7 @@ void LocalSearch<Route,
                    s_t.second,
                    best_gains[s_t.first][s_t.second]);
 
-        if (r.gain() > best_gains[s_t.first][s_t.second]) {
+        if (best_gains[s_t.first][s_t.second] < r.gain()) {
           best_gains[s_t.first][s_t.second] = r.gain();
           best_ops[s_t.first][s_t.second] = std::make_unique<SwapStar>(r);
         }
@@ -1693,7 +1693,7 @@ void LocalSearch<Route,
                        empty_route_refs,
                        best_gains[s_t.first][s_t.second]);
 
-          if (r.gain() > best_gains[s_t.first][s_t.second]) {
+          if (best_gains[s_t.first][s_t.second] < r.gain()) {
             best_gains[s_t.first][s_t.second] = r.gain();
             best_ops[s_t.first][s_t.second] = std::make_unique<RouteSplit>(r);
           }
@@ -1720,7 +1720,7 @@ void LocalSearch<Route,
     if (best_priority == 0) {
       for (unsigned s_v = 0; s_v < _nb_vehicles; ++s_v) {
         for (unsigned t_v = 0; t_v < _nb_vehicles; ++t_v) {
-          if (best_gains[s_v][t_v] > best_gain) {
+          if (best_gain < best_gains[s_v][t_v]) {
             best_gain = best_gains[s_v][t_v];
             best_source = s_v;
             best_target = t_v;
@@ -2267,7 +2267,7 @@ void LocalSearch<Route,
         const auto& removal_gain = _sol_state.node_gains[v][r];
         current_gain = removal_gain - relocate_cost_lower_bound(v, r);
 
-        if (current_gain > best_gain) {
+        if (best_gain < current_gain) {
           // Only check validity if required.
           valid_removal = _input.vehicles[v].ok_for_travel_time(
                             current_travel_time - removal_gain.duration) &&
@@ -2280,7 +2280,7 @@ void LocalSearch<Route,
         current_gain =
           removal_gain - relocate_cost_lower_bound(v, r, delivery_r);
 
-        if (current_gain > best_gain &&
+        if (best_gain < current_gain &&
             _input.vehicles[v].ok_for_travel_time(current_travel_time -
                                                   removal_gain.duration)) {
           // Only check validity if required.
@@ -2301,7 +2301,7 @@ void LocalSearch<Route,
         }
       }
 
-      if (current_gain > best_gain and valid_removal) {
+      if (best_gain < current_gain and valid_removal) {
         best_gain = current_gain;
         best_rank = r;
       }

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -380,7 +380,7 @@ void LocalSearch<Route,
   std::vector<Priority> best_priorities(_nb_vehicles, 0);
 
   // Dummy init to enter first loop.
-  Eval best_gain(static_cast<Cost>(1), static_cast<Cost>(0));
+  Eval best_gain(static_cast<Cost>(1));
   Priority best_priority = 0;
 
   while (best_gain.cost > 0 or best_priority > 0) {

--- a/src/algorithms/local_search/operator.cpp
+++ b/src/algorithms/local_search/operator.cpp
@@ -24,14 +24,12 @@ Eval Operator::gain() {
 
 bool Operator::is_valid_for_source_max_travel_time() const {
   const auto& s_v = _input.vehicles[s_vehicle];
-  return s_v.ok_for_travel_time(_sol_state.route_evals[s_vehicle].duration -
-                                s_gain.duration);
+  return s_v.ok_for_range_bounds(_sol_state.route_evals[s_vehicle] - s_gain);
 }
 
 bool Operator::is_valid_for_target_max_travel_time() const {
   const auto& t_v = _input.vehicles[t_vehicle];
-  return t_v.ok_for_travel_time(_sol_state.route_evals[t_vehicle].duration -
-                                t_gain.duration);
+  return t_v.ok_for_range_bounds(_sol_state.route_evals[t_vehicle] - t_gain);
 }
 
 bool Operator::is_valid_for_max_travel_time() const {
@@ -39,8 +37,8 @@ bool Operator::is_valid_for_max_travel_time() const {
   assert(gain_computed);
 
   const auto& s_v = _input.vehicles[s_vehicle];
-  return s_v.ok_for_travel_time(_sol_state.route_evals[s_vehicle].duration -
-                                stored_gain.duration);
+  return s_v.ok_for_range_bounds(_sol_state.route_evals[s_vehicle] -
+                                 stored_gain);
 }
 
 std::vector<Index> Operator::required_unassigned() const {

--- a/src/algorithms/local_search/route_split_utils.h
+++ b/src/algorithms/local_search/route_split_utils.h
@@ -72,7 +72,7 @@ compute_best_route_split_choice(const Input& input,
         continue;
       }
 
-      Eval current_end_eval(end_v.fixed_cost(), 0);
+      Eval current_end_eval(end_v.fixed_cost());
       current_end_eval += sol_state.fwd_costs[s_vehicle][v].back() -
                           sol_state.fwd_costs[s_vehicle][v][r];
       if (end_v.has_start()) {
@@ -143,7 +143,7 @@ compute_best_route_split_choice(const Input& input,
         continue;
       }
 
-      Eval current_begin_eval(begin_v.fixed_cost(), 0);
+      Eval current_begin_eval(begin_v.fixed_cost());
       current_begin_eval += sol_state.fwd_costs[s_vehicle][v][r - 1];
       if (begin_v.has_start()) {
         current_begin_eval +=

--- a/src/algorithms/local_search/route_split_utils.h
+++ b/src/algorithms/local_search/route_split_utils.h
@@ -244,7 +244,7 @@ compute_best_route_split_choice(const Input& input,
       }
     }
 
-    if (current_split_choice.gain > best_choice.gain) {
+    if (best_choice.gain < current_split_choice.gain) {
       best_choice = current_split_choice;
     }
   }

--- a/src/algorithms/local_search/route_split_utils.h
+++ b/src/algorithms/local_search/route_split_utils.h
@@ -84,7 +84,7 @@ compute_best_route_split_choice(const Input& input,
                                        end_v.end.value().index());
       }
 
-      if (!end_v.ok_for_travel_time(current_end_eval.duration)) {
+      if (!end_v.ok_for_range_bounds(current_end_eval)) {
         continue;
       }
 
@@ -156,7 +156,7 @@ compute_best_route_split_choice(const Input& input,
                        begin_v.end.value().index());
       }
 
-      if (!begin_v.ok_for_travel_time(current_begin_eval.duration)) {
+      if (!begin_v.ok_for_range_bounds(current_begin_eval)) {
         continue;
       }
 

--- a/src/algorithms/local_search/swap_star_utils.h
+++ b/src/algorithms/local_search/swap_star_utils.h
@@ -181,8 +181,8 @@ SwapChoice compute_best_swap_star_choice(const Input& input,
   const auto& s_v = input.vehicles[s_vehicle];
   const auto& t_v = input.vehicles[t_vehicle];
 
-  const auto s_travel_time = sol_state.route_evals[s_vehicle].duration;
-  const auto t_travel_time = sol_state.route_evals[t_vehicle].duration;
+  const auto& s_eval = sol_state.route_evals[s_vehicle];
+  const auto& t_eval = sol_state.route_evals[t_vehicle];
 
   const auto& s_delivery_margin = source.delivery_margin();
   const auto& s_pickup_margin = source.pickup_margin();
@@ -246,11 +246,11 @@ SwapChoice compute_best_swap_star_choice(const Input& input,
 
       Eval current_gain = in_place_s_gain + in_place_t_gain;
 
-      if (s_v.ok_for_travel_time(s_travel_time - in_place_s_gain.duration)) {
+      if (s_v.ok_for_range_bounds(s_eval - in_place_s_gain)) {
         // Only bother further checking in-place insertion in source
         // route if max travel time constraint is OK.
         if (best_gain < current_gain &&
-            t_v.ok_for_travel_time(t_travel_time - in_place_t_gain.duration)) {
+            t_v.ok_for_range_bounds(t_eval - in_place_t_gain)) {
           SwapChoice sc(current_gain, s_rank, t_rank, s_rank, t_rank);
           if (valid_choice_for_insertion_ranks(sol_state,
                                                s_vehicle,
@@ -268,7 +268,7 @@ SwapChoice compute_best_swap_star_choice(const Input& input,
             const Eval t_gain = target_delta - ti.cost;
             current_gain = in_place_s_gain + t_gain;
             if (best_gain < current_gain &&
-                t_v.ok_for_travel_time(t_travel_time - t_gain.duration)) {
+                t_v.ok_for_range_bounds(t_eval - t_gain)) {
               SwapChoice sc(current_gain, s_rank, t_rank, s_rank, ti.rank);
               if (valid_choice_for_insertion_ranks(sol_state,
                                                    s_vehicle,
@@ -292,7 +292,7 @@ SwapChoice compute_best_swap_star_choice(const Input& input,
             (si.cost != NO_EVAL)) {
           const Eval s_gain = source_delta - si.cost;
 
-          if (!s_v.ok_for_travel_time(s_travel_time - s_gain.duration)) {
+          if (!s_v.ok_for_range_bounds(s_eval - s_gain)) {
             // Don't bother further checking if max travel time
             // constraint is violated for source route.
             continue;
@@ -300,8 +300,7 @@ SwapChoice compute_best_swap_star_choice(const Input& input,
 
           current_gain = s_gain + in_place_t_gain;
           if (best_gain < current_gain &&
-              t_v.ok_for_travel_time(t_travel_time -
-                                     in_place_t_gain.duration)) {
+              t_v.ok_for_range_bounds(t_eval - in_place_t_gain)) {
             SwapChoice sc(current_gain, s_rank, t_rank, si.rank, t_rank);
             if (valid_choice_for_insertion_ranks(sol_state,
                                                  s_vehicle,
@@ -319,7 +318,7 @@ SwapChoice compute_best_swap_star_choice(const Input& input,
               const Eval t_gain = target_delta - ti.cost;
               current_gain = s_gain + t_gain;
               if (best_gain < current_gain &&
-                  t_v.ok_for_travel_time(t_travel_time - t_gain.duration)) {
+                  t_v.ok_for_range_bounds(t_eval - t_gain)) {
                 SwapChoice sc(current_gain, s_rank, t_rank, si.rank, ti.rank);
                 if (valid_choice_for_insertion_ranks(sol_state,
                                                      s_vehicle,

--- a/src/algorithms/local_search/swap_star_utils.h
+++ b/src/algorithms/local_search/swap_star_utils.h
@@ -90,7 +90,7 @@ struct SwapChoice {
 };
 
 const auto SwapChoiceCmp = [](const SwapChoice& lhs, const SwapChoice& rhs) {
-  return lhs.gain > rhs.gain;
+  return rhs.gain < lhs.gain;
 };
 
 const SwapChoice empty_swap_choice = {Eval(), 0, 0, 0, 0};
@@ -310,7 +310,7 @@ SwapChoice compute_best_swap_star_choice(const Input& input,
       if (s_v.ok_for_travel_time(s_travel_time - in_place_s_gain.duration)) {
         // Only bother further checking in-place insertion in source
         // route if max travel time constraint is OK.
-        if (current_gain > best_gain and
+        if (best_gain < current_gain and
             t_v.ok_for_travel_time(t_travel_time - in_place_t_gain.duration)) {
           SwapChoice sc(current_gain, s_rank, t_rank, s_rank, t_rank);
           if (valid_choice_for_insertion_ranks(sol_state,
@@ -328,7 +328,7 @@ SwapChoice compute_best_swap_star_choice(const Input& input,
               (ti.cost != NO_EVAL)) {
             const Eval t_gain = target_delta - ti.cost;
             current_gain = in_place_s_gain + t_gain;
-            if (current_gain > best_gain and
+            if (best_gain < current_gain and
                 t_v.ok_for_travel_time(t_travel_time - t_gain.duration)) {
               SwapChoice sc(current_gain, s_rank, t_rank, s_rank, ti.rank);
               if (valid_choice_for_insertion_ranks(sol_state,
@@ -360,7 +360,7 @@ SwapChoice compute_best_swap_star_choice(const Input& input,
           }
 
           current_gain = s_gain + in_place_t_gain;
-          if (current_gain > best_gain and
+          if (best_gain < current_gain and
               t_v.ok_for_travel_time(t_travel_time -
                                      in_place_t_gain.duration)) {
             SwapChoice sc(current_gain, s_rank, t_rank, si.rank, t_rank);
@@ -379,7 +379,7 @@ SwapChoice compute_best_swap_star_choice(const Input& input,
                 (ti.cost != NO_EVAL)) {
               const Eval t_gain = target_delta - ti.cost;
               current_gain = s_gain + t_gain;
-              if (current_gain > best_gain and
+              if (best_gain < current_gain and
                   t_v.ok_for_travel_time(t_travel_time - t_gain.duration)) {
                 SwapChoice sc(current_gain, s_rank, t_rank, si.rank, ti.rank);
                 if (valid_choice_for_insertion_ranks(sol_state,

--- a/src/problems/cvrp/cvrp.cpp
+++ b/src/problems/cvrp/cvrp.cpp
@@ -149,7 +149,7 @@ Solution CVRP::solve(unsigned exploration_level,
       _input.zero_amount().empty() && !_input.has_shipments() &&
       (_input.jobs.size() <= _input.vehicles[0].max_tasks) &&
       _input.vehicles[0].steps.empty() &&
-      !_input.vehicles[0].has_max_travel_time()) {
+      !_input.vehicles[0].has_range_bounds()) {
     // This is a plain TSP, no need to go through the trouble below.
     std::vector<Index> job_ranks(_input.jobs.size());
     std::iota(job_ranks.begin(), job_ranks.end(), 0);

--- a/src/problems/cvrp/operators/cross_exchange.cpp
+++ b/src/problems/cvrp/operators/cross_exchange.cpp
@@ -183,7 +183,7 @@ Eval CrossExchange::gain_upper_bound() {
 void CrossExchange::compute_gain() {
   assert(_gain_upper_bound_computed);
   assert(s_is_normal_valid or s_is_reverse_valid);
-  if (_reversed_s_gain > _normal_s_gain) {
+  if (_normal_s_gain < _reversed_s_gain) {
     // Biggest potential gain is obtained when reversing edge.
     if (s_is_reverse_valid) {
       stored_gain += _reversed_s_gain;
@@ -202,7 +202,7 @@ void CrossExchange::compute_gain() {
   }
 
   assert(t_is_normal_valid or t_is_reverse_valid);
-  if (_reversed_t_gain > _normal_t_gain) {
+  if (_normal_t_gain < _reversed_t_gain) {
     // Biggest potential gain is obtained when reversing edge.
     if (t_is_reverse_valid) {
       stored_gain += _reversed_t_gain;

--- a/src/problems/cvrp/operators/cross_exchange.cpp
+++ b/src/problems/cvrp/operators/cross_exchange.cpp
@@ -235,12 +235,12 @@ bool CrossExchange::is_valid() {
 
   if (valid) {
     const auto& s_v = _input.vehicles[s_vehicle];
-    const auto s_travel_time = _sol_state.route_evals[s_vehicle].duration;
+    const auto& s_eval = _sol_state.route_evals[s_vehicle];
 
     // Keep target edge direction when inserting in source route.
     auto t_start = t_route.begin() + t_rank;
     s_is_normal_valid =
-      s_v.ok_for_travel_time(s_travel_time - _normal_s_gain.duration) &&
+      s_v.ok_for_range_bounds(s_eval - _normal_s_gain) &&
       source.is_valid_addition_for_capacity_inclusion(_input,
                                                       target_delivery,
                                                       t_start,
@@ -252,7 +252,7 @@ bool CrossExchange::is_valid() {
       // Reverse target edge direction when inserting in source route.
       auto t_reverse_start = t_route.rbegin() + t_route.size() - 2 - t_rank;
       s_is_reverse_valid =
-        s_v.ok_for_travel_time(s_travel_time - _reversed_s_gain.duration) &&
+        s_v.ok_for_range_bounds(s_eval - _reversed_s_gain) &&
         source.is_valid_addition_for_capacity_inclusion(_input,
                                                         target_delivery,
                                                         t_reverse_start,
@@ -276,12 +276,12 @@ bool CrossExchange::is_valid() {
 
   if (valid) {
     const auto& t_v = _input.vehicles[t_vehicle];
-    const auto t_travel_time = _sol_state.route_evals[t_vehicle].duration;
+    const auto& t_eval = _sol_state.route_evals[t_vehicle];
 
     // Keep source edge direction when inserting in target route.
     auto s_start = s_route.begin() + s_rank;
     t_is_normal_valid =
-      t_v.ok_for_travel_time(t_travel_time - _normal_t_gain.duration) &&
+      t_v.ok_for_range_bounds(t_eval - _normal_t_gain) &&
       target.is_valid_addition_for_capacity_inclusion(_input,
                                                       source_delivery,
                                                       s_start,
@@ -293,7 +293,7 @@ bool CrossExchange::is_valid() {
       // Reverse source edge direction when inserting in target route.
       auto s_reverse_start = s_route.rbegin() + s_route.size() - 2 - s_rank;
       t_is_reverse_valid =
-        t_v.ok_for_travel_time(t_travel_time - _reversed_t_gain.duration) &&
+        t_v.ok_for_range_bounds(t_eval - _reversed_t_gain) &&
         target.is_valid_addition_for_capacity_inclusion(_input,
                                                         source_delivery,
                                                         s_reverse_start,

--- a/src/problems/cvrp/operators/intra_cross_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_cross_exchange.cpp
@@ -170,7 +170,7 @@ void IntraCrossExchange::compute_gain() {
 
   if (s_normal_t_normal_is_valid) {
     const auto current_gain = _normal_s_gain + _normal_t_gain;
-    if (current_gain > stored_gain) {
+    if (stored_gain < current_gain) {
       stored_gain = current_gain;
       reverse_s_edge = false;
       reverse_t_edge = false;
@@ -179,7 +179,7 @@ void IntraCrossExchange::compute_gain() {
 
   if (s_normal_t_reverse_is_valid) {
     const auto current_gain = _reversed_s_gain + _normal_t_gain;
-    if (current_gain > stored_gain) {
+    if (stored_gain < current_gain) {
       stored_gain = current_gain;
       reverse_s_edge = false;
       reverse_t_edge = true;
@@ -188,7 +188,7 @@ void IntraCrossExchange::compute_gain() {
 
   if (s_reverse_t_reverse_is_valid) {
     const auto current_gain = _reversed_s_gain + _reversed_t_gain;
-    if (current_gain > stored_gain) {
+    if (stored_gain < current_gain) {
       stored_gain = current_gain;
       reverse_s_edge = true;
       reverse_t_edge = true;
@@ -197,7 +197,7 @@ void IntraCrossExchange::compute_gain() {
 
   if (s_reverse_t_normal_is_valid) {
     const auto current_gain = _normal_s_gain + _reversed_t_gain;
-    if (current_gain > stored_gain) {
+    if (stored_gain < current_gain) {
       stored_gain = current_gain;
       reverse_s_edge = true;
       reverse_t_edge = false;

--- a/src/problems/cvrp/operators/intra_cross_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_cross_exchange.cpp
@@ -209,12 +209,11 @@ bool IntraCrossExchange::is_valid() {
   assert(_gain_upper_bound_computed);
 
   const auto& s_v = _input.vehicles[s_vehicle];
-  const auto s_travel_time = _sol_state.route_evals[s_vehicle].duration;
-  const auto s_normal_t_normal_duration =
-    _normal_s_gain.duration + _normal_t_gain.duration;
+  const auto& s_eval = _sol_state.route_evals[s_vehicle];
+  const auto s_normal_t_normal_eval = _normal_s_gain + _normal_t_gain;
 
   s_normal_t_normal_is_valid =
-    s_v.ok_for_travel_time(s_travel_time - s_normal_t_normal_duration) &&
+    s_v.ok_for_range_bounds(s_eval - s_normal_t_normal_eval) &&
     source.is_valid_addition_for_capacity_inclusion(_input,
                                                     _delivery,
                                                     _moved_jobs.begin(),
@@ -225,11 +224,10 @@ bool IntraCrossExchange::is_valid() {
   std::swap(_moved_jobs[0], _moved_jobs[1]);
 
   if (check_t_reverse) {
-    const auto s_normal_t_reverse_duration =
-      _reversed_s_gain.duration + _normal_t_gain.duration;
+    const auto s_normal_t_reverse_eval = _reversed_s_gain + _normal_t_gain;
 
     s_normal_t_reverse_is_valid =
-      s_v.ok_for_travel_time(s_travel_time - s_normal_t_reverse_duration) &&
+      s_v.ok_for_range_bounds(s_eval - s_normal_t_reverse_eval) &&
       source.is_valid_addition_for_capacity_inclusion(_input,
                                                       _delivery,
                                                       _moved_jobs.begin(),
@@ -242,10 +240,9 @@ bool IntraCrossExchange::is_valid() {
             _moved_jobs[_moved_jobs.size() - 1]);
 
   if (check_s_reverse && check_t_reverse) {
-    const auto s_reversed_t_reversed_duration =
-      _reversed_s_gain.duration + _reversed_t_gain.duration;
+    const auto s_reversed_t_reversed_eval = _reversed_s_gain + _reversed_t_gain;
     s_reverse_t_reverse_is_valid =
-      s_v.ok_for_travel_time(s_travel_time - s_reversed_t_reversed_duration) &&
+      s_v.ok_for_range_bounds(s_eval - s_reversed_t_reversed_eval) &&
       source.is_valid_addition_for_capacity_inclusion(_input,
                                                       _delivery,
                                                       _moved_jobs.begin(),
@@ -257,11 +254,10 @@ bool IntraCrossExchange::is_valid() {
   std::swap(_moved_jobs[0], _moved_jobs[1]);
 
   if (check_s_reverse) {
-    const auto s_reverse_t_normal_duration =
-      _normal_s_gain.duration + _reversed_t_gain.duration;
+    const auto s_reverse_t_normal_eval = _normal_s_gain + _reversed_t_gain;
 
     s_reverse_t_normal_is_valid =
-      s_v.ok_for_travel_time(s_travel_time - s_reverse_t_normal_duration) &&
+      s_v.ok_for_range_bounds(s_eval - s_reverse_t_normal_eval) &&
       source.is_valid_addition_for_capacity_inclusion(_input,
                                                       _delivery,
                                                       _moved_jobs.begin(),

--- a/src/problems/cvrp/operators/intra_mixed_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_mixed_exchange.cpp
@@ -170,7 +170,7 @@ Eval IntraMixedExchange::gain_upper_bound() {
 void IntraMixedExchange::compute_gain() {
   assert(_gain_upper_bound_computed);
   assert(s_is_normal_valid or s_is_reverse_valid);
-  if (_reversed_s_gain > _normal_s_gain) {
+  if (_normal_s_gain < _reversed_s_gain) {
     // Biggest potential gain is obtained when reversing edge.
     if (s_is_reverse_valid) {
       stored_gain += _reversed_s_gain;

--- a/src/problems/cvrp/operators/intra_mixed_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_mixed_exchange.cpp
@@ -196,11 +196,11 @@ bool IntraMixedExchange::is_valid() {
   assert(_gain_upper_bound_computed);
 
   const auto& s_v = _input.vehicles[s_vehicle];
-  const auto s_travel_time = _sol_state.route_evals[s_vehicle].duration;
-  const auto normal_duration = _normal_s_gain.duration + t_gain.duration;
+  const auto& s_eval = _sol_state.route_evals[s_vehicle];
+  const auto normal_eval = _normal_s_gain + t_gain;
 
   s_is_normal_valid =
-    s_v.ok_for_travel_time(s_travel_time - normal_duration) &&
+    s_v.ok_for_range_bounds(s_eval - normal_eval) &&
     source.is_valid_addition_for_capacity_inclusion(_input,
                                                     _delivery,
                                                     _moved_jobs.begin(),
@@ -209,9 +209,9 @@ bool IntraMixedExchange::is_valid() {
                                                     _last_rank);
 
   if (check_t_reverse) {
-    const auto reversed_duration = _reversed_s_gain.duration + t_gain.duration;
+    const auto reversed_eval = _reversed_s_gain + t_gain;
 
-    if (s_v.ok_for_travel_time(s_travel_time - reversed_duration)) {
+    if (s_v.ok_for_range_bounds(s_eval - reversed_eval)) {
       std::swap(_moved_jobs[_t_edge_first], _moved_jobs[_t_edge_last]);
 
       s_is_reverse_valid =

--- a/src/problems/cvrp/operators/intra_or_opt.cpp
+++ b/src/problems/cvrp/operators/intra_or_opt.cpp
@@ -174,11 +174,11 @@ bool IntraOrOpt::is_valid() {
   assert(_gain_upper_bound_computed);
 
   const auto& s_v = _input.vehicles[s_vehicle];
-  const auto s_travel_time = _sol_state.route_evals[s_vehicle].duration;
-  const auto normal_duration = s_gain.duration + _normal_t_gain.duration;
+  const auto& s_eval = _sol_state.route_evals[s_vehicle];
+  const auto normal_eval = s_gain + _normal_t_gain;
 
   is_normal_valid =
-    s_v.ok_for_travel_time(s_travel_time - normal_duration) &&
+    s_v.ok_for_range_bounds(s_eval - normal_eval) &&
     source.is_valid_addition_for_capacity_inclusion(_input,
                                                     _delivery,
                                                     _moved_jobs.begin(),
@@ -187,9 +187,9 @@ bool IntraOrOpt::is_valid() {
                                                     _last_rank);
 
   if (check_reverse) {
-    const auto reversed_duration = s_gain.duration + _reversed_t_gain.duration;
+    const auto reversed_eval = s_gain + _reversed_t_gain;
 
-    if (s_v.ok_for_travel_time(s_travel_time - reversed_duration)) {
+    if (s_v.ok_for_range_bounds(s_eval - reversed_eval)) {
       std::swap(_moved_jobs[_s_edge_first], _moved_jobs[_s_edge_last]);
 
       is_reverse_valid =

--- a/src/problems/cvrp/operators/intra_or_opt.cpp
+++ b/src/problems/cvrp/operators/intra_or_opt.cpp
@@ -150,7 +150,7 @@ void IntraOrOpt::compute_gain() {
 
   stored_gain = s_gain;
 
-  if (_reversed_t_gain > _normal_t_gain) {
+  if (_normal_t_gain < _reversed_t_gain) {
     // Biggest potential gain is obtained when reversing edge.
     if (is_reverse_valid) {
       reverse_s_edge = true;

--- a/src/problems/cvrp/operators/mixed_exchange.cpp
+++ b/src/problems/cvrp/operators/mixed_exchange.cpp
@@ -150,7 +150,7 @@ Eval MixedExchange::gain_upper_bound() {
 void MixedExchange::compute_gain() {
   assert(_gain_upper_bound_computed);
   assert(s_is_normal_valid or s_is_reverse_valid);
-  if (_reversed_s_gain > _normal_s_gain) {
+  if (_normal_s_gain < _reversed_s_gain) {
     // Biggest potential gain is obtained when reversing edge.
     if (s_is_reverse_valid) {
       stored_gain += _reversed_s_gain;

--- a/src/problems/cvrp/operators/mixed_exchange.cpp
+++ b/src/problems/cvrp/operators/mixed_exchange.cpp
@@ -198,10 +198,10 @@ bool MixedExchange::is_valid() {
     auto t_start = t_route.begin() + t_rank;
 
     const auto& s_v = _input.vehicles[s_vehicle];
-    const auto s_travel_time = _sol_state.route_evals[s_vehicle].duration;
+    const auto s_eval = _sol_state.route_evals[s_vehicle];
 
     s_is_normal_valid =
-      s_v.ok_for_travel_time(s_travel_time - _normal_s_gain.duration) &&
+      s_v.ok_for_range_bounds(s_eval - _normal_s_gain) &&
       source.is_valid_addition_for_capacity_inclusion(_input,
                                                       target_delivery,
                                                       t_start,
@@ -212,7 +212,7 @@ bool MixedExchange::is_valid() {
       // Reverse target edge direction when inserting in source route.
       auto t_reverse_start = t_route.rbegin() + t_route.size() - 2 - t_rank;
       s_is_reverse_valid =
-        s_v.ok_for_travel_time(s_travel_time - _reversed_s_gain.duration) &&
+        s_v.ok_for_range_bounds(s_eval - _reversed_s_gain) &&
         source.is_valid_addition_for_capacity_inclusion(_input,
                                                         target_delivery,
                                                         t_reverse_start,

--- a/src/problems/cvrp/operators/or_opt.cpp
+++ b/src/problems/cvrp/operators/or_opt.cpp
@@ -134,7 +134,7 @@ void OrOpt::compute_gain() {
 
   stored_gain = s_gain;
 
-  if (_reversed_t_gain > _normal_t_gain) {
+  if (_normal_t_gain < _reversed_t_gain) {
     // Biggest potential gain is obtained when reversing edge.
     if (is_reverse_valid) {
       reverse_s_edge = true;

--- a/src/problems/cvrp/operators/or_opt.cpp
+++ b/src/problems/cvrp/operators/or_opt.cpp
@@ -172,10 +172,10 @@ bool OrOpt::is_valid() {
     auto s_start = s_route.begin() + s_rank;
 
     const auto& t_v = _input.vehicles[t_vehicle];
-    const auto t_travel_time = _sol_state.route_evals[t_vehicle].duration;
+    const auto t_eval = _sol_state.route_evals[t_vehicle];
 
     is_normal_valid =
-      t_v.ok_for_travel_time(t_travel_time - _normal_t_gain.duration) &&
+      t_v.ok_for_range_bounds(t_eval - _normal_t_gain) &&
       target.is_valid_addition_for_capacity_inclusion(_input,
                                                       edge_delivery,
                                                       s_start,
@@ -186,7 +186,7 @@ bool OrOpt::is_valid() {
     // Reverse edge direction.
     auto s_reverse_start = s_route.rbegin() + s_route.size() - 2 - s_rank;
     is_reverse_valid =
-      t_v.ok_for_travel_time(t_travel_time - _reversed_t_gain.duration) &&
+      t_v.ok_for_range_bounds(t_eval - _reversed_t_gain) &&
       target.is_valid_addition_for_capacity_inclusion(_input,
                                                       edge_delivery,
                                                       s_reverse_start,

--- a/src/problems/cvrp/operators/pd_shift.cpp
+++ b/src/problems/cvrp/operators/pd_shift.cpp
@@ -50,8 +50,8 @@ PDShift::PDShift(const Input& input,
     t_gain.cost -= _input.vehicles[t_vehicle].fixed_cost();
   }
 
-  assert(_input.vehicles[s_vehicle].ok_for_travel_time(
-    _sol_state.route_evals[s_vehicle].duration - s_gain.duration));
+  assert(_input.vehicles[s_vehicle].ok_for_range_bounds(
+    _sol_state.route_evals[s_vehicle] - s_gain));
 
   stored_gain = gain_threshold;
 }

--- a/src/problems/vrp.h
+++ b/src/problems/vrp.h
@@ -121,7 +121,7 @@ protected:
 
           if (!_input.has_homogeneous_costs() &&
               p.heuristic != HEURISTIC::INIT_ROUTES && h_param.empty() &&
-              p.sort == SORT::CAPACITY) {
+              p.sort == SORT::AVAILABILITY) {
             // Worth trying another vehicle ordering scheme in
             // heuristic.
             std::vector<Route> other_sol = empty_sol;

--- a/src/structures/generic/matrix.cpp
+++ b/src/structures/generic/matrix.cpp
@@ -15,6 +15,10 @@ template <class T> Matrix<T>::Matrix(std::size_t n) : n(n) {
   data.resize(n * n);
 }
 
+template <class T>
+Matrix<T>::Matrix(std::size_t n, T value) : n(n), data(n * n, value) {
+}
+
 template <class T> Matrix<T>::Matrix() : Matrix(0) {
 }
 

--- a/src/structures/generic/matrix.h
+++ b/src/structures/generic/matrix.h
@@ -26,6 +26,8 @@ public:
 
   Matrix(std::size_t n);
 
+  Matrix(std::size_t n, T value);
+
   Matrix<T> get_sub_matrix(const std::vector<Index>& indices) const;
 
   T* operator[](std::size_t i) {

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -35,6 +35,7 @@ using Cost = int64_t;
 using UserDuration = uint32_t;
 using Duration = int64_t;
 using UserDistance = uint32_t;
+using Distance = int64_t;
 using Coordinate = double;
 using Capacity = int64_t;
 using Skill = uint32_t;

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -79,9 +79,10 @@ constexpr unsigned MAX_EXPLORATION_LEVEL = 5;
 
 constexpr unsigned DEFAULT_EXPLORATION_LEVEL = 5;
 constexpr unsigned DEFAULT_THREADS_NUMBER = 4;
-constexpr Duration DEFAULT_MAX_TRAVEL_TIME =
-  std::numeric_limits<Duration>::max();
-constexpr Duration DEFAULT_MAX_DISTANCE = std::numeric_limits<Distance>::max();
+
+constexpr auto DEFAULT_MAX_TASKS = std::numeric_limits<size_t>::max();
+constexpr auto DEFAULT_MAX_TRAVEL_TIME = std::numeric_limits<Duration>::max();
+constexpr auto DEFAULT_MAX_DISTANCE = std::numeric_limits<Distance>::max();
 
 // Available routing engines.
 enum class ROUTER { OSRM, LIBOSRM, ORS, VALHALLA };

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -111,7 +111,7 @@ enum class STEP_TYPE { START, JOB, BREAK, END };
 // Heuristic options.
 enum class HEURISTIC { BASIC, DYNAMIC, INIT_ROUTES };
 enum class INIT { NONE, HIGHER_AMOUNT, NEAREST, FURTHEST, EARLIEST_DEADLINE };
-enum class SORT { CAPACITY, COST };
+enum class SORT { AVAILABILITY, COST };
 
 struct HeuristicParameters {
   HEURISTIC heuristic;
@@ -122,7 +122,7 @@ struct HeuristicParameters {
   constexpr HeuristicParameters(HEURISTIC heuristic,
                                 INIT init,
                                 float regret_coeff,
-                                SORT sort = SORT::CAPACITY)
+                                SORT sort = SORT::AVAILABILITY)
     : heuristic(heuristic), init(init), regret_coeff(regret_coeff), sort(sort) {
   }
 
@@ -131,7 +131,7 @@ struct HeuristicParameters {
     : heuristic(heuristic),
       init(INIT::NONE),
       regret_coeff(0),
-      sort(SORT::CAPACITY) {
+      sort(SORT::AVAILABILITY) {
     assert(heuristic == HEURISTIC::INIT_ROUTES);
   }
 };

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -81,6 +81,7 @@ constexpr unsigned DEFAULT_EXPLORATION_LEVEL = 5;
 constexpr unsigned DEFAULT_THREADS_NUMBER = 4;
 constexpr Duration DEFAULT_MAX_TRAVEL_TIME =
   std::numeric_limits<Duration>::max();
+constexpr Duration DEFAULT_MAX_DISTANCE = std::numeric_limits<Distance>::max();
 
 // Available routing engines.
 enum class ROUTER { OSRM, LIBOSRM, ORS, VALHALLA };

--- a/src/structures/vroom/amount.h
+++ b/src/structures/vroom/amount.h
@@ -33,8 +33,8 @@ public:
 // Lexicographical comparison, useful for situations where a total
 // order is required.
 template <typename E1, typename E2>
-bool operator<<(const AmountExpression<E1>& lhs,
-                const AmountExpression<E2>& rhs) {
+bool operator<(const AmountExpression<E1>& lhs,
+               const AmountExpression<E2>& rhs) {
   assert(lhs.size() == rhs.size());
   if (lhs.empty()) {
     return false;

--- a/src/structures/vroom/cost_wrapper.cpp
+++ b/src/structures/vroom/cost_wrapper.cpp
@@ -30,6 +30,11 @@ void CostWrapper::set_durations_matrix(const Matrix<UserDuration>* matrix) {
   duration_data = (*matrix)[0];
 }
 
+void CostWrapper::set_distances_matrix(const Matrix<UserDistance>* matrix) {
+  distance_matrix_size = matrix->size();
+  distance_data = (*matrix)[0];
+}
+
 void CostWrapper::set_costs_matrix(const Matrix<UserCost>* matrix,
                                    bool reset_cost_factor) {
   cost_matrix_size = matrix->size();

--- a/src/structures/vroom/cost_wrapper.h
+++ b/src/structures/vroom/cost_wrapper.h
@@ -55,6 +55,10 @@ public:
            static_cast<Duration>(duration_data[i * duration_matrix_size + j]);
   }
 
+  Distance distance(Index i, Index j) const {
+    return static_cast<Distance>(distance_data[i * distance_matrix_size + j]);
+  }
+
   Cost cost(Index i, Index j) const {
     return discrete_cost_factor *
            static_cast<Cost>(cost_data[i * cost_matrix_size + j]);

--- a/src/structures/vroom/cost_wrapper.h
+++ b/src/structures/vroom/cost_wrapper.h
@@ -21,6 +21,9 @@ private:
   std::size_t duration_matrix_size;
   const UserDuration* duration_data;
 
+  std::size_t distance_matrix_size;
+  const UserDistance* distance_data;
+
   Cost discrete_cost_factor;
   std::size_t cost_matrix_size;
   const UserCost* cost_data;
@@ -33,6 +36,8 @@ public:
   CostWrapper(double speed_factor, Cost per_hour);
 
   void set_durations_matrix(const Matrix<UserDuration>* matrix);
+
+  void set_distances_matrix(const Matrix<UserDistance>* matrix);
 
   void set_costs_matrix(const Matrix<UserCost>* matrix,
                         bool reset_cost_factor = false);

--- a/src/structures/vroom/eval.h
+++ b/src/structures/vroom/eval.h
@@ -56,10 +56,6 @@ struct Eval {
            (lhs.cost == rhs.cost and lhs.duration < rhs.duration);
   }
 
-  friend bool operator>(const Eval& lhs, const Eval& rhs) {
-    return lhs.cost > rhs.cost;
-  }
-
   friend bool operator<=(const Eval& lhs, const Eval& rhs) {
     return lhs.cost <= rhs.cost;
   }

--- a/src/structures/vroom/eval.h
+++ b/src/structures/vroom/eval.h
@@ -10,6 +10,8 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <tuple>
+
 #include "structures/typedefs.h"
 
 namespace vroom {
@@ -17,15 +19,17 @@ namespace vroom {
 struct Eval {
   Cost cost;
   Duration duration;
+  Distance distance;
 
-  constexpr Eval() : cost(0), duration(0){};
+  constexpr Eval() : cost(0), duration(0), distance(0){};
 
-  constexpr Eval(Cost cost, Duration duration)
-    : cost(cost), duration(duration){};
+  constexpr Eval(Cost cost, Duration duration = 0, Distance distance = 0)
+    : cost(cost), duration(duration), distance(distance){};
 
   Eval& operator+=(const Eval& rhs) {
     cost += rhs.cost;
     duration += rhs.duration;
+    distance += rhs.distance;
 
     return *this;
   }
@@ -33,12 +37,13 @@ struct Eval {
   Eval& operator-=(const Eval& rhs) {
     cost -= rhs.cost;
     duration -= rhs.duration;
+    distance -= rhs.distance;
 
     return *this;
   }
 
   Eval operator-() const {
-    return {-cost, -duration};
+    return {-cost, -duration, -distance};
   }
 
   friend Eval operator+(Eval lhs, const Eval& rhs) {
@@ -52,8 +57,8 @@ struct Eval {
   }
 
   friend bool operator<(const Eval& lhs, const Eval& rhs) {
-    return lhs.cost < rhs.cost or
-           (lhs.cost == rhs.cost and lhs.duration < rhs.duration);
+    return std::tie(lhs.cost, lhs.duration, lhs.distance) <
+           std::tie(rhs.cost, rhs.duration, rhs.distance);
   }
 
   friend bool operator<=(const Eval& lhs, const Eval& rhs) {
@@ -61,18 +66,21 @@ struct Eval {
   }
 
   friend bool operator==(const Eval& lhs, const Eval& rhs) {
-    return lhs.cost == rhs.cost and lhs.duration == rhs.duration;
+    return lhs.cost == rhs.cost and lhs.duration == rhs.duration and
+           lhs.distance == rhs.distance;
   }
 
   friend bool operator!=(const Eval& lhs, const Eval& rhs) {
-    return lhs.cost != rhs.cost or lhs.duration != rhs.duration;
+    return lhs.cost != rhs.cost or lhs.duration != rhs.duration or
+           lhs.distance != rhs.distance;
   }
 };
 
 constexpr Eval MAX_EVAL = {std::numeric_limits<Cost>::max(),
-                           std::numeric_limits<Duration>::max()};
-constexpr Eval NO_EVAL = {std::numeric_limits<Cost>::max(), 0};
-constexpr Eval NO_GAIN = {std::numeric_limits<Cost>::min(), 0};
+                           std::numeric_limits<Duration>::max(),
+                           std::numeric_limits<Distance>::max()};
+constexpr Eval NO_EVAL = {std::numeric_limits<Cost>::max(), 0, 0};
+constexpr Eval NO_GAIN = {std::numeric_limits<Cost>::min(), 0, 0};
 
 } // namespace vroom
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -667,12 +667,16 @@ void Input::set_vehicles_max_tasks() {
           if (vehicle_ok_with_job(v, job_pickups_per_component[i][j].rank) &&
               pickup_sum <= vehicles[v].capacity[i]) {
             pickup_sum += job_pickups_per_component[i][j].amount;
-            ++doable_pickups;
+            if (pickup_sum <= vehicles[v].capacity[i]) {
+              ++doable_pickups;
+            }
           }
           if (vehicle_ok_with_job(v, job_deliveries_per_component[i][j].rank) &&
               delivery_sum <= vehicles[v].capacity[i]) {
             delivery_sum += job_deliveries_per_component[i][j].amount;
-            ++doable_deliveries;
+            if (delivery_sum <= vehicles[v].capacity[i]) {
+              ++doable_deliveries;
+            }
           }
         }
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -602,9 +602,15 @@ void Input::set_vehicles_TSP_flag() {
 
 void Input::set_vehicles_costs() {
   for (auto& vehicle : vehicles) {
-    auto d_m = _durations_matrices.find(vehicle.profile);
-    assert(d_m != _durations_matrices.end());
-    vehicle.cost_wrapper.set_durations_matrix(&(d_m->second));
+    auto duration_m = _durations_matrices.find(vehicle.profile);
+    assert(duration_m != _durations_matrices.end());
+    vehicle.cost_wrapper.set_durations_matrix(&(duration_m->second));
+
+    // TODO this will probably break with user-provided durations but
+    // not distances.
+    auto distance_m = _distances_matrices.find(vehicle.profile);
+    assert(distance_m != _distances_matrices.end());
+    vehicle.cost_wrapper.set_distances_matrix(&(distance_m->second));
 
     auto c_m = _costs_matrices.find(vehicle.profile);
     if (c_m != _costs_matrices.end()) {
@@ -622,7 +628,7 @@ void Input::set_vehicles_costs() {
       constexpr bool reset_cost_factor = true;
       vehicle.cost_wrapper.set_costs_matrix(&(c_m->second), reset_cost_factor);
     } else {
-      vehicle.cost_wrapper.set_costs_matrix(&(d_m->second));
+      vehicle.cost_wrapper.set_costs_matrix(&(duration_m->second));
     }
   }
 }

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -96,6 +96,7 @@ private:
   void set_jobs_vehicles_evals();
   void set_vehicles_TSP_flag();
   void set_vehicle_steps_ranks();
+  void init_missing_matrices(const std::string& profile);
   void set_matrices(unsigned nb_thread);
 
   void add_routing_wrapper(const std::string& profile);

--- a/src/structures/vroom/solution_state.cpp
+++ b/src/structures/vroom/solution_state.cpp
@@ -192,7 +192,7 @@ void SolutionState::set_node_gains(const std::vector<Index>& route, Index v) {
     current_gain = edges_evals_around - vehicle.eval(p_index, n_index);
     node_gains[v][i] = current_gain;
 
-    if (current_gain > best_gain) {
+    if (best_gain < current_gain) {
       best_gain = current_gain;
       node_candidates[v] = i;
     }
@@ -234,7 +234,7 @@ void SolutionState::set_node_gains(const std::vector<Index>& route, Index v) {
   current_gain = edges_evals_around - new_edge_eval;
   node_gains[v][last_rank] = current_gain;
 
-  if (current_gain > best_gain) {
+  if (best_gain < current_gain) {
     node_candidates[v] = last_rank;
   }
 }
@@ -317,7 +317,7 @@ void SolutionState::set_edge_gains(const std::vector<Index>& route, Index v) {
     current_gain = edges_evals_around - vehicle.eval(p_index, n_index);
     edge_gains[v][i] = current_gain;
 
-    if (current_gain > best_gain) {
+    if (best_gain < current_gain) {
       best_gain = current_gain;
       edge_candidates[v] = i;
     }
@@ -360,7 +360,7 @@ void SolutionState::set_edge_gains(const std::vector<Index>& route, Index v) {
   current_gain = edges_evals_around - new_edge_eval;
   edge_gains[v][last_edge_rank] = current_gain;
 
-  if (current_gain > best_gain) {
+  if (best_gain < current_gain) {
     edge_candidates[v] = last_edge_rank;
   }
 }

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -150,6 +150,11 @@ Duration Vehicle::available_duration() const {
   return available - breaks_duration;
 }
 
+bool Vehicle::has_range_bounds() const {
+  return max_travel_time != DEFAULT_MAX_TRAVEL_TIME ||
+         max_distance != DEFAULT_MAX_DISTANCE;
+}
+
 Index Vehicle::break_rank(Id break_id) const {
   auto search = break_id_to_rank.find(break_id);
   assert(search != break_id_to_rank.end());

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -26,7 +26,7 @@ Vehicle::Vehicle(Id id,
                  std::string description,
                  const VehicleCosts& costs,
                  double speed_factor,
-                 const size_t max_tasks,
+                 const std::optional<size_t>& max_tasks,
                  const std::optional<UserDuration>& max_travel_time,
                  const std::optional<UserDuration>& max_distance,
                  const std::vector<VehicleStep>& input_steps)
@@ -41,7 +41,7 @@ Vehicle::Vehicle(Id id,
     description(std::move(description)),
     costs(costs),
     cost_wrapper(speed_factor, costs.per_hour),
-    max_tasks(max_tasks),
+    max_tasks(max_tasks.has_value() ? max_tasks.value() : DEFAULT_MAX_TASKS),
     max_travel_time(max_travel_time.has_value()
                       ? utils::scale_from_user_duration(max_travel_time.value())
                       : DEFAULT_MAX_TRAVEL_TIME),

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -41,12 +41,11 @@ Vehicle::Vehicle(Id id,
     description(std::move(description)),
     costs(costs),
     cost_wrapper(speed_factor, costs.per_hour),
-    max_tasks(max_tasks.has_value() ? max_tasks.value() : DEFAULT_MAX_TASKS),
+    max_tasks(max_tasks.value_or(DEFAULT_MAX_TASKS)),
     max_travel_time(max_travel_time.has_value()
                       ? utils::scale_from_user_duration(max_travel_time.value())
                       : DEFAULT_MAX_TRAVEL_TIME),
-    max_distance(max_distance.has_value() ? max_distance.value()
-                                          : DEFAULT_MAX_DISTANCE),
+    max_distance(max_distance.value_or(DEFAULT_MAX_DISTANCE)),
     has_break_max_load(std::ranges::any_of(breaks, [](const auto& b) {
       return b.max_load.has_value();
     })) {

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -28,6 +28,7 @@ Vehicle::Vehicle(Id id,
                  double speed_factor,
                  const size_t max_tasks,
                  const std::optional<UserDuration>& max_travel_time,
+                 const std::optional<UserDuration>& max_distance,
                  const std::vector<VehicleStep>& input_steps)
   : id(id),
     start(start),
@@ -44,6 +45,8 @@ Vehicle::Vehicle(Id id,
     max_travel_time(max_travel_time.has_value()
                       ? utils::scale_from_user_duration(max_travel_time.value())
                       : DEFAULT_MAX_TRAVEL_TIME),
+    max_distance(max_distance.has_value() ? max_distance.value()
+                                          : DEFAULT_MAX_DISTANCE),
     has_break_max_load(
       std::any_of(breaks.cbegin(), breaks.cend(), [](const auto& b) {
         return b.max_load.has_value();

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -115,9 +115,7 @@ struct Vehicle {
     return d <= max_travel_time;
   }
 
-  bool has_max_travel_time() const {
-    return max_travel_time != DEFAULT_MAX_TRAVEL_TIME;
-  }
+  bool has_range_bounds() const;
 
   Index break_rank(Id break_id) const;
 };

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -102,7 +102,9 @@ struct Vehicle {
   }
 
   Eval eval(Index i, Index j) const {
-    return Eval(cost_wrapper.cost(i, j), cost_wrapper.duration(i, j));
+    return Eval(cost_wrapper.cost(i, j),
+                cost_wrapper.duration(i, j),
+                cost_wrapper.distance(i, j));
   }
 
   bool ok_for_travel_time(Duration d) const {

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -11,6 +11,7 @@ All rights reserved (see LICENSE).
 */
 
 #include <string>
+#include <tuple>
 #include <unordered_map>
 
 #include "structures/typedefs.h"
@@ -128,6 +129,15 @@ struct Vehicle {
   bool has_range_bounds() const;
 
   Index break_rank(Id break_id) const;
+
+  friend bool operator<(const Vehicle& lhs, const Vehicle& rhs) {
+    // Sort by:
+    //   - decreasing max_tasks
+    //   - decreasing capacity
+    //   - decreasing TW length
+    return std::tie(rhs.max_tasks, rhs.capacity, rhs.tw.length) <
+           std::tie(lhs.max_tasks, lhs.capacity, lhs.tw.length);
+  }
 };
 
 } // namespace vroom

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -73,7 +73,7 @@ struct Vehicle {
     std::string description = "",
     const VehicleCosts& costs = VehicleCosts(),
     double speed_factor = 1.,
-    const size_t max_tasks = std::numeric_limits<size_t>::max(),
+    const std::optional<size_t>& max_tasks = std::optional<size_t>(),
     const std::optional<UserDuration>& max_travel_time =
       std::optional<UserDuration>(),
     const std::optional<UserDistance>& max_distance =

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -115,6 +115,11 @@ struct Vehicle {
     return d <= max_travel_time;
   }
 
+  bool ok_for_distance(Distance d) const {
+    assert(0 <= d);
+    return d <= max_distance;
+  }
+
   bool ok_for_range_bounds(const Eval& e) const {
     assert(0 <= e.duration && 0 <= e.distance);
     return e.duration <= max_travel_time && e.distance <= max_distance;

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -56,6 +56,7 @@ struct Vehicle {
   CostWrapper cost_wrapper;
   size_t max_tasks;
   const Duration max_travel_time;
+  const Distance max_distance;
   const bool has_break_max_load;
   std::vector<VehicleStep> steps;
   std::unordered_map<Id, Index> break_id_to_rank;
@@ -75,6 +76,8 @@ struct Vehicle {
     const size_t max_tasks = std::numeric_limits<size_t>::max(),
     const std::optional<UserDuration>& max_travel_time =
       std::optional<UserDuration>(),
+    const std::optional<UserDistance>& max_distance =
+      std::optional<UserDistance>(),
     const std::vector<VehicleStep>& input_steps = std::vector<VehicleStep>());
 
   bool has_start() const;

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -135,8 +135,16 @@ struct Vehicle {
     //   - decreasing max_tasks
     //   - decreasing capacity
     //   - decreasing TW length
-    return std::tie(rhs.max_tasks, rhs.capacity, rhs.tw.length) <
-           std::tie(lhs.max_tasks, lhs.capacity, lhs.tw.length);
+    //   - decreasing range (max travel time and distance)
+    return std::tie(rhs.max_tasks,
+                    rhs.capacity,
+                    rhs.tw.length,
+                    rhs.max_travel_time,
+                    rhs.max_distance) < std::tie(lhs.max_tasks,
+                                                 lhs.capacity,
+                                                 lhs.tw.length,
+                                                 lhs.max_travel_time,
+                                                 lhs.max_distance);
   }
 };
 

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -115,6 +115,11 @@ struct Vehicle {
     return d <= max_travel_time;
   }
 
+  bool ok_for_range_bounds(const Eval& e) const {
+    assert(0 <= e.duration && 0 <= e.distance);
+    return e.duration <= max_travel_time && e.distance <= max_distance;
+  }
+
   bool has_range_bounds() const;
 
   Index break_rank(Id break_id) const;

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -73,8 +73,8 @@ inline INIT get_init(std::string_view s) {
 }
 
 inline SORT get_sort(std::string_view s) {
-  if (s == "CAPACITY") {
-    return SORT::CAPACITY;
+  if (s == "AVAILABILITY") {
+    return SORT::AVAILABILITY;
   }
   if (s == "COST") {
     return SORT::COST;
@@ -150,7 +150,7 @@ inline HeuristicParameters str_to_heuristic_param(const std::string& s) {
   }
 
   auto init = get_init(tokens[1]);
-  auto sort = (tokens.size() == 3) ? SORT::CAPACITY : get_sort(tokens[3]);
+  auto sort = (tokens.size() == 3) ? SORT::AVAILABILITY : get_sort(tokens[3]);
 
   try {
     auto h = std::stoul(tokens[0]);

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -543,7 +543,7 @@ inline Solution format_solution(const Input& input,
     steps.back().arrival = scale_to_user_duration(ETA);
 
     assert(expected_delivery_ranks.empty());
-    assert(v.ok_for_travel_time(eval_sum.duration));
+    assert(v.ok_for_range_bounds(eval_sum));
 
     assert(v.fixed_cost() % (DURATION_FACTOR * COST_FACTOR) == 0);
     const UserCost user_fixed_cost = scale_to_user_cost(v.fixed_cost());
@@ -1002,7 +1002,7 @@ inline Route format_route(const Input& input,
   assert(expected_delivery_ranks.empty());
 
   assert(eval_sum.duration == duration);
-  assert(v.ok_for_travel_time(eval_sum.duration));
+  assert(v.ok_for_range_bounds(eval_sum));
 
   assert(v.fixed_cost() % (DURATION_FACTOR * COST_FACTOR) == 0);
   const UserCost user_fixed_cost = utils::scale_to_user_cost(v.fixed_cost());

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -119,7 +119,7 @@ inline Priority get_priority(const rapidjson::Value& object) {
 template <typename T>
 inline std::optional<T> get_value_for(const rapidjson::Value& object,
                                       const char* key) {
-  std::optional<UserDuration> value;
+  std::optional<T> value;
   if (object.HasMember(key)) {
     if (!object[key].IsUint()) {
       throw InputException("Invalid " + std::string(key) + " value.");

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -116,39 +116,17 @@ inline Priority get_priority(const rapidjson::Value& object) {
   return priority;
 }
 
-inline std::optional<size_t> get_max_tasks(const rapidjson::Value& object) {
-  std::optional<size_t> max_tasks;
-  if (object.HasMember("max_tasks")) {
-    if (!object["max_tasks"].IsUint()) {
-      throw InputException("Invalid max_tasks value.");
+template <typename T>
+inline std::optional<T> get_value_for(const rapidjson::Value& object,
+                                      const char* key) {
+  std::optional<UserDuration> value;
+  if (object.HasMember(key)) {
+    if (!object[key].IsUint()) {
+      throw InputException("Invalid " + std::string(key) + " value.");
     }
-    max_tasks = object["max_tasks"].GetUint();
+    value = object[key].GetUint();
   }
-  return max_tasks;
-}
-
-inline std::optional<UserDuration>
-get_max_travel_time(const rapidjson::Value& object) {
-  std::optional<UserDuration> max_travel_time;
-  if (object.HasMember("max_travel_time")) {
-    if (!object["max_travel_time"].IsUint()) {
-      throw InputException("Invalid max_travel_time value.");
-    }
-    max_travel_time = object["max_travel_time"].GetUint();
-  }
-  return max_travel_time;
-}
-
-inline std::optional<UserDistance>
-get_max_distance(const rapidjson::Value& object) {
-  std::optional<UserDistance> max_distance;
-  if (object.HasMember("max_distance")) {
-    if (!object["max_distance"].IsUint()) {
-      throw InputException("Invalid max_distance value.");
-    }
-    max_distance = object["max_distance"].GetUint();
-  }
-  return max_distance;
+  return value;
 }
 
 inline void check_id(const rapidjson::Value& v, const std::string& type) {
@@ -435,9 +413,9 @@ inline Vehicle get_vehicle(const rapidjson::Value& json_vehicle,
                  get_string(json_vehicle, "description"),
                  get_vehicle_costs(json_vehicle),
                  get_double(json_vehicle, "speed_factor"),
-                 get_max_tasks(json_vehicle),
-                 get_max_travel_time(json_vehicle),
-                 get_max_distance(json_vehicle),
+                 get_value_for<size_t>(json_vehicle, "max_tasks"),
+                 get_value_for<UserDuration>(json_vehicle, "max_travel_time"),
+                 get_value_for<UserDistance>(json_vehicle, "max_distance"),
                  get_vehicle_steps(json_vehicle));
 }
 

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -139,6 +139,18 @@ get_max_travel_time(const rapidjson::Value& object) {
   return max_travel_time;
 }
 
+inline std::optional<UserDistance>
+get_max_distance(const rapidjson::Value& object) {
+  std::optional<UserDistance> max_distance;
+  if (object.HasMember("max_distance")) {
+    if (!object["max_distance"].IsUint()) {
+      throw InputException("Invalid max_distance value.");
+    }
+    max_distance = object["max_distance"].GetUint();
+  }
+  return max_distance;
+}
+
 inline void check_id(const rapidjson::Value& v, const std::string& type) {
   if (!v.IsObject()) {
     throw InputException("Invalid " + type + ".");
@@ -425,6 +437,7 @@ inline Vehicle get_vehicle(const rapidjson::Value& json_vehicle,
                  get_double(json_vehicle, "speed_factor"),
                  get_max_tasks(json_vehicle),
                  get_max_travel_time(json_vehicle),
+                 get_max_distance(json_vehicle),
                  get_vehicle_steps(json_vehicle));
 }
 

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -116,8 +116,8 @@ inline Priority get_priority(const rapidjson::Value& object) {
   return priority;
 }
 
-inline size_t get_max_tasks(const rapidjson::Value& object) {
-  size_t max_tasks = std::numeric_limits<size_t>::max();
+inline std::optional<size_t> get_max_tasks(const rapidjson::Value& object) {
+  std::optional<size_t> max_tasks;
   if (object.HasMember("max_tasks")) {
     if (!object["max_tasks"].IsUint()) {
       throw InputException("Invalid max_tasks value.");


### PR DESCRIPTION
## Issue

Fixes #354.

## Tasks

 - [x] Parse `max_distance` value in input
 - [x] Store `max_distance` at vehicle level
 - [x] Adjust `Eval` and `CostWrapper` to hold distances
 - [x] Replicate `max_travel_time` logic in heuristics and local search to account for max distances constraints
 - [x] Adjust vehicle ordering in heuristics to account for `max_*` constraints
 - [x] Update `docs/API.md`
 - [x] Update `CHANGELOG.md`
 - [x] review
