### PR TITLE
Provide backward-compatible `Input::solve`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -164,7 +164,7 @@ int main(int argc, char** argv) {
     vroom::io::update_port(cl_args.servers, port);
   }
   exploration_level = std::min(exploration_level, vroom::MAX_EXPLORATION_LEVEL);
-  vroom::io::set_exploration_level(cl_args, exploration_level);
+  cl_args.set_exploration_level(exploration_level);
   if (debug_depth) {
     cl_args.depth = debug_depth.value();
   }

--- a/src/structures/cl_args.cpp
+++ b/src/structures/cl_args.cpp
@@ -75,17 +75,17 @@ void update_port(Servers& servers, std::string_view value) {
   }
 }
 
-void set_exploration_level(CLArgs& cl_args, unsigned exploration_level) {
-  cl_args.depth = exploration_level;
+void CLArgs::set_exploration_level(unsigned exploration_level) {
+  depth = exploration_level;
 
   assert(exploration_level <= MAX_EXPLORATION_LEVEL);
 
-  cl_args.nb_searches = 4 * (exploration_level + 1);
+  nb_searches = 4 * (exploration_level + 1);
   if (exploration_level >= 4) {
-    cl_args.nb_searches += 4;
+    nb_searches += 4;
   }
   if (exploration_level == MAX_EXPLORATION_LEVEL) {
-    cl_args.nb_searches += 4;
+    nb_searches += 4;
   }
 }
 

--- a/src/structures/cl_args.cpp
+++ b/src/structures/cl_args.cpp
@@ -75,18 +75,28 @@ void update_port(Servers& servers, std::string_view value) {
   }
 }
 
-void CLArgs::set_exploration_level(unsigned exploration_level) {
-  depth = exploration_level;
+unsigned CLArgs::get_depth(unsigned exploration_level) {
+  return exploration_level;
+}
 
+unsigned CLArgs::get_nb_searches(unsigned exploration_level) {
   assert(exploration_level <= MAX_EXPLORATION_LEVEL);
 
-  nb_searches = 4 * (exploration_level + 1);
+  unsigned nb_searches = 4 * (exploration_level + 1);
   if (exploration_level >= 4) {
     nb_searches += 4;
   }
   if (exploration_level == MAX_EXPLORATION_LEVEL) {
     nb_searches += 4;
   }
+
+  return nb_searches;
+}
+
+void CLArgs::set_exploration_level(unsigned exploration_level) {
+  depth = get_depth(exploration_level);
+
+  nb_searches = get_nb_searches(exploration_level);
 }
 
 } // namespace vroom::io

--- a/src/structures/cl_args.cpp
+++ b/src/structures/cl_args.cpp
@@ -10,6 +10,7 @@ All rights reserved (see LICENSE).
 #include <cassert>
 
 #include "structures/cl_args.h"
+#include "utils/helpers.h"
 
 namespace vroom::io {
 
@@ -75,28 +76,10 @@ void update_port(Servers& servers, std::string_view value) {
   }
 }
 
-unsigned CLArgs::get_depth(unsigned exploration_level) {
-  return exploration_level;
-}
-
-unsigned CLArgs::get_nb_searches(unsigned exploration_level) {
-  assert(exploration_level <= MAX_EXPLORATION_LEVEL);
-
-  unsigned nb_searches = 4 * (exploration_level + 1);
-  if (exploration_level >= 4) {
-    nb_searches += 4;
-  }
-  if (exploration_level == MAX_EXPLORATION_LEVEL) {
-    nb_searches += 4;
-  }
-
-  return nb_searches;
-}
-
 void CLArgs::set_exploration_level(unsigned exploration_level) {
-  depth = get_depth(exploration_level);
+  depth = utils::get_depth(exploration_level);
 
-  nb_searches = get_nb_searches(exploration_level);
+  nb_searches = utils::get_nb_searches(exploration_level);
 }
 
 } // namespace vroom::io

--- a/src/structures/cl_args.h
+++ b/src/structures/cl_args.h
@@ -36,13 +36,13 @@ struct CLArgs {
   unsigned nb_threads;                       // -t
   unsigned nb_searches;                      // derived from -x
   unsigned depth;                            // derived from -x
+
+  void set_exploration_level(unsigned exploration_level);
 };
 
 void update_host(Servers& servers, std::string_view value);
 
 void update_port(Servers& servers, std::string_view value);
-
-void set_exploration_level(CLArgs& cl_args, unsigned exploration_level);
 
 } // namespace vroom::io
 

--- a/src/structures/cl_args.h
+++ b/src/structures/cl_args.h
@@ -37,10 +37,6 @@ struct CLArgs {
   unsigned nb_searches;                      // derived from -x
   unsigned depth;                            // derived from -x
 
-  static unsigned get_depth(unsigned exploration_level);
-
-  static unsigned get_nb_searches(unsigned exploration_level);
-
   void set_exploration_level(unsigned exploration_level);
 };
 

