### PR TITLE
Fix routing coordinate format

### DIFF
--- a/src/routing/ors_wrapper.cpp
+++ b/src/routing/ors_wrapper.cpp
@@ -33,7 +33,7 @@ std::string OrsWrapper::build_query(const std::vector<Location>& locations,
   }
   body += "\":[";
   for (auto const& location : locations) {
-    body += std::format("[{},{}],", location.lon(), location.lat());
+    body += std::format("[{:.6f},{:.6f}],", location.lon(), location.lat());
   }
   body.pop_back(); // Remove trailing ','.
   body += "]";

--- a/src/routing/osrm_routed_wrapper.cpp
+++ b/src/routing/osrm_routed_wrapper.cpp
@@ -74,8 +74,9 @@ void OsrmRoutedWrapper::check_response(const rapidjson::Document& json_result,
       const auto error_loc =
         std::stoul(message.substr(snapping_error_base.size(),
                                   message.size() - snapping_error_base.size()));
-      const auto coordinates =
-        std::format("[{},{}]", locs[error_loc].lon(), locs[error_loc].lat());
+      const auto coordinates = std::format("[{:.6f},{:.6f}]",
+                                           locs[error_loc].lon(),
+                                           locs[error_loc].lat());
       throw RoutingException("Could not find route near location " +
                              coordinates);
     }

--- a/src/routing/osrm_routed_wrapper.cpp
+++ b/src/routing/osrm_routed_wrapper.cpp
@@ -38,7 +38,7 @@ OsrmRoutedWrapper::build_query(const std::vector<Location>& locations,
 
   // Adding locations and radiuses values.
   for (auto const& location : locations) {
-    query += std::format("{},{};", location.lon(), location.lat());
+    query += std::format("{:.6f},{:.6f};", location.lon(), location.lat());
     radiuses += DEFAULT_OSRM_SNAPPING_RADIUS + ";";
   }
   // Remove trailing ';'.

--- a/src/routing/valhalla_wrapper.cpp
+++ b/src/routing/valhalla_wrapper.cpp
@@ -37,8 +37,9 @@ std::string ValhallaWrapper::get_matrix_query(
   // List locations.
   std::string all_locations;
   for (auto const& location : locations) {
-    all_locations +=
-      std::format(R"({{"lon":{},"lat":{}}},)", location.lon(), location.lat());
+    all_locations += std::format(R"({{"lon":{:.6f},"lat":{:.6f}}},)",
+                                 location.lon(),
+                                 location.lat());
   }
   all_locations.pop_back(); // Remove trailing ','.
 
@@ -61,7 +62,7 @@ ValhallaWrapper::get_route_query(const std::vector<Location>& locations) const {
     "GET /" + _server.path + _route_service + "?json={\"locations\":[";
 
   for (auto const& location : locations) {
-    query += std::format(R"({{"lon":{},"lat":{},"type":"break"}},)",
+    query += std::format(R"({{"lon":{:.6f},"lat":{:.6f},"type":"break"}},)",
                          location.lon(),
                          location.lat());
   }

--- a/src/routing/wrapper.h
+++ b/src/routing/wrapper.h
@@ -147,7 +147,7 @@ protected:
     if (max_unfound_routes_for_a_loc > 0) {
       std::string error_msg = "Unfound route(s) ";
       error_msg += error_direction;
-      error_msg += std::format("location [{},{}]",
+      error_msg += std::format("location [{:.6f},{:.6f}]",
                                locs[error_loc].lon(),
                                locs[error_loc].lat());
 


### PR DESCRIPTION
## Issue

Fixes #1186

## Tasks

 - [x] Avoid scientific notation for small coordinates sent to routing
 - [x] Avoid scientific notation for small coordinates in error messages
 - [x] review
