### PR TITLE
Avoid solution "shadowing" when comparing indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Crash when input is valid JSON but not an object (#1172)
 - Capacity array check consistency (#1086)
 - Segfault when using the C++ API with empty vehicles (#1187)
+- Solution "shadowing" when only comparing indicators (#1199)
 
 #### Internals
 

--- a/src/structures/vroom/solution_indicators.h
+++ b/src/structures/vroom/solution_indicators.h
@@ -10,6 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <algorithm>
 #include <tuple>
 
 #include "structures/typedefs.h"
@@ -23,6 +24,8 @@ struct SolutionIndicators {
   unsigned assigned{0};
   Eval eval;
   unsigned used_vehicles{0};
+  // Hash based on the ordered sizes of routes in the solution.
+  uint32_t routes_hash;
 
   SolutionIndicators() = default;
 
@@ -41,6 +44,14 @@ struct SolutionIndicators {
         used_vehicles += 1;
       }
     }
+
+    std::vector<uint32_t> routes_sizes;
+    routes_sizes.reserve(sol.size());
+    std::ranges::transform(sol,
+                           std::back_inserter(routes_sizes),
+                           [](const auto& r) { return r.size(); });
+    std::ranges::sort(routes_sizes);
+    routes_hash = get_vector_hash(routes_sizes);
   }
 
   friend bool operator<(const SolutionIndicators& lhs,

--- a/src/structures/vroom/solution_indicators.h
+++ b/src/structures/vroom/solution_indicators.h
@@ -61,28 +61,32 @@ struct SolutionIndicators {
                     lhs.eval.cost,
                     lhs.used_vehicles,
                     lhs.eval.duration,
-                    lhs.eval.distance) < std::tie(lhs.priority_sum,
-                                                  lhs.assigned,
-                                                  rhs.eval.cost,
-                                                  rhs.used_vehicles,
-                                                  rhs.eval.duration,
-                                                  rhs.eval.distance);
+                    lhs.eval.distance,
+                    lhs.routes_hash) < std::tie(lhs.priority_sum,
+                                                lhs.assigned,
+                                                rhs.eval.cost,
+                                                rhs.used_vehicles,
+                                                rhs.eval.duration,
+                                                rhs.eval.distance,
+                                                rhs.routes_hash);
   }
 
 #ifdef LOG_LS
   friend bool operator==(const SolutionIndicators& lhs,
                          const SolutionIndicators& rhs) {
-    return std::tie(rhs.priority_sum,
-                    rhs.assigned,
+    return std::tie(lhs.priority_sum,
+                    lhs.assigned,
                     lhs.eval.cost,
                     lhs.used_vehicles,
                     lhs.eval.duration,
-                    lhs.eval.distance) == std::tie(lhs.priority_sum,
-                                                   lhs.assigned,
-                                                   rhs.eval.cost,
-                                                   rhs.used_vehicles,
-                                                   rhs.eval.duration,
-                                                   rhs.eval.distance);
+                    lhs.eval.distance,
+                    lhs.routes_hash) == std::tie(rhs.priority_sum,
+                                                 rhs.assigned,
+                                                 rhs.eval.cost,
+                                                 rhs.used_vehicles,
+                                                 rhs.eval.duration,
+                                                 rhs.eval.distance,
+                                                 rhs.routes_hash);
   }
 #endif
 };

--- a/src/structures/vroom/solution_indicators.h
+++ b/src/structures/vroom/solution_indicators.h
@@ -49,7 +49,7 @@ struct SolutionIndicators {
     routes_sizes.reserve(sol.size());
     std::ranges::transform(sol,
                            std::back_inserter(routes_sizes),
-                           [](const auto& r) { return r.size(); });
+                           [](const auto& r) { return std::size(r); });
     std::ranges::sort(routes_sizes);
     routes_hash = get_vector_hash(routes_sizes);
   }

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -38,6 +38,18 @@ inline UserCost add_without_overflow(UserCost a, UserCost b) {
   return a + b;
 }
 
+// Taken from https://stackoverflow.com/a/72073933.
+inline uint32_t get_vector_hash(const std::vector<uint32_t>& vec) {
+  uint32_t seed = vec.size();
+  for (auto x : vec) {
+    x = ((x >> 16) ^ x) * 0x45d9f3b;
+    x = ((x >> 16) ^ x) * 0x45d9f3b;
+    x = (x >> 16) ^ x;
+    seed ^= x + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  }
+  return seed;
+}
+
 inline unsigned get_depth(unsigned exploration_level) {
   return exploration_level;
 }


### PR DESCRIPTION
## Issue

Fixes #1199 

## Tasks

 - [x] Add hash function for a vector
 - [x] Store hashed value for ordered route sizes
 - [x] Adjust `SolutionIndicators` operators
 - [x] Update `CHANGELOG.md`
 - [ ] review
