### PR TITLE
Copy avoidance in SWAP* insertion ranges

### DIFF
--- a/src/algorithms/local_search/swap_star_utils.h
+++ b/src/algorithms/local_search/swap_star_utils.h
@@ -14,6 +14,7 @@ All rights reserved (see LICENSE).
 
 #include "algorithms/local_search/top_insertions.h"
 #include "structures/typedefs.h"
+#include "structures/prepostview.h"
 #include "structures/vroom/input/input.h"
 #include "structures/vroom/solution_state.h"
 #include "utils/helpers.h"
@@ -130,7 +131,7 @@ bool valid_choice_for_insertion_ranks(const utils::SolutionState& sol_state,
 }
 
 struct InsertionRange {
-  std::vector<Index> range;
+  prepostview<Index> range;
   Index first_rank;
   Index last_rank;
 };
@@ -143,24 +144,16 @@ inline InsertionRange get_insert_range(const std::vector<Index>& s_route,
                                        Index insertion_rank) {
   InsertionRange insert;
   if (s_rank == insertion_rank) {
-    insert.range.push_back(job_rank);
+    insert.range = prepostview(job_rank, {});
     insert.first_rank = s_rank;
     insert.last_rank = s_rank + 1;
   } else {
     if (s_rank < insertion_rank) {
-      insert.range.reserve(insertion_rank - s_rank);
-      std::copy(s_route.begin() + s_rank + 1,
-                s_route.begin() + insertion_rank,
-                std::back_inserter(insert.range));
-      insert.range.push_back(job_rank);
+      insert.range = prepostview(s_route, job_rank, s_rank + 1, insertion_rank);
       insert.first_rank = s_rank;
       insert.last_rank = insertion_rank;
     } else {
-      insert.range.reserve(s_rank - insertion_rank + 1);
-      insert.range.push_back(job_rank);
-      std::copy(s_route.begin() + insertion_rank,
-                s_route.begin() + s_rank,
-                std::back_inserter(insert.range));
+      insert.range = prepostview(job_rank, s_route, insertion_rank, s_rank);
       insert.first_rank = insertion_rank;
       insert.last_rank = s_rank + 1;
     }

--- a/src/structures/prepostview.h
+++ b/src/structures/prepostview.h
@@ -1,0 +1,123 @@
+#ifndef PREPOSTVIEW_H
+#define PREPOSTVIEW_H
+
+#include <vector>
+
+
+template<typename T>
+class prepostview
+{
+    public:
+        prepostview(T const & value, std::vector<T> const & vector)
+          : prepostview(value, vector, 0, vector.size())
+        {
+        }
+
+        prepostview(std::vector<T> const & vector, T const & value)
+          : prepostview(vector, value, 0)
+        {
+        }
+
+        prepostview(T const & value, std::vector<T> const & vector, std::size_t start)
+          : prepostview(value, vector, start, vector.size())
+        {
+        }
+
+        prepostview(std::vector<T> const & vector, T const & value, std::size_t start)
+          : prepostview(vector, value, start, vector.size())
+        {
+        }
+
+        prepostview(T const & value, std::vector<T> const & vector, std::size_t start, std::size_t end)
+          : m_vector(&vector)
+          , m_value(value)
+          , m_prepended(true)
+          , m_start(start)
+          , m_end(end)
+        {
+        }
+
+        prepostview(std::vector<T> const & vector, T const & value, std::size_t start, std::size_t end)
+          : m_vector(&vector)
+          , m_value(value)
+          , m_prepended(false)
+          , m_start(start)
+          , m_end(end)
+        {
+        }
+
+        prepostview()
+          : m_vector(nullptr)
+          , m_value()
+          , m_prepended(false)
+          , m_start(0)
+          , m_end(0)
+        {
+        }
+
+        auto operator[](std::size_t index) const -> const T &
+        {
+            if (index == m_start - 1 && m_prepended)
+            {
+                return m_value;
+            }
+
+            if (index == m_end && !m_prepended)
+            {
+                return m_value;
+            }
+
+            return (*m_vector)[index];
+        }
+
+        class iterator
+        {
+            public:
+                iterator(prepostview const & ppv, std::size_t index)
+                  : m_ppv(ppv)
+                  , m_index(index)
+                {
+                }
+
+                auto operator!=(iterator const & other) const -> bool
+                {
+                    return m_index != other.m_index;
+                }
+
+                auto operator*() const -> T
+                {
+                    return m_ppv[m_index];
+                }
+
+                auto operator++() -> iterator &
+                {
+                    ++m_index;
+                    return *this;
+                }
+
+                using iterator_category = std::forward_iterator_tag;
+
+            private:
+                prepostview const & m_ppv;
+                std::size_t m_index;
+        };
+
+        auto begin() const -> iterator
+        {
+            return iterator(*this, m_prepended ? m_start - 1 : m_start);
+        }
+
+        auto end() const -> iterator
+        {
+            return iterator(*this, m_prepended ? m_end : m_end + 1);
+        }
+
+    private:
+        std::vector<T> const * m_vector;
+        T m_value;
+        bool m_prepended;
+        std::size_t m_start;
+        std::size_t m_end;
+};
+
+#endif

--- a/src/structures/prepostview.h
+++ b/src/structures/prepostview.h
@@ -1,6 +1,7 @@
 #ifndef PREPOSTVIEW_H
 #define PREPOSTVIEW_H
 
+#include <iterator>
 #include <vector>
 
 
@@ -74,9 +75,26 @@ class prepostview
         {
             public:
                 iterator(prepostview const & ppv, std::size_t index)
-                  : m_ppv(ppv)
+                  : m_ppv(&ppv)
                   , m_index(index)
                 {
+                }
+
+                iterator(iterator const & other)
+                  : m_ppv(other.m_ppv)
+                  , m_index(other.m_index)
+                {
+                }
+
+                iterator()
+                  : m_ppv(nullptr)
+                  , m_index(-2)
+                {
+                }
+
+                auto operator==(iterator const & other) const -> bool
+                {
+                    return m_index == other.m_index;
                 }
 
                 auto operator!=(iterator const & other) const -> bool
@@ -84,9 +102,34 @@ class prepostview
                     return m_index != other.m_index;
                 }
 
+                auto operator<(iterator const & other) const -> bool
+                {
+                    if (m_index == other.m_index)
+                    {
+                        return false;
+                    }
+
+                    if (m_index == -1)
+                    {
+                        return true;
+                    }
+
+                    return m_index < other.m_index;
+                }
+
+                auto operator<=(iterator const & other) const -> bool
+                {
+                    return !(other < *this);
+                }
+
                 auto operator*() const -> T
                 {
-                    return m_ppv[m_index];
+                    return (*m_ppv)[m_index];
+                }
+
+                auto operator->() -> T &
+                {
+                    return &((*m_ppv)[m_index]);
                 }
 
                 auto operator++() -> iterator &
@@ -95,10 +138,26 @@ class prepostview
                     return *this;
                 }
 
-                using iterator_category = std::forward_iterator_tag;
+                auto operator++(int) -> iterator
+                {
+                    auto tmp = *this;
+                    ++(*this);
+                    return tmp;
+                }
+
+                auto operator-(int i) const -> iterator
+                {
+                    return iterator(*m_ppv, m_index - i);
+                }
+
+                // using iterator_category = std::forward_iterator_tag;
+                using difference_type = std::ptrdiff_t;
+                using element_type = T;
+                // using pointer = T *;
+                // using reference = T &;
 
             private:
-                prepostview const & m_ppv;
+                prepostview const * m_ppv;
                 std::size_t m_index;
         };
 

