### PR TITLE
Priority-oriented local search operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Default radius of 35km for OSRM snapping (#922)
 - Support for URL path in host (#966)
 - Experimental `TSPFix` local search operator (#737)
+- `PriorityReplace` local search operator (#988)
 
 ### Changed
 

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -452,8 +452,11 @@ void LocalSearch<Route,
 
           assert(fwd_over_rank > 0 || bwd_over_rank > 0);
 
-          if (best_priorities[source] <=
-              std::max(begin_priority_gain, end_priority_gain)) {
+          const auto best_current_priority =
+            std::max(begin_priority_gain, end_priority_gain);
+
+          if (best_current_priority > 0 &&
+              best_priorities[source] <= best_current_priority) {
 #ifdef LOG_LS_OPERATORS
             ++tried_moves[OperatorName::PriorityReplace];
 #endif
@@ -470,9 +473,6 @@ void LocalSearch<Route,
             if (r.is_valid() &&
                 (best_priorities[source] < r.priority_gain() ||
                  (best_priorities[source] == r.priority_gain() &&
-                  // Avoid cycling between replacements with gain
-                  // improvement but zero net priority gain.
-                  r.priority_gain() > 0 &&
                   best_gains[source][source] < r.gain()))) {
               best_priorities[source] = r.priority_gain();
               // This may potentially define a negative value as best

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -21,6 +21,7 @@ All rights reserved (see LICENSE).
 #include "problems/vrptw/operators/mixed_exchange.h"
 #include "problems/vrptw/operators/or_opt.h"
 #include "problems/vrptw/operators/pd_shift.h"
+#include "problems/vrptw/operators/priority_replace.h"
 #include "problems/vrptw/operators/relocate.h"
 #include "problems/vrptw/operators/reverse_two_opt.h"
 #include "problems/vrptw/operators/route_exchange.h"
@@ -51,6 +52,7 @@ template <class Route,
           class RouteExchange,
           class SwapStar,
           class RouteSplit,
+          class PriorityReplace,
           class TSPFix>
 LocalSearch<Route,
             UnassignedExchange,
@@ -70,6 +72,7 @@ LocalSearch<Route,
             RouteExchange,
             SwapStar,
             RouteSplit,
+            PriorityReplace,
             TSPFix>::LocalSearch(const Input& input,
                                  std::vector<Route>& sol,
                                  unsigned max_nb_jobs_removal,
@@ -137,6 +140,7 @@ template <class Route,
           class RouteExchange,
           class SwapStar,
           class RouteSplit,
+          class PriorityReplace,
           class TSPFix>
 void LocalSearch<Route,
                  UnassignedExchange,
@@ -156,6 +160,7 @@ void LocalSearch<Route,
                  RouteExchange,
                  SwapStar,
                  RouteSplit,
+                 PriorityReplace,
                  TSPFix>::try_job_additions(const std::vector<Index>& routes,
                                             double regret_coeff) {
   bool job_added;
@@ -339,6 +344,7 @@ template <class Route,
           class RouteExchange,
           class SwapStar,
           class RouteSplit,
+          class PriorityReplace,
           class TSPFix>
 void LocalSearch<Route,
                  UnassignedExchange,
@@ -358,6 +364,7 @@ void LocalSearch<Route,
                  RouteExchange,
                  SwapStar,
                  RouteSplit,
+                 PriorityReplace,
                  TSPFix>::run_ls_step() {
   // Store best move involving a pair of routes.
   std::vector<std::vector<std::unique_ptr<Operator>>> best_ops(_nb_vehicles);
@@ -1872,6 +1879,7 @@ template <class Route,
           class RouteExchange,
           class SwapStar,
           class RouteSplit,
+          class PriorityReplace,
           class TSPFix>
 void LocalSearch<Route,
                  UnassignedExchange,
@@ -1891,6 +1899,7 @@ void LocalSearch<Route,
                  RouteExchange,
                  SwapStar,
                  RouteSplit,
+                 PriorityReplace,
                  TSPFix>::run() {
   bool try_ls_step = true;
   bool first_step = true;
@@ -1983,6 +1992,7 @@ template <class Route,
           class RouteExchange,
           class SwapStar,
           class RouteSplit,
+          class PriorityReplace,
           class TSPFix>
 std::array<OperatorStats, OperatorName::MAX>
 LocalSearch<Route,
@@ -2003,6 +2013,7 @@ LocalSearch<Route,
             RouteExchange,
             SwapStar,
             RouteSplit,
+            PriorityReplace,
             TSPFix>::get_stats() const {
   std::array<OperatorStats, OperatorName::MAX> stats;
   for (auto op = 0; op < OperatorName::MAX; ++op) {
@@ -2031,6 +2042,7 @@ template <class Route,
           class RouteExchange,
           class SwapStar,
           class RouteSplit,
+          class PriorityReplace,
           class TSPFix>
 Eval LocalSearch<Route,
                  UnassignedExchange,
@@ -2050,6 +2062,7 @@ Eval LocalSearch<Route,
                  RouteExchange,
                  SwapStar,
                  RouteSplit,
+                 PriorityReplace,
                  TSPFix>::job_route_cost(Index v_target, Index v, Index r) {
   assert(v != v_target);
 
@@ -2104,6 +2117,7 @@ template <class Route,
           class RouteExchange,
           class SwapStar,
           class RouteSplit,
+          class PriorityReplace,
           class TSPFix>
 Eval LocalSearch<Route,
                  UnassignedExchange,
@@ -2123,6 +2137,7 @@ Eval LocalSearch<Route,
                  RouteExchange,
                  SwapStar,
                  RouteSplit,
+                 PriorityReplace,
                  TSPFix>::relocate_cost_lower_bound(Index v, Index r) {
   Eval best_bound = NO_EVAL;
 
@@ -2156,6 +2171,7 @@ template <class Route,
           class RouteExchange,
           class SwapStar,
           class RouteSplit,
+          class PriorityReplace,
           class TSPFix>
 Eval LocalSearch<Route,
                  UnassignedExchange,
@@ -2175,6 +2191,7 @@ Eval LocalSearch<Route,
                  RouteExchange,
                  SwapStar,
                  RouteSplit,
+                 PriorityReplace,
                  TSPFix>::relocate_cost_lower_bound(Index v,
                                                     Index r1,
                                                     Index r2) {
@@ -2212,6 +2229,7 @@ template <class Route,
           class RouteExchange,
           class SwapStar,
           class RouteSplit,
+          class PriorityReplace,
           class TSPFix>
 void LocalSearch<Route,
                  UnassignedExchange,
@@ -2231,6 +2249,7 @@ void LocalSearch<Route,
                  RouteExchange,
                  SwapStar,
                  RouteSplit,
+                 PriorityReplace,
                  TSPFix>::remove_from_routes() {
   // Store nearest job from and to any job in any route for constant
   // time access down the line.
@@ -2365,6 +2384,7 @@ template <class Route,
           class RouteExchange,
           class SwapStar,
           class RouteSplit,
+          class PriorityReplace,
           class TSPFix>
 utils::SolutionIndicators<Route> LocalSearch<Route,
                                              UnassignedExchange,
@@ -2384,6 +2404,7 @@ utils::SolutionIndicators<Route> LocalSearch<Route,
                                              RouteExchange,
                                              SwapStar,
                                              RouteSplit,
+                                             PriorityReplace,
                                              TSPFix>::indicators() const {
   return _best_sol_indicators;
 }
@@ -2406,6 +2427,7 @@ template class LocalSearch<TWRoute,
                            vrptw::RouteExchange,
                            vrptw::SwapStar,
                            vrptw::RouteSplit,
+                           vrptw::PriorityReplace,
                            vrptw::TSPFix>;
 
 template class LocalSearch<RawRoute,
@@ -2426,6 +2448,7 @@ template class LocalSearch<RawRoute,
                            cvrp::RouteExchange,
                            cvrp::SwapStar,
                            cvrp::RouteSplit,
+                           cvrp::PriorityReplace,
                            cvrp::TSPFix>;
 
 } // namespace vroom::ls

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -404,7 +404,6 @@ void LocalSearch<Route,
       break;
     }
 
-    // Operators applied to a pair of (different) routes.
     if (_input.has_jobs()) {
       // Move(s) that don't make sense for shipment-only instances.
 

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -1791,6 +1791,7 @@ void LocalSearch<Route,
       for (auto v_rank : update_candidates) {
         _sol_state.update_costs(_sol[v_rank].route, v_rank);
         _sol_state.update_skills(_sol[v_rank].route, v_rank);
+        _sol_state.update_priorities(_sol[v_rank].route, v_rank);
         _sol_state.set_node_gains(_sol[v_rank].route, v_rank);
         _sol_state.set_edge_gains(_sol[v_rank].route, v_rank);
         _sol_state.set_pd_matching_ranks(_sol[v_rank].route, v_rank);
@@ -1951,6 +1952,7 @@ void LocalSearch<Route,
       for (std::size_t v = 0; v < _sol.size(); ++v) {
         _sol_state.update_costs(_sol[v].route, v);
         _sol_state.update_skills(_sol[v].route, v);
+        _sol_state.update_priorities(_sol[v].route, v);
         _sol_state.set_node_gains(_sol[v].route, v);
         _sol_state.set_edge_gains(_sol[v].route, v);
         _sol_state.set_pd_matching_ranks(_sol[v].route, v);

--- a/src/algorithms/local_search/local_search.h
+++ b/src/algorithms/local_search/local_search.h
@@ -33,6 +33,7 @@ template <class Route,
           class RouteExchange,
           class SwapStar,
           class RouteSplit,
+          class PriorityReplace,
           class TSPFix>
 class LocalSearch {
 private:

--- a/src/algorithms/local_search/operator.cpp
+++ b/src/algorithms/local_search/operator.cpp
@@ -22,17 +22,17 @@ Eval Operator::gain() {
   return stored_gain;
 }
 
-bool Operator::is_valid_for_source_max_travel_time() const {
+bool Operator::is_valid_for_source_range_bounds() const {
   const auto& s_v = _input.vehicles[s_vehicle];
   return s_v.ok_for_range_bounds(_sol_state.route_evals[s_vehicle] - s_gain);
 }
 
-bool Operator::is_valid_for_target_max_travel_time() const {
+bool Operator::is_valid_for_target_range_bounds() const {
   const auto& t_v = _input.vehicles[t_vehicle];
   return t_v.ok_for_range_bounds(_sol_state.route_evals[t_vehicle] - t_gain);
 }
 
-bool Operator::is_valid_for_max_travel_time() const {
+bool Operator::is_valid_for_range_bounds() const {
   assert(s_vehicle == t_vehicle);
   assert(gain_computed);
 

--- a/src/algorithms/local_search/operator.h
+++ b/src/algorithms/local_search/operator.h
@@ -40,12 +40,12 @@ protected:
 
   virtual void compute_gain() = 0;
 
-  bool is_valid_for_source_max_travel_time() const;
+  bool is_valid_for_source_range_bounds() const;
 
-  bool is_valid_for_target_max_travel_time() const;
+  bool is_valid_for_target_range_bounds() const;
 
   // Used for internal operators only.
-  bool is_valid_for_max_travel_time() const;
+  bool is_valid_for_range_bounds() const;
 
 public:
   Operator(OperatorName name,

--- a/src/problems/cvrp/cvrp.cpp
+++ b/src/problems/cvrp/cvrp.cpp
@@ -20,6 +20,7 @@ All rights reserved (see LICENSE).
 #include "problems/cvrp/operators/mixed_exchange.h"
 #include "problems/cvrp/operators/or_opt.h"
 #include "problems/cvrp/operators/pd_shift.h"
+#include "problems/cvrp/operators/priority_replace.h"
 #include "problems/cvrp/operators/relocate.h"
 #include "problems/cvrp/operators/reverse_two_opt.h"
 #include "problems/cvrp/operators/route_exchange.h"
@@ -53,6 +54,7 @@ using LocalSearch = ls::LocalSearch<RawRoute,
                                     cvrp::RouteExchange,
                                     cvrp::SwapStar,
                                     cvrp::RouteSplit,
+                                    cvrp::PriorityReplace,
                                     cvrp::TSPFix>;
 } // namespace cvrp
 

--- a/src/problems/cvrp/operators/intra_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_exchange.cpp
@@ -99,7 +99,7 @@ void IntraExchange::compute_gain() {
 }
 
 bool IntraExchange::is_valid() {
-  return is_valid_for_max_travel_time() &&
+  return is_valid_for_range_bounds() &&
          source.is_valid_addition_for_capacity_inclusion(_input,
                                                          _delivery,
                                                          _moved_jobs.begin(),

--- a/src/problems/cvrp/operators/intra_relocate.cpp
+++ b/src/problems/cvrp/operators/intra_relocate.cpp
@@ -69,7 +69,7 @@ void IntraRelocate::compute_gain() {
 }
 
 bool IntraRelocate::is_valid() {
-  return is_valid_for_max_travel_time() &&
+  return is_valid_for_range_bounds() &&
          source.is_valid_addition_for_capacity_inclusion(_input,
                                                          _delivery,
                                                          _moved_jobs.begin(),

--- a/src/problems/cvrp/operators/intra_two_opt.cpp
+++ b/src/problems/cvrp/operators/intra_two_opt.cpp
@@ -95,7 +95,7 @@ bool IntraTwoOpt::reversal_ok_for_shipments() const {
 
 bool IntraTwoOpt::is_valid() {
   bool valid = (!_input.has_shipments() || reversal_ok_for_shipments()) &&
-               is_valid_for_max_travel_time();
+               is_valid_for_range_bounds();
 
   if (valid) {
     auto rev_t = s_route.rbegin() + (s_route.size() - t_rank - 1);

--- a/src/problems/cvrp/operators/mixed_exchange.cpp
+++ b/src/problems/cvrp/operators/mixed_exchange.cpp
@@ -176,7 +176,7 @@ bool MixedExchange::is_valid() {
   assert(_gain_upper_bound_computed);
 
   bool valid =
-    is_valid_for_target_max_travel_time() &&
+    is_valid_for_target_range_bounds() &&
     target.is_valid_addition_for_capacity_margins(_input,
                                                   _input.jobs[s_route[s_rank]]
                                                     .pickup,

--- a/src/problems/cvrp/operators/or_opt.cpp
+++ b/src/problems/cvrp/operators/or_opt.cpp
@@ -161,7 +161,7 @@ bool OrOpt::is_valid() {
   auto edge_pickup = _input.jobs[s_route[s_rank]].pickup +
                      _input.jobs[s_route[s_rank + 1]].pickup;
 
-  bool valid = is_valid_for_source_max_travel_time() &&
+  bool valid = is_valid_for_source_range_bounds() &&
                target.is_valid_addition_for_capacity(_input,
                                                      edge_pickup,
                                                      edge_delivery,

--- a/src/problems/cvrp/operators/priority_replace.cpp
+++ b/src/problems/cvrp/operators/priority_replace.cpp
@@ -40,6 +40,7 @@ PriorityReplace::PriorityReplace(const Input& input,
     _best_known_priority_gain(best_known_priority_gain),
     _unassigned(unassigned) {
   assert(!s_route.empty());
+  assert(_start_priority_gain > 0 or _end_priority_gain > 0);
 }
 
 void PriorityReplace::compute_start_gain() {

--- a/src/problems/cvrp/operators/priority_replace.cpp
+++ b/src/problems/cvrp/operators/priority_replace.cpp
@@ -176,19 +176,25 @@ void PriorityReplace::apply() {
   assert(_unassigned.contains(_u));
   _unassigned.erase(_u);
 
-  assert(
-    std::all_of(s_route.cbegin(),
-                s_route.cbegin() + s_rank + 1,
-                [this](const auto j) { return !_unassigned.contains(j); }));
-  _unassigned.insert(s_route.cbegin(), s_route.cbegin() + s_rank + 1);
-
   const std::vector<Index> addition({_u});
 
   assert(replace_start_valid xor replace_end_valid);
 
   if (replace_start_valid) {
+    assert(
+      std::all_of(s_route.cbegin(),
+                  s_route.cbegin() + s_rank + 1,
+                  [this](const auto j) { return !_unassigned.contains(j); }));
+    _unassigned.insert(s_route.cbegin(), s_route.cbegin() + s_rank + 1);
+
     source.replace(_input, addition.begin(), addition.end(), 0, s_rank + 1);
   } else {
+    assert(
+      std::all_of(s_route.cbegin() + t_rank,
+                  s_route.cend(),
+                  [this](const auto j) { return !_unassigned.contains(j); }));
+    _unassigned.insert(s_route.cbegin() + t_rank, s_route.cend());
+
     source.replace(_input,
                    addition.begin(),
                    addition.end(),

--- a/src/problems/cvrp/operators/priority_replace.cpp
+++ b/src/problems/cvrp/operators/priority_replace.cpp
@@ -1,0 +1,116 @@
+/*
+
+This file is part of VROOM.
+
+Copyright (c) 2015-2022, Julien Coupey.
+All rights reserved (see LICENSE).
+
+*/
+
+#include "problems/cvrp/operators/priority_replace.h"
+#include "utils/helpers.h"
+
+namespace vroom::cvrp {
+
+PriorityReplace::PriorityReplace(const Input& input,
+                                 const utils::SolutionState& sol_state,
+                                 std::unordered_set<Index>& unassigned,
+                                 RawRoute& s_raw_route,
+                                 Index s_vehicle,
+                                 Index s_rank,
+                                 Index u)
+  : Operator(OperatorName::PriorityReplace,
+             input,
+             sol_state,
+             s_raw_route,
+             s_vehicle,
+             s_rank,
+             s_raw_route,
+             s_vehicle,
+             0),
+    _u(u),
+    _unassigned(unassigned) {
+  assert(!s_route.empty());
+}
+
+void PriorityReplace::compute_gain() {
+  const auto& v = _input.vehicles[s_vehicle];
+
+  const Index u_index = _input.jobs[_u].index();
+
+  // Replace full beginning or route up to s_rank with _u.
+  s_gain = _sol_state.fwd_costs[s_vehicle][s_vehicle][s_rank];
+
+  if (v.has_start()) {
+    s_gain += v.eval(v.start.value().index(), _input.jobs[s_route[0]].index());
+    s_gain -= v.eval(v.start.value().index(), u_index);
+  }
+
+  const Index s_index = _input.jobs[s_route[s_rank]].index();
+
+  if (s_rank == s_route.size() - 1) {
+    if (v.has_end()) {
+      s_gain += v.eval(s_index, v.end.value().index());
+      s_gain -= v.eval(u_index, v.end.value().index());
+    }
+  } else {
+    const auto s_next_index = _input.jobs[s_route[s_rank + 1]].index();
+    s_gain += v.eval(s_index, s_next_index);
+    s_gain -= v.eval(u_index, s_next_index);
+  }
+
+  stored_gain = s_gain;
+  gain_computed = true;
+}
+
+bool PriorityReplace::is_valid() {
+  const auto& j = _input.jobs[_u];
+
+  bool valid = source.is_valid_addition_for_capacity_margins(_input,
+                                                             j.pickup,
+                                                             j.delivery,
+                                                             0,
+                                                             s_rank + 1);
+
+  if (valid) {
+    // Check validity with regard to vehicle range bounds, requires
+    // valid gain value.
+    if (!gain_computed) {
+      // We don't check gain before validity if priority is strictly
+      // improved.
+      this->compute_gain();
+    }
+
+    valid = is_valid_for_source_range_bounds();
+  }
+
+  return valid;
+}
+
+void PriorityReplace::apply() {
+  assert(_unassigned.contains(_u));
+  _unassigned.erase(_u);
+
+  assert(
+    std::all_of(s_route.cbegin(),
+                s_route.cbegin() + s_rank + 1,
+                [this](const auto j) { return !_unassigned.contains(j); }));
+  _unassigned.insert(s_route.cbegin(), s_route.cbegin() + s_rank + 1);
+
+  const std::vector<Index> addition({_u});
+  source.replace(_input, addition.begin(), addition.end(), 0, s_rank + 1);
+}
+
+std::vector<Index> PriorityReplace::addition_candidates() const {
+  return {s_vehicle};
+}
+
+std::vector<Index> PriorityReplace::update_candidates() const {
+  return {s_vehicle};
+}
+
+std::vector<Index> PriorityReplace::required_unassigned() const {
+  return {_u};
+}
+
+} // namespace vroom::cvrp

--- a/src/problems/cvrp/operators/priority_replace.cpp
+++ b/src/problems/cvrp/operators/priority_replace.cpp
@@ -7,6 +7,8 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <algorithm>
+
 #include "problems/cvrp/operators/priority_replace.h"
 #include "utils/helpers.h"
 

--- a/src/problems/cvrp/operators/priority_replace.cpp
+++ b/src/problems/cvrp/operators/priority_replace.cpp
@@ -20,6 +20,7 @@ PriorityReplace::PriorityReplace(const Input& input,
                                  RawRoute& s_raw_route,
                                  Index s_vehicle,
                                  Index s_rank,
+                                 Index t_rank,
                                  Index u,
                                  Priority best_known_priority_gain)
   : Operator(OperatorName::PriorityReplace,
@@ -30,25 +31,28 @@ PriorityReplace::PriorityReplace(const Input& input,
              s_rank,
              s_raw_route,
              s_vehicle,
-             0),
-    _u(u),
-    _begin_priority_gain(_input.jobs[u].priority -
+             t_rank),
+    _start_priority_gain(_input.jobs[u].priority -
                          _sol_state.fwd_priority[s_vehicle][s_rank]),
+    _end_priority_gain(_input.jobs[u].priority -
+                       _sol_state.bwd_priority[s_vehicle][t_rank]),
+    _u(u),
     _best_known_priority_gain(best_known_priority_gain),
     _unassigned(unassigned) {
   assert(!s_route.empty());
 }
 
-void PriorityReplace::compute_gain() {
+void PriorityReplace::compute_start_gain() {
   const auto& v = _input.vehicles[s_vehicle];
 
   const Index u_index = _input.jobs[_u].index();
 
-  // Replace full beginning or route up to s_rank with _u.
+  // Replace start of route up to s_rank with _u and store in s_gain.
   s_gain = _sol_state.fwd_costs[s_vehicle][s_vehicle][s_rank];
 
   if (v.has_start()) {
-    s_gain += v.eval(v.start.value().index(), _input.jobs[s_route[0]].index());
+    s_gain +=
+      v.eval(v.start.value().index(), _input.jobs[s_route.front()].index());
     s_gain -= v.eval(v.start.value().index(), u_index);
   }
 
@@ -65,34 +69,107 @@ void PriorityReplace::compute_gain() {
     s_gain -= v.eval(u_index, s_next_index);
   }
 
-  stored_gain = s_gain;
+  _start_gain_computed = true;
+}
+
+void PriorityReplace::compute_end_gain() {
+  const auto& v = _input.vehicles[s_vehicle];
+
+  const Index u_index = _input.jobs[_u].index();
+
+  // Replace end of route after t_rank with _u and store in t_gain.
+  t_gain += _sol_state.fwd_costs[s_vehicle][s_vehicle].back();
+  t_gain -= _sol_state.fwd_costs[s_vehicle][s_vehicle][t_rank];
+
+  if (v.has_end()) {
+    t_gain +=
+      v.eval(_input.jobs[s_route.back()].index(), v.end.value().index());
+    t_gain -= v.eval(u_index, v.end.value().index());
+  }
+
+  assert(t_rank < s_route.size());
+  const Index t_index = _input.jobs[s_route[t_rank]].index();
+
+  if (t_rank == 0) {
+    if (v.has_start()) {
+      t_gain += v.eval(v.start.value().index(), t_index);
+      t_gain -= v.eval(v.start.value().index(), u_index);
+    }
+  } else {
+    const auto t_previous_index = _input.jobs[s_route[t_rank - 1]].index();
+    t_gain += v.eval(t_previous_index, t_index);
+    t_gain -= v.eval(t_previous_index, u_index);
+  }
+
+  _end_gain_computed = true;
+}
+
+void PriorityReplace::compute_gain() {
+  assert(replace_start_valid || replace_end_valid);
+  assert(_start_gain_computed || !replace_start_valid);
+  assert(_end_gain_computed || !replace_end_valid);
+
+  if (replace_start_valid && replace_end_valid) {
+    // Decide based on priority and cost.
+    if (std::tie(_end_priority_gain, t_gain) <
+        std::tie(_start_priority_gain, s_gain)) {
+      replace_end_valid = false;
+    } else {
+      replace_start_valid = false;
+    }
+  }
+
+  if (replace_start_valid) {
+    stored_gain = s_gain;
+  } else {
+    assert(replace_end_valid);
+    stored_gain = t_gain;
+  }
+
   gain_computed = true;
 }
 
 bool PriorityReplace::is_valid() {
   const auto& j = _input.jobs[_u];
 
-  // Early abort if priority gain is not interesting anyway.
-  bool valid = (_best_known_priority_gain <= _begin_priority_gain) &&
-               source.is_valid_addition_for_capacity_margins(_input,
-                                                             j.pickup,
-                                                             j.delivery,
-                                                             0,
-                                                             s_rank + 1);
+  // Early abort if priority gain is not interesting anyway or the
+  // move is not interesting: s_rank is zero if the candidate start
+  // portion is empty or with a single job (that would be an
+  // UnassignedExchange move).
+  replace_start_valid =
+    (s_rank > 0) && (_best_known_priority_gain <= _start_priority_gain) &&
+    source.is_valid_addition_for_capacity_margins(_input,
+                                                  j.pickup,
+                                                  j.delivery,
+                                                  0,
+                                                  s_rank + 1);
 
-  if (valid) {
-    // Check validity with regard to vehicle range bounds, requires
-    // valid gain value.
-    if (!gain_computed) {
-      // We don't check gain before validity if priority is strictly
-      // improved.
-      this->compute_gain();
-    }
+  // Don't bother if the candidate end portion is empty or with a
+  // single job (that would be an UnassignedExchange move).
+  replace_end_valid =
+    (t_rank < s_route.size() - 1) &&
+    (_best_known_priority_gain <= _end_priority_gain) &&
+    source.is_valid_addition_for_capacity_margins(_input,
+                                                  j.pickup,
+                                                  j.delivery,
+                                                  t_rank,
+                                                  s_route.size());
 
-    valid = is_valid_for_source_range_bounds();
+  // Check validity with regard to vehicle range bounds, requires
+  // valid gain values for both options.
+  if (replace_start_valid) {
+    this->compute_start_gain();
+
+    replace_start_valid = is_valid_for_source_range_bounds();
   }
 
-  return valid;
+  if (replace_end_valid) {
+    this->compute_end_gain();
+
+    replace_end_valid = is_valid_for_target_range_bounds();
+  }
+
+  return replace_start_valid || replace_end_valid;
 }
 
 void PriorityReplace::apply() {
@@ -106,11 +183,29 @@ void PriorityReplace::apply() {
   _unassigned.insert(s_route.cbegin(), s_route.cbegin() + s_rank + 1);
 
   const std::vector<Index> addition({_u});
-  source.replace(_input, addition.begin(), addition.end(), 0, s_rank + 1);
+
+  assert(replace_start_valid xor replace_end_valid);
+
+  if (replace_start_valid) {
+    source.replace(_input, addition.begin(), addition.end(), 0, s_rank + 1);
+  } else {
+    source.replace(_input,
+                   addition.begin(),
+                   addition.end(),
+                   t_rank,
+                   s_route.size());
+  }
 }
 
-Priority PriorityReplace::priority_gain() const {
-  return _begin_priority_gain;
+Priority PriorityReplace::priority_gain() {
+  if (!gain_computed) {
+    // Priority gain depends on actual option, decided in compute_gain.
+    this->compute_gain();
+  }
+
+  assert(replace_start_valid xor replace_end_valid);
+
+  return replace_start_valid ? _start_priority_gain : _end_priority_gain;
 }
 
 std::vector<Index> PriorityReplace::addition_candidates() const {

--- a/src/problems/cvrp/operators/priority_replace.h
+++ b/src/problems/cvrp/operators/priority_replace.h
@@ -15,13 +15,27 @@ All rights reserved (see LICENSE).
 namespace vroom::cvrp {
 
 class PriorityReplace : public ls::Operator {
+private:
+  bool _start_gain_computed{false};
+  bool _end_gain_computed{false};
+  Priority _start_priority_gain;
+  Priority _end_priority_gain;
+
 protected:
   const Index _u; // Unassigned job to insert.
-  Priority _begin_priority_gain;
   Priority _best_known_priority_gain;
   std::unordered_set<Index>& _unassigned;
 
+  bool replace_start_valid{false};
+  bool replace_end_valid{false};
+
   void compute_gain() override;
+
+  // Compute possible gains depending on whether we replace start or
+  // end of route.
+  void compute_start_gain();
+
+  void compute_end_gain();
 
 public:
   PriorityReplace(const Input& input,
@@ -29,7 +43,9 @@ public:
                   std::unordered_set<Index>& unassigned,
                   RawRoute& s_raw_route,
                   Index s_vehicle,
-                  Index s_rank,
+                  Index s_rank, // last rank (included) when replacing
+                                // route start
+                  Index t_rank, // first rank when replacing route end
                   Index u,
                   Priority best_known_priority_gain);
 
@@ -37,7 +53,7 @@ public:
 
   void apply() override;
 
-  Priority priority_gain() const;
+  Priority priority_gain();
 
   std::vector<Index> addition_candidates() const override;
 

--- a/src/problems/cvrp/operators/priority_replace.h
+++ b/src/problems/cvrp/operators/priority_replace.h
@@ -18,12 +18,12 @@ class PriorityReplace : public ls::Operator {
 private:
   bool _start_gain_computed{false};
   bool _end_gain_computed{false};
-  Priority _start_priority_gain;
-  Priority _end_priority_gain;
+  const Priority _start_priority_gain;
+  const Priority _end_priority_gain;
 
 protected:
   const Index _u; // Unassigned job to insert.
-  Priority _best_known_priority_gain;
+  const Priority _best_known_priority_gain;
   std::unordered_set<Index>& _unassigned;
 
   bool replace_start_valid{false};

--- a/src/problems/cvrp/operators/priority_replace.h
+++ b/src/problems/cvrp/operators/priority_replace.h
@@ -17,6 +17,8 @@ namespace vroom::cvrp {
 class PriorityReplace : public ls::Operator {
 protected:
   const Index _u; // Unassigned job to insert.
+  Priority _begin_priority_gain;
+  Priority _best_known_priority_gain;
   std::unordered_set<Index>& _unassigned;
 
   void compute_gain() override;
@@ -28,11 +30,14 @@ public:
                   RawRoute& s_raw_route,
                   Index s_vehicle,
                   Index s_rank,
-                  Index u);
+                  Index u,
+                  Priority best_known_priority_gain);
 
   bool is_valid() override;
 
   void apply() override;
+
+  Priority priority_gain() const;
 
   std::vector<Index> addition_candidates() const override;
 

--- a/src/problems/cvrp/operators/priority_replace.h
+++ b/src/problems/cvrp/operators/priority_replace.h
@@ -1,0 +1,46 @@
+#ifndef CVRP_PRIORITY_REPLACE_H
+#define CVRP_PRIORITY_REPLACE_H
+
+/*
+
+This file is part of VROOM.
+
+Copyright (c) 2015-2022, Julien Coupey.
+All rights reserved (see LICENSE).
+
+*/
+
+#include "algorithms/local_search/operator.h"
+
+namespace vroom::cvrp {
+
+class PriorityReplace : public ls::Operator {
+protected:
+  const Index _u; // Unassigned job to insert.
+  std::unordered_set<Index>& _unassigned;
+
+  void compute_gain() override;
+
+public:
+  PriorityReplace(const Input& input,
+                  const utils::SolutionState& sol_state,
+                  std::unordered_set<Index>& unassigned,
+                  RawRoute& s_raw_route,
+                  Index s_vehicle,
+                  Index s_rank,
+                  Index u);
+
+  bool is_valid() override;
+
+  void apply() override;
+
+  std::vector<Index> addition_candidates() const override;
+
+  std::vector<Index> update_candidates() const override;
+
+  std::vector<Index> required_unassigned() const override;
+};
+
+} // namespace vroom::cvrp
+
+#endif

--- a/src/problems/cvrp/operators/relocate.cpp
+++ b/src/problems/cvrp/operators/relocate.cpp
@@ -61,8 +61,8 @@ void Relocate::compute_gain() {
 
 bool Relocate::is_valid() {
   assert(gain_computed);
-  return is_valid_for_source_max_travel_time() &&
-         is_valid_for_target_max_travel_time() &&
+  return is_valid_for_source_range_bounds() &&
+         is_valid_for_target_range_bounds() &&
          target
            .is_valid_addition_for_capacity(_input,
                                            _input.jobs[s_route[s_rank]].pickup,

--- a/src/problems/cvrp/operators/reverse_two_opt.cpp
+++ b/src/problems/cvrp/operators/reverse_two_opt.cpp
@@ -150,8 +150,8 @@ bool ReverseTwoOpt::is_valid() {
 
   const auto& s_pickup = source.bwd_pickups(s_rank);
 
-  return is_valid_for_source_max_travel_time() &&
-         is_valid_for_target_max_travel_time() &&
+  return is_valid_for_source_range_bounds() &&
+         is_valid_for_target_range_bounds() &&
          source.is_valid_addition_for_capacity_margins(_input,
                                                        t_pickup,
                                                        _t_delivery,

--- a/src/problems/cvrp/operators/route_exchange.cpp
+++ b/src/problems/cvrp/operators/route_exchange.cpp
@@ -99,8 +99,8 @@ void RouteExchange::compute_gain() {
 bool RouteExchange::is_valid() {
   assert(gain_computed);
 
-  return is_valid_for_source_max_travel_time() &&
-         is_valid_for_target_max_travel_time() &&
+  return is_valid_for_source_range_bounds() &&
+         is_valid_for_target_range_bounds() &&
          (source.max_load() <= _input.vehicles[t_vehicle].capacity) &&
          (target.max_load() <= _input.vehicles[s_vehicle].capacity);
 }

--- a/src/problems/cvrp/operators/tsp_fix.cpp
+++ b/src/problems/cvrp/operators/tsp_fix.cpp
@@ -42,7 +42,7 @@ void TSPFix::compute_gain() {
 }
 
 bool TSPFix::is_valid() {
-  bool valid = is_valid_for_source_max_travel_time();
+  bool valid = is_valid_for_source_range_bounds();
 
   if (valid) {
     RawRoute route(_input, s_vehicle, _input.zero_amount().size());

--- a/src/problems/cvrp/operators/two_opt.cpp
+++ b/src/problems/cvrp/operators/two_opt.cpp
@@ -113,8 +113,8 @@ bool TwoOpt::is_valid() {
 
   const auto& s_pickup = source.bwd_pickups(s_rank);
 
-  return is_valid_for_source_max_travel_time() &&
-         is_valid_for_target_max_travel_time() &&
+  return is_valid_for_source_range_bounds() &&
+         is_valid_for_target_range_bounds() &&
          source.is_valid_addition_for_capacity_margins(_input,
                                                        t_pickup,
                                                        _t_delivery,

--- a/src/problems/cvrp/operators/unassigned_exchange.cpp
+++ b/src/problems/cvrp/operators/unassigned_exchange.cpp
@@ -124,7 +124,7 @@ bool UnassignedExchange::is_valid() {
       this->compute_gain();
     }
 
-    valid = is_valid_for_source_max_travel_time();
+    valid = is_valid_for_source_range_bounds();
   }
 
   return valid;

--- a/src/problems/cvrp/operators/unassigned_exchange.cpp
+++ b/src/problems/cvrp/operators/unassigned_exchange.cpp
@@ -116,11 +116,11 @@ bool UnassignedExchange::is_valid() {
                                                           _last_rank);
 
   if (valid) {
-    // Check validity with regard to max_travel_time, requires valid
-    // gain value.
+    // Check validity with regard to vehicle range bounds, requires
+    // valid gain value.
     if (!gain_computed) {
-      // May happen that we don't check gain before validity if priority
-      // is improved.
+      // We don't check gain before validity if priority is strictly
+      // improved.
       this->compute_gain();
     }
 
@@ -133,9 +133,9 @@ bool UnassignedExchange::is_valid() {
 void UnassignedExchange::apply() {
   std::ranges::copy(_moved_jobs, s_route.begin() + _first_rank);
 
-  assert(_unassigned.find(_u) != _unassigned.end());
+  assert(_unassigned.contains(_u));
   _unassigned.erase(_u);
-  assert(_unassigned.find(_removed) == _unassigned.end());
+  assert(!_unassigned.contains(_removed));
   _unassigned.insert(_removed);
 
   source.update_amounts(_input);

--- a/src/problems/vrptw/operators/priority_replace.cpp
+++ b/src/problems/vrptw/operators/priority_replace.cpp
@@ -19,14 +19,16 @@ PriorityReplace::PriorityReplace(const Input& input,
                                  TWRoute& tw_s_route,
                                  Index s_vehicle,
                                  Index s_rank,
-                                 Index u)
+                                 Index u,
+                                 Priority best_known_priority_gain)
   : cvrp::PriorityReplace(input,
                           sol_state,
                           unassigned,
                           static_cast<RawRoute&>(tw_s_route),
                           s_vehicle,
                           s_rank,
-                          u),
+                          u,
+                          best_known_priority_gain),
     _tw_s_route(tw_s_route) {
 }
 

--- a/src/problems/vrptw/operators/priority_replace.cpp
+++ b/src/problems/vrptw/operators/priority_replace.cpp
@@ -1,0 +1,66 @@
+/*
+
+This file is part of VROOM.
+
+Copyright (c) 2015-2022, Julien Coupey.
+All rights reserved (see LICENSE).
+
+*/
+
+#include "problems/vrptw/operators/priority_replace.h"
+
+namespace vroom::vrptw {
+
+PriorityReplace::PriorityReplace(const Input& input,
+                                 const utils::SolutionState& sol_state,
+                                 std::unordered_set<Index>& unassigned,
+                                 TWRoute& tw_s_route,
+                                 Index s_vehicle,
+                                 Index s_rank,
+                                 Index u)
+  : cvrp::PriorityReplace(input,
+                          sol_state,
+                          unassigned,
+                          static_cast<RawRoute&>(tw_s_route),
+                          s_vehicle,
+                          s_rank,
+                          u),
+    _tw_s_route(tw_s_route) {
+}
+
+bool PriorityReplace::is_valid() {
+  bool valid = cvrp::PriorityReplace::is_valid();
+
+  if (valid) {
+    std::vector<Index> job_ranks({_u});
+    valid = _tw_s_route.is_valid_addition_for_tw(_input,
+                                                 _input.jobs[_u].delivery,
+                                                 job_ranks.begin(),
+                                                 job_ranks.end(),
+                                                 0,
+                                                 s_rank + 1);
+  }
+
+  return valid;
+}
+
+void PriorityReplace::apply() {
+  assert(_unassigned.contains(_u));
+  _unassigned.erase(_u);
+
+  assert(
+    std::all_of(s_route.cbegin(),
+                s_route.cbegin() + s_rank + 1,
+                [this](const auto j) { return !_unassigned.contains(j); }));
+  _unassigned.insert(s_route.cbegin(), s_route.cbegin() + s_rank + 1);
+
+  const std::vector<Index> addition({_u});
+  _tw_s_route.replace(_input,
+                      _input.jobs[_u].delivery,
+                      addition.begin(),
+                      addition.end(),
+                      0,
+                      s_rank + 1);
+}
+
+} // namespace vroom::vrptw

--- a/src/problems/vrptw/operators/priority_replace.cpp
+++ b/src/problems/vrptw/operators/priority_replace.cpp
@@ -7,6 +7,8 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <algorithm>
+
 #include "problems/vrptw/operators/priority_replace.h"
 
 namespace vroom::vrptw {

--- a/src/problems/vrptw/operators/priority_replace.cpp
+++ b/src/problems/vrptw/operators/priority_replace.cpp
@@ -67,17 +67,17 @@ void PriorityReplace::apply() {
   assert(_unassigned.contains(_u));
   _unassigned.erase(_u);
 
-  assert(
-    std::all_of(s_route.cbegin(),
-                s_route.cbegin() + s_rank + 1,
-                [this](const auto j) { return !_unassigned.contains(j); }));
-  _unassigned.insert(s_route.cbegin(), s_route.cbegin() + s_rank + 1);
-
   const std::vector<Index> addition({_u});
 
   assert(replace_start_valid xor replace_end_valid);
 
   if (replace_start_valid) {
+    assert(
+      std::all_of(s_route.cbegin(),
+                  s_route.cbegin() + s_rank + 1,
+                  [this](const auto j) { return !_unassigned.contains(j); }));
+    _unassigned.insert(s_route.cbegin(), s_route.cbegin() + s_rank + 1);
+
     _tw_s_route.replace(_input,
                         _input.jobs[_u].delivery,
                         addition.begin(),
@@ -85,6 +85,12 @@ void PriorityReplace::apply() {
                         0,
                         s_rank + 1);
   } else {
+    assert(
+      std::all_of(s_route.cbegin() + t_rank,
+                  s_route.cend(),
+                  [this](const auto j) { return !_unassigned.contains(j); }));
+    _unassigned.insert(s_route.cbegin() + t_rank, s_route.cend());
+
     _tw_s_route.replace(_input,
                         _input.jobs[_u].delivery,
                         addition.begin(),

--- a/src/problems/vrptw/operators/priority_replace.h
+++ b/src/problems/vrptw/operators/priority_replace.h
@@ -1,0 +1,37 @@
+#ifndef VRPTW_PRIORITY_REPLACE_H
+#define VRPTW_PRIORITY_REPLACE_H
+
+/*
+
+This file is part of VROOM.
+
+Copyright (c) 2015-2022, Julien Coupey.
+All rights reserved (see LICENSE).
+
+*/
+
+#include "problems/cvrp/operators/priority_replace.h"
+
+namespace vroom::vrptw {
+
+class PriorityReplace : public cvrp::PriorityReplace {
+private:
+  TWRoute& _tw_s_route;
+
+public:
+  PriorityReplace(const Input& input,
+                  const utils::SolutionState& sol_state,
+                  std::unordered_set<Index>& unassigned,
+                  TWRoute& tw_s_route,
+                  Index s_vehicle,
+                  Index s_rank,
+                  Index u);
+
+  bool is_valid() override;
+
+  void apply() override;
+};
+
+} // namespace vroom::vrptw
+
+#endif

--- a/src/problems/vrptw/operators/priority_replace.h
+++ b/src/problems/vrptw/operators/priority_replace.h
@@ -25,6 +25,7 @@ public:
                   TWRoute& tw_s_route,
                   Index s_vehicle,
                   Index s_rank,
+                  Index t_rank,
                   Index u,
                   Priority best_known_priority_gain);
 

--- a/src/problems/vrptw/operators/priority_replace.h
+++ b/src/problems/vrptw/operators/priority_replace.h
@@ -25,7 +25,8 @@ public:
                   TWRoute& tw_s_route,
                   Index s_vehicle,
                   Index s_rank,
-                  Index u);
+                  Index u,
+                  Priority best_known_priority_gain);
 
   bool is_valid() override;
 

--- a/src/problems/vrptw/vrptw.cpp
+++ b/src/problems/vrptw/vrptw.cpp
@@ -20,6 +20,7 @@ All rights reserved (see LICENSE).
 #include "problems/vrptw/operators/mixed_exchange.h"
 #include "problems/vrptw/operators/or_opt.h"
 #include "problems/vrptw/operators/pd_shift.h"
+#include "problems/vrptw/operators/priority_replace.h"
 #include "problems/vrptw/operators/relocate.h"
 #include "problems/vrptw/operators/reverse_two_opt.h"
 #include "problems/vrptw/operators/route_exchange.h"
@@ -52,6 +53,7 @@ using LocalSearch = ls::LocalSearch<TWRoute,
                                     vrptw::RouteExchange,
                                     vrptw::SwapStar,
                                     vrptw::RouteSplit,
+                                    vrptw::PriorityReplace,
                                     vrptw::TSPFix>;
 } // namespace vrptw
 

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -173,6 +173,7 @@ enum OperatorName {
   RouteExchange,
   SwapStar,
   RouteSplit,
+  PriorityReplace,
   TSPFix,
   MAX
 };

--- a/src/structures/vroom/raw_route.cpp
+++ b/src/structures/vroom/raw_route.cpp
@@ -329,5 +329,9 @@ template void RawRoute::replace(const Input& input,
                                 std::vector<Index>::iterator last_job,
                                 const Index first_rank,
                                 const Index last_rank);
-
+template void RawRoute::replace(const Input& input,
+                                std::vector<Index>::const_iterator first_job,
+                                std::vector<Index>::const_iterator last_job,
+                                const Index first_rank,
+                                const Index last_rank);
 } // namespace vroom

--- a/src/structures/vroom/solution_state.h
+++ b/src/structures/vroom/solution_state.h
@@ -44,6 +44,13 @@ public:
   std::vector<std::vector<Index>> fwd_skill_rank;
   std::vector<std::vector<Index>> bwd_skill_rank;
 
+  // fwd_priority[v][i] stores the sum of priorities from job at rank
+  // 0 to job at rank i (included) in the route for vehicle v.
+  // bwd_priority[v][i] stores the sum of priorities from job at rank
+  // i to last job in the route for vehicle v.
+  std::vector<std::vector<Priority>> fwd_priority;
+  std::vector<std::vector<Priority>> bwd_priority;
+
   // edge_evals_around_node[v][i] evaluates the sum of edges that
   // appear before and after job at rank i in route for vehicle v
   // (handling cases where those edges are absent or linked with
@@ -127,6 +134,8 @@ public:
   void update_costs(const std::vector<Index>& route, Index v);
 
   void update_skills(const std::vector<Index>& route, Index v1);
+
+  void update_priorities(const std::vector<Index>& route, Index v);
 
   void set_node_gains(const std::vector<Index>& route, Index v);
 

--- a/src/utils/helpers.cpp
+++ b/src/utils/helpers.cpp
@@ -81,6 +81,7 @@ const std::array<std::string, OperatorName::MAX>
                   "RouteExchange",
                   "SwapStar",
                   "RouteSplit",
+                  "PriorityReplace",
                   "TSPFix"});
 
 void log_LS_operators(


### PR DESCRIPTION
## Issue

Attempt at fixing #988 

## Tasks

 - [x] Store forward/backward accumulated priority score at route level
 - [x] Design a move replacing the biggest possible start portion of a route by an unassigned job with higher overall priority
 - [x] Extend that to the end portion of a route
 - [x] Benchmark
 - [x] Update `CHANGELOG.md`
 - [x] review