--- a/src/structures/cl_args.h
+++ b/src/structures/cl_args.h
@@ -37,6 +37,10 @@ struct CLArgs {
   unsigned nb_searches;                      // derived from -x
   unsigned depth;                            // derived from -x
 
+  static unsigned get_depth(unsigned exploration_level);
+
+  static unsigned get_nb_searches(unsigned exploration_level);
+
   void set_exploration_level(unsigned exploration_level);
 };
 

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -1118,6 +1118,17 @@ std::unique_ptr<VRP> Input::get_problem() const {
   return std::make_unique<CVRP>(*this);
 }
 
+Solution Input::solve(unsigned exploration_level,
+                      unsigned nb_thread,
+                      const Timeout& timeout,
+                      const std::vector<HeuristicParameters>& h_param) {
+  return solve(utils::get_nb_searches(exploration_level),
+               utils::get_depth(exploration_level),
+               nb_thread,
+               timeout,
+               h_param);
+}
+
 Solution Input::solve(unsigned nb_searches,
                       unsigned depth,
                       unsigned nb_thread,

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -16,6 +16,7 @@ All rights reserved (see LICENSE).
 #include <unordered_map>
 
 #include "routing/wrapper.h"
+#include "structures/cl_args.h"
 #include "structures/generic/matrix.h"
 #include "structures/typedefs.h"
 #include "structures/vroom/matrices.h"
@@ -192,6 +193,21 @@ public:
 
   // Returns true iff both vehicles have common job candidates.
   bool vehicle_ok_with_vehicle(Index v1_index, Index v2_index) const;
+
+  Solution solve(unsigned exploration_level,
+                 unsigned nb_thread,
+                 const Timeout& timeout = Timeout(),
+                 const std::vector<HeuristicParameters>& h_param =
+                   std::vector<HeuristicParameters>()) {
+    // Overload designed to expose the same interface as the `-x`
+    // command-line flag for out-of-the-box setup of exploration
+    // level.
+    return solve(io::CLArgs::get_nb_searches(exploration_level),
+                 io::CLArgs::get_depth(exploration_level),
+                 nb_thread,
+                 timeout,
+                 h_param);
+  }
 
   Solution solve(unsigned nb_searches,
                  unsigned depth,

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -16,7 +16,6 @@ All rights reserved (see LICENSE).
 #include <unordered_map>
 
 #include "routing/wrapper.h"
-#include "structures/cl_args.h"
 #include "structures/generic/matrix.h"
 #include "structures/typedefs.h"
 #include "structures/vroom/matrices.h"
@@ -194,23 +193,16 @@ public:
   // Returns true iff both vehicles have common job candidates.
   bool vehicle_ok_with_vehicle(Index v1_index, Index v2_index) const;
 
-  Solution solve(unsigned exploration_level,
+  Solution solve(unsigned nb_searches,
+                 unsigned depth,
                  unsigned nb_thread,
                  const Timeout& timeout = Timeout(),
                  const std::vector<HeuristicParameters>& h_param =
-                   std::vector<HeuristicParameters>()) {
-    // Overload designed to expose the same interface as the `-x`
-    // command-line flag for out-of-the-box setup of exploration
-    // level.
-    return solve(io::CLArgs::get_nb_searches(exploration_level),
-                 io::CLArgs::get_depth(exploration_level),
-                 nb_thread,
-                 timeout,
-                 h_param);
-  }
+                   std::vector<HeuristicParameters>());
 
-  Solution solve(unsigned nb_searches,
-                 unsigned depth,
+  // Overload designed to expose the same interface as the `-x`
+  // command-line flag for out-of-the-box setup of exploration level.
+  Solution solve(unsigned exploration_level,
                  unsigned nb_thread,
                  const Timeout& timeout = Timeout(),
                  const std::vector<HeuristicParameters>& h_param =

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -38,6 +38,24 @@ inline UserCost add_without_overflow(UserCost a, UserCost b) {
   return a + b;
 }
 
+inline unsigned get_depth(unsigned exploration_level) {
+  return exploration_level;
+}
+
+inline unsigned get_nb_searches(unsigned exploration_level) {
+  assert(exploration_level <= MAX_EXPLORATION_LEVEL);
+
+  unsigned nb_searches = 4 * (exploration_level + 1);
+  if (exploration_level >= 4) {
+    nb_searches += 4;
+  }
+  if (exploration_level == MAX_EXPLORATION_LEVEL) {
+    nb_searches += 4;
+  }
+
+  return nb_searches;
+}
+
 INIT get_init(std::string_view s);
 
 SORT get_sort(std::string_view s);


### PR DESCRIPTION
## Issue

The signature for `Input::solve` changed to introduce debug options, but this unnecessarily exposes internal variable choices. We should restore the old signature for out-of-the-box exploration level for both C++ and downstream pyvroom compatibility, see https://github.com/VROOM-Project/pyvroom/pull/121#discussion_r1865424722.

## Tasks

 - [x] Add `Input::solve` overload taking exploration level as parameter
 - [x] Expose definition of depth and number of searches as helper functions for consistency
 - [x] Refactor command-line parameters handling
 - [x] review
