### PR TITLE
Fix capacity array check consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Refactor to use `std::format` whenever possible (#1081)
 - Reduce complexity for recreation process (#1155)
 - Refactor `SolutionIndicators` (#1169)
+- Remove amount consistency checks in `parse` in favor of upstream checks in `Input` (#1086)
 
 #### CI
 
@@ -27,6 +28,10 @@
 - Update clang-format to 18 (#1148)
 
 ### Fixed
+
+#### Core solving
+
+- Capacity array check consistency (#1086)
 
 #### Internals
 

--- a/libvroom_examples/libvroom.cpp
+++ b/libvroom_examples/libvroom.cpp
@@ -105,8 +105,8 @@ void run_example_with_osrm() {
 
   // Create one-dimension capacity restrictions to model the situation
   // where one vehicle can handle 4 jobs with deliveries.
-  problem_instance.set_amount_size(amount_dimension);
   vroom::Amount vehicle_capacity(amount_dimension);
+  vehicle_capacity[0] = 4;
 
   vroom::TimeWindow vehicle_tw(28800, 43200); // Working hours.
   // Default "zero" amount data structures with relevant dimension.
@@ -120,7 +120,6 @@ void run_example_with_osrm() {
 
   vroom::UserDuration setup = 0;
   vroom::UserDuration service = 5 * 60; // 5 minutes
-  vehicle_capacity[0] = 4;
 
   // Define vehicle breaks.
   vroom::Break break_1(1, {vroom::TimeWindow(32400, 34200)}, 300);

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -605,9 +605,8 @@ void Input::set_vehicles_costs() {
 }
 
 void Input::set_vehicles_max_tasks() {
-  const auto amount_size = get_amount_size();
-
-  if (_has_jobs && !_has_shipments && amount_size > 0) {
+  if (const auto amount_size = get_amount_size();
+      _has_jobs && !_has_shipments && amount_size > 0) {
     // For job-only instances where capacity restrictions apply:
     // compute an upper bound of the number of jobs for each vehicle
     // based on pickups load and delivery loads. This requires sorting

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -12,6 +12,7 @@ All rights reserved (see LICENSE).
 
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 
 #include "routing/wrapper.h"
@@ -77,8 +78,7 @@ private:
   bool _all_locations_have_coords{true};
   std::vector<std::vector<Eval>> _jobs_vehicles_evals;
 
-  bool _amount_size_set{false};
-  unsigned _amount_size;
+  std::optional<unsigned> _amount_size;
   Amount _zero;
 
   const io::Servers _servers;
@@ -117,7 +117,8 @@ public:
         bool apply_TSPFix = false);
 
   unsigned get_amount_size() const {
-    return _amount_size;
+    assert(_amount_size.has_value());
+    return _amount_size.value();
   }
 
   void set_geometry(bool geometry);

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -77,14 +77,16 @@ private:
   bool _all_locations_have_coords{true};
   std::vector<std::vector<Eval>> _jobs_vehicles_evals;
 
-  unsigned _amount_size{0};
-  Amount _zero{0};
+  bool _amount_size_set{false};
+  unsigned _amount_size;
+  Amount _zero;
 
   const io::Servers _servers;
   const ROUTER _router;
 
   std::unique_ptr<VRP> get_problem() const;
 
+  void check_amount_size(const Amount& amount);
   void check_job(Job& job);
 
   UserCost check_cost_bound(const Matrix<UserCost>& matrix) const;
@@ -113,8 +115,6 @@ public:
   Input(io::Servers servers = {},
         ROUTER router = ROUTER::OSRM,
         bool apply_TSPFix = false);
-
-  void set_amount_size(unsigned amount_size);
 
   unsigned get_amount_size() const {
     return _amount_size;

--- a/src/structures/vroom/vehicle.cpp
+++ b/src/structures/vroom/vehicle.cpp
@@ -66,7 +66,7 @@ Vehicle::Vehicle(Id id,
     if (b.max_load.has_value() &&
         b.max_load.value().size() != capacity.size()) {
       throw InputException(
-        std::format("Inconsistent break max_load size for break: {}.", b.id));
+        std::format("Inconsistent break max_load size for break {}.", b.id));
     }
   }
 

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -538,7 +538,6 @@ void parse(Input& input, const std::string& input_str, bool geometry) {
   const unsigned amount_size =
     first_vehicle_has_capacity ? first_vehicle["capacity"].Size() : 0;
 
-  input.set_amount_size(amount_size);
   input.set_geometry(geometry);
 
   // Add all vehicles.

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -48,31 +48,6 @@ inline double get_double(const rapidjson::Value& object, const char* key) {
   return value;
 }
 
-inline Amount get_capacity(const rapidjson::Value& vehicle) {
-  unsigned amount_size = 0;
-
-  const bool vehicle_has_capacity = vehicle.HasMember("capacity");
-
-  if (vehicle_has_capacity) {
-    if (!vehicle["capacity"].IsArray()) {
-      throw InputException("Invalid capacity array.");
-    }
-
-    amount_size = vehicle["capacity"].Size();
-  }
-
-  Amount capacity(amount_size);
-
-  for (rapidjson::SizeType i = 0; i < amount_size; ++i) {
-    if (!vehicle["capacity"][i].IsUint()) {
-      throw InputException("Invalid capacity value.");
-    }
-    capacity[i] = vehicle["capacity"][i].GetUint();
-  }
-
-  return capacity;
-}
-
 inline Amount get_amount(const rapidjson::Value& object,
                          const char* key,
                          unsigned amount_size) {
@@ -445,7 +420,7 @@ inline Vehicle get_vehicle(const rapidjson::Value& json_vehicle,
                  start,
                  end,
                  profile,
-                 get_capacity(json_vehicle),
+                 get_amount(json_vehicle, "capacity", 0),
                  get_skills(json_vehicle),
                  get_vehicle_time_window(json_vehicle),
                  get_vehicle_breaks(json_vehicle, amount_size),

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -48,6 +48,31 @@ inline double get_double(const rapidjson::Value& object, const char* key) {
   return value;
 }
 
+inline Amount get_capacity(const rapidjson::Value& vehicle) {
+  unsigned amount_size = 0;
+
+  bool vehicle_has_capacity = vehicle.HasMember("capacity");
+
+  if (vehicle_has_capacity) {
+    if (!vehicle["capacity"].IsArray()) {
+      throw InputException("Invalid capacity array.");
+    }
+
+    amount_size = vehicle["capacity"].Size();
+  }
+
+  Amount capacity(amount_size);
+
+  for (rapidjson::SizeType i = 0; i < amount_size; ++i) {
+    if (!vehicle["capacity"][i].IsUint()) {
+      throw InputException("Invalid capacity value.");
+    }
+    capacity[i] = vehicle["capacity"][i].GetUint();
+  }
+
+  return capacity;
+}
+
 inline Amount get_amount(const rapidjson::Value& object,
                          const char* key,
                          unsigned amount_size) {
@@ -420,7 +445,7 @@ inline Vehicle get_vehicle(const rapidjson::Value& json_vehicle,
                  start,
                  end,
                  profile,
-                 get_amount(json_vehicle, "capacity", amount_size),
+                 get_capacity(json_vehicle),
                  get_skills(json_vehicle),
                  get_vehicle_time_window(json_vehicle),
                  get_vehicle_breaks(json_vehicle, amount_size),

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -51,7 +51,7 @@ inline double get_double(const rapidjson::Value& object, const char* key) {
 inline Amount get_capacity(const rapidjson::Value& vehicle) {
   unsigned amount_size = 0;
 
-  bool vehicle_has_capacity = vehicle.HasMember("capacity");
+  const bool vehicle_has_capacity = vehicle.HasMember("capacity");
 
   if (vehicle_has_capacity) {
     if (!vehicle["capacity"].IsArray()) {
@@ -76,21 +76,21 @@ inline Amount get_capacity(const rapidjson::Value& vehicle) {
 inline Amount get_amount(const rapidjson::Value& object,
                          const char* key,
                          unsigned amount_size) {
-  // Default to zero amount with provided size.
-  Amount amount(amount_size);
+  const bool has_amount_key = object.HasMember(key);
 
-  if (object.HasMember(key)) {
+  if (has_amount_key) {
     if (!object[key].IsArray()) {
       throw InputException("Invalid " + std::string(key) + " array.");
     }
 
-    if (object[key].Size() != amount_size) {
-      throw InputException(std::format("Inconsistent {} length: {} and {}.",
-                                       key,
-                                       object[key].Size(),
-                                       amount_size));
-    }
+    amount_size = object[key].Size();
+  }
 
+  // This will default to zero amount with provided size if expected
+  // key is omitted.
+  Amount amount(amount_size);
+
+  if (has_amount_key) {
     for (rapidjson::SizeType i = 0; i < object[key].Size(); ++i) {
       if (!object[key][i].IsUint()) {
         throw InputException("Invalid " + std::string(key) + " value.");


### PR DESCRIPTION
## Issue

Fixes #1086 

## Tasks

 - [x] Remove amount size consistency checks in `parse`
 - [x] Improve amount size consistency checks in `Input`
 - [x] Parse vehicle capacity based on their actual size regardless of expected amount size
 - [x] Update `CHANGELOG.md`
 - [x] review
