### PR TITLE
Add information on distance matrices in input

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -353,7 +353,7 @@ The `summary` object has the following properties:
 | [`pickup`] | total pickup for all routes |
 | [`distance`]* | total distance for all routes |
 
-*: provided when using the `-g` flag.
+*: provided when using the `-g` flag or passing distance matrices in input.
 
 ## Routes
 
@@ -375,9 +375,10 @@ A `route` object has the following properties:
 | [`pickup`] | total pickup for tasks in this route |
 | [`description`] | vehicle description, if provided in input |
 | [`geometry`]* | polyline encoded route geometry |
-| [`distance`]* | total route distance |
+| [`distance`]** | total route distance |
 
 *: provided when using the `-g` flag.
+**: provided when using the `-g` flag or passing distance matrices in input.
 
 ### Steps
 


### PR DESCRIPTION
## Issue #1126 

Proposed wording for information on `distance` entries being available when distance matrices are passed ininput.

I think the change is relevant for both master and the 1.14 release branches.

## Tasks

 - [x] Update `docs/API.md` (remove if irrelevant)
 - [ ] Update `CHANGELOG.md` (remove if irrelevant)
 - [x] review
