### PR TITLE
Adapt URI to ORS production settings without default /ors base path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 lib/
 build/
 .vscode
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@
 - Update gcc to version 12 in CI (#1002)
 - Update clang to version 15 in CI (#1022)
 
+### Removed
+
+- **Breaking:** hard-coded ors base path of '/ors/v2'. Can be added as path in passed host ([#1036](https://github.com/VROOM-Project/vroom/issues/1036))
+
 ### Fixed
 
 #### Core solving

--- a/src/routing/ors_wrapper.cpp
+++ b/src/routing/ors_wrapper.cpp
@@ -49,7 +49,7 @@ std::string OrsWrapper::build_query(const std::vector<Location>& locations,
 
   // Building query for ORS
   std::string query =
-    "POST /" + _server.path + "ors/v2/" + service + "/" + profile;
+    "POST /" + _server.path + service + "/" + profile;
 
   query += " HTTP/1.0\r\n";
   query += "Accept: */*\r\n";


### PR DESCRIPTION
## Issue

https://github.com/VROOM-Project/vroom/issues/1036

## Tasks

 - [x] Update `CHANGELOG.md` (remove if irrelevant)
 - [x] review
