### PR TITLE
Improve heuristic regrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 #### Core solving
 
+- Solution quality regression when using lots of skills (#1193)
 - Crash due to wrong delivery values in some validity checks (#1164)
 - Crash when input is valid JSON but not an object (#1172)
 - Capacity array check consistency (#1086)

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -534,11 +534,24 @@ Eval dynamic_vehicle_choice(const Input& input,
     // if any.
     std::vector<Cost> regrets(input.jobs.size(), input.get_cost_upper_bound());
 
+    bool all_compatible_jobs_later_undoable = true;
     for (const auto j : unassigned) {
       if (jobs_min_costs[j] < evals[j][v_rank].cost) {
         regrets[j] = jobs_min_costs[j];
       } else {
         regrets[j] = jobs_second_min_costs[j];
+      }
+
+      if (input.vehicle_ok_with_job(v_rank, j) &&
+          regrets[j] < input.get_cost_upper_bound()) {
+        all_compatible_jobs_later_undoable = false;
+      }
+    }
+
+    if (all_compatible_jobs_later_undoable) {
+      // Same approach as for basic heuristic.
+      for (const auto j : unassigned) {
+        regrets[j] = evals[j][v_rank].cost;
       }
     }
 

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -466,14 +466,14 @@ Eval dynamic_vehicle_choice(const Input& input,
                                      input.get_cost_upper_bound());
     std::vector<Cost> jobs_second_min_costs(input.jobs.size(),
                                             input.get_cost_upper_bound());
-    for (const auto job_rank : unassigned) {
-      for (const auto v_rank : vehicles_ranks) {
-        if (evals[job_rank][v_rank].cost <= jobs_min_costs[job_rank]) {
-          jobs_second_min_costs[job_rank] = jobs_min_costs[job_rank];
-          jobs_min_costs[job_rank] = evals[job_rank][v_rank].cost;
+    for (const auto j : unassigned) {
+      for (const auto v : vehicles_ranks) {
+        if (evals[j][v].cost <= jobs_min_costs[j]) {
+          jobs_second_min_costs[j] = jobs_min_costs[j];
+          jobs_min_costs[j] = evals[j][v].cost;
         } else {
-          if (evals[job_rank][v_rank].cost < jobs_second_min_costs[job_rank]) {
-            jobs_second_min_costs[job_rank] = evals[job_rank][v_rank].cost;
+          if (evals[j][v].cost < jobs_second_min_costs[j]) {
+            jobs_second_min_costs[j] = evals[j][v].cost;
           }
         }
       }
@@ -483,10 +483,10 @@ Eval dynamic_vehicle_choice(const Input& input,
     // unassigned jobs closest to him than to any other different
     // vehicle still available.
     std::vector<unsigned> closest_jobs_count(input.vehicles.size(), 0);
-    for (const auto job_rank : unassigned) {
-      for (const auto v_rank : vehicles_ranks) {
-        if (evals[job_rank][v_rank].cost == jobs_min_costs[job_rank]) {
-          ++closest_jobs_count[v_rank];
+    for (const auto j : unassigned) {
+      for (const auto v : vehicles_ranks) {
+        if (evals[j][v].cost == jobs_min_costs[j]) {
+          ++closest_jobs_count[v];
         }
       }
     }
@@ -533,11 +533,12 @@ Eval dynamic_vehicle_choice(const Input& input,
     // empty routes evaluations so do not account for initial routes
     // if any.
     std::vector<Cost> regrets(input.jobs.size(), input.get_cost_upper_bound());
-    for (const auto job_rank : unassigned) {
-      if (jobs_min_costs[job_rank] < evals[job_rank][v_rank].cost) {
-        regrets[job_rank] = jobs_min_costs[job_rank];
+
+    for (const auto j : unassigned) {
+      if (jobs_min_costs[j] < evals[j][v_rank].cost) {
+        regrets[j] = jobs_min_costs[j];
       } else {
-        regrets[job_rank] = jobs_second_min_costs[job_rank];
+        regrets[j] = jobs_second_min_costs[j];
       }
     }
 

--- a/src/structures/vroom/eval.h
+++ b/src/structures/vroom/eval.h
@@ -76,9 +76,6 @@ struct Eval {
   }
 };
 
-constexpr Eval MAX_EVAL = {std::numeric_limits<Cost>::max(),
-                           std::numeric_limits<Duration>::max(),
-                           std::numeric_limits<Distance>::max()};
 constexpr Eval NO_EVAL = {std::numeric_limits<Cost>::max(), 0, 0};
 constexpr Eval NO_GAIN = {std::numeric_limits<Cost>::min(), 0, 0};
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -747,7 +747,7 @@ void Input::set_jobs_vehicles_evals() {
   _jobs_vehicles_evals =
     std::vector<std::vector<Eval>>(jobs.size(),
                                    std::vector<Eval>(vehicles.size(),
-                                                     MAX_EVAL));
+                                                     Eval(_cost_upper_bound)));
 
   for (std::size_t j = 0; j < jobs.size(); ++j) {
     Index j_index = jobs[j].index();


### PR DESCRIPTION
## Issue

Fixes #1193 

## Tasks

 - [x] Adjust regrets in `basic` heuristic whenever all values are equal for jobs not doable down the line
 - [x] Determine if `dynamic` heuristic is affected by the same problem
 - [x] Update `dynamic` heuristic if required based on previous point
 - [x] Update `CHANGELOG.md`
 - [x] review
