### PR TITLE
Fix crash with non-object JSON input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 
 ### Fixed
 
+#### Core solving
+
+- Crash when input is valid JSON but not an object (#1172)
+
 #### Internals
 
 - Iterator type required by `TWRoute::replace` function (#1103)

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -517,6 +517,10 @@ void parse(Input& input, const std::string& input_str, bool geometry) {
   }
 
   // Main checks for valid json input.
+  if (!json_input.IsObject()) {
+    throw InputException("Input root is not an object.");
+  }
+
   bool has_jobs = json_input.HasMember("jobs") &&
                   json_input["jobs"].IsArray() && !json_input["jobs"].Empty();
   bool has_shipments = json_input.HasMember("shipments") &&


### PR DESCRIPTION
## Issue

Fixes #1172 

## Tasks

 - [x] Add a check for object after parsing
 - [x] Update `CHANGELOG.md`
 - [x] review