--- a/src/structures/vroom/raw_route.cpp
+++ b/src/structures/vroom/raw_route.cpp
@@ -8,6 +8,7 @@ All rights reserved (see LICENSE).
 */
 
 #include "structures/vroom/raw_route.h"
+#include "structures/prepostview.h"
 
 namespace vroom {
 
@@ -322,6 +323,13 @@ template bool RawRoute::is_valid_addition_for_capacity_inclusion(
   Amount delivery,
   const std::vector<Index>::reverse_iterator first_job,
   const std::vector<Index>::reverse_iterator last_job,
+  const Index first_rank,
+  const Index last_rank) const;
+template bool RawRoute::is_valid_addition_for_capacity_inclusion(
+  const Input& input,
+  Amount delivery,
+  const prepostview<Index>::iterator first_job,
+  const prepostview<Index>::iterator last_job,
   const Index first_rank,
   const Index last_rank) const;
 template void RawRoute::replace(const Input& input,

--- a/src/structures/vroom/tw_route.cpp
+++ b/src/structures/vroom/tw_route.cpp
@@ -10,6 +10,7 @@ All rights reserved (see LICENSE).
 #include <algorithm>
 
 #include "structures/vroom/tw_route.h"
+#include "structures/prepostview.h"
 #include "utils/helpers.h"
 
 namespace vroom {
@@ -1474,6 +1475,15 @@ template bool TWRoute::is_valid_addition_for_tw(
   const Index last_rank,
   bool check_max_load) const;
 
+template bool TWRoute::is_valid_addition_for_tw(
+  const Input& input,
+  const Amount& delivery,
+  const prepostview<Index>::iterator first_job,
+  const prepostview<Index>::iterator last_job,
+  const Index first_rank,
+  const Index last_rank,
+  bool check_max_load) const;
+
 template void TWRoute::replace(const Input& input,
                                const Amount& delivery,
                                const std::vector<Index>::iterator first_job,
@@ -1500,6 +1510,13 @@ TWRoute::replace(const Input& input,
                  const Amount& delivery,
                  const std::array<Index, 1>::const_iterator first_job,
                  const std::array<Index, 1>::const_iterator last_job,
+                 const Index first_rank,
+                 const Index last_rank);
+template void
+TWRoute::replace(const Input& input,
+                 const Amount& delivery,
+                 const prepostview<Index>::iterator first_job,
+                 const prepostview<Index>::iterator last_job,
                  const Index first_rank,
                  const Index last_rank);
 


### PR DESCRIPTION
## Issue

This is a draft of proposed change for #657.

The `prepostview` is a template class representing a lightweight view over contents of a vector (or a part of it) with an additional element in front or at back. It has just enough facilities to allow it being used in a range-based for loop.

This is work in progress and needs some polishing before it can be merged, but should work and allow to run tests and benchmarks.

Basically, we are trading a copy + trivial iteration over copied range for no copy but slightly slower iteration (each dereference contains some logic).

## Tasks

 - [ ] ...
 - [ ] Update `docs/API.md` (remove if irrelevant)
 - [ ] Update `CHANGELOG.md` (remove if irrelevant)
 - [ ] review
