### PR TITLE
Fix `PriorityReplace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 #### Core solving
 
 - Solution quality regression when using lots of skills (#1193)
+- Invalid route reached by `PriorityReplace` (#1162)
 - Crash due to wrong delivery values in some validity checks (#1164)
 - Crash when input is valid JSON but not an object (#1172)
 - Capacity array check consistency (#1086)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 - Solution quality regression when using lots of skills (#1193)
 - Invalid route reached by `PriorityReplace` (#1162)
+- Account for gain and assigned tasks to pick priority-improving moves (#1212)
 - Crash due to wrong delivery values in some validity checks (#1164)
 - Crash when input is valid JSON but not an object (#1172)
 - Capacity array check consistency (#1086)

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -439,7 +439,8 @@ void LocalSearch<Route,
             continue;
           }
 
-          // Find where to stop when replacing beginning of route.
+          // Find where to stop when replacing beginning of route in
+          // order to generate a net priority gain.
           const auto fwd_over =
             std::ranges::find_if(_sol_state.fwd_priority[source],
                                  [u_priority](const auto p) {
@@ -449,8 +450,13 @@ void LocalSearch<Route,
             std::distance(_sol_state.fwd_priority[source].begin(), fwd_over);
           // A fwd_last_rank of zero will discard replacing the start
           // of the route.
-          const Index fwd_last_rank =
-            (fwd_over_rank > 0) ? fwd_over_rank - 1 : 0;
+          Index fwd_last_rank = (fwd_over_rank > 0) ? fwd_over_rank - 1 : 0;
+          // Go back to find the biggest route beginning portion where
+          // splitting is possible.
+          while (fwd_last_rank > 0 &&
+                 _sol[source].has_pending_delivery_after_rank(fwd_last_rank)) {
+            --fwd_last_rank;
+          }
           const Priority begin_priority_gain =
             u_priority - _sol_state.fwd_priority[source][fwd_last_rank];
 

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -415,6 +415,7 @@ void LocalSearch<Route,
   // Dummy init to enter first loop.
   Eval best_gain(static_cast<Cost>(1));
   Priority best_priority = 0;
+  auto best_removal = std::numeric_limits<unsigned>::max();
 
   while (best_gain.cost > 0 || best_priority > 0) {
     if (_deadline.has_value() && _deadline.value() < utils::now()) {
@@ -1838,7 +1839,7 @@ void LocalSearch<Route,
     // Find best overall move, first checking priority increase then
     // best gain if no priority increase is available.
     best_priority = 0;
-    auto best_removal = std::numeric_limits<unsigned>::max();
+    best_removal = std::numeric_limits<unsigned>::max();
     best_gain = Eval();
     Index best_source = 0;
     Index best_target = 0;
@@ -1949,6 +1950,7 @@ void LocalSearch<Route,
       for (auto v_rank : update_candidates) {
         best_gains[v_rank].assign(_nb_vehicles, Eval());
         best_priorities[v_rank] = 0;
+        best_removals[v_rank] = std::numeric_limits<unsigned>::max();
         best_ops[v_rank] = std::vector<std::unique_ptr<Operator>>(_nb_vehicles);
       }
 
@@ -1991,6 +1993,7 @@ void LocalSearch<Route,
         if (invalidate_move) {
           best_gains[v][v] = Eval();
           best_priorities[v] = 0;
+          best_removals[v] = std::numeric_limits<unsigned>::max();
           best_ops[v][v] = std::unique_ptr<Operator>();
           s_t_pairs.emplace_back(v, v);
         }

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -444,7 +444,7 @@ void LocalSearch<Route,
           const auto fwd_over =
             std::ranges::find_if(_sol_state.fwd_priority[source],
                                  [u_priority](const auto p) {
-                                   return u_priority < p;
+                                   return u_priority <= p;
                                  });
           const Index fwd_over_rank =
             std::distance(_sol_state.fwd_priority[source].begin(), fwd_over);
@@ -465,7 +465,7 @@ void LocalSearch<Route,
           const auto bwd_over =
             std::find_if(_sol_state.bwd_priority[source].crbegin(),
                          _sol_state.bwd_priority[source].crend(),
-                         [u_priority](const auto p) { return u_priority < p; });
+                         [u_priority](const auto p) { return u_priority <= p; });
           const Index bwd_over_rank =
             std::distance(_sol_state.bwd_priority[source].crbegin(), bwd_over);
           Index bwd_first_rank = _sol[source].size() - bwd_over_rank;

--- a/src/problems/cvrp/operators/priority_replace.cpp
+++ b/src/problems/cvrp/operators/priority_replace.cpp
@@ -139,6 +139,7 @@ bool PriorityReplace::is_valid() {
   replace_start_valid =
     (0 < _start_priority_gain) &&
     (_best_known_priority_gain <= _start_priority_gain) && (s_rank > 0) &&
+    (!source.has_pending_delivery_after_rank(s_rank)) &&
     source.is_valid_addition_for_capacity_margins(_input,
                                                   j.pickup,
                                                   j.delivery,
@@ -151,6 +152,7 @@ bool PriorityReplace::is_valid() {
     (0 < _end_priority_gain) &&
     (_best_known_priority_gain <= _end_priority_gain) &&
     (t_rank < s_route.size() - 1) &&
+    (t_rank == 0 || !source.has_pending_delivery_after_rank(t_rank - 1)) &&
     source.is_valid_addition_for_capacity_margins(_input,
                                                   j.pickup,
                                                   j.delivery,

--- a/src/problems/cvrp/operators/priority_replace.cpp
+++ b/src/problems/cvrp/operators/priority_replace.cpp
@@ -41,6 +41,7 @@ PriorityReplace::PriorityReplace(const Input& input,
     _best_known_priority_gain(best_known_priority_gain),
     _unassigned(unassigned) {
   assert(!s_route.empty());
+  assert(t_rank != 0);
   assert(_start_priority_gain > 0 or _end_priority_gain > 0);
 }
 

--- a/src/problems/cvrp/operators/priority_replace.cpp
+++ b/src/problems/cvrp/operators/priority_replace.cpp
@@ -156,12 +156,13 @@ bool PriorityReplace::is_valid() {
     (0 < _end_priority_gain) &&
     (_best_known_priority_gain <= _end_priority_gain) &&
     (t_rank < s_route.size() - 1) &&
-    (t_rank == 0 || !source.has_pending_delivery_after_rank(t_rank - 1)) &&
     source.is_valid_addition_for_capacity_margins(_input,
                                                   j.pickup,
                                                   j.delivery,
                                                   t_rank,
                                                   s_route.size());
+  assert(!replace_end_valid ||
+         !source.has_pending_delivery_after_rank(t_rank - 1));
 
   // Check validity with regard to vehicle range bounds, requires
   // valid gain values for both options.

--- a/src/problems/cvrp/operators/priority_replace.cpp
+++ b/src/problems/cvrp/operators/priority_replace.cpp
@@ -35,6 +35,8 @@ PriorityReplace::PriorityReplace(const Input& input,
                          _sol_state.fwd_priority[s_vehicle][s_rank]),
     _end_priority_gain(_input.jobs[u].priority -
                        _sol_state.bwd_priority[s_vehicle][t_rank]),
+    _start_assigned_number(s_route.size() - s_rank),
+    _end_assigned_number(t_rank + 1),
     _u(u),
     _best_known_priority_gain(best_known_priority_gain),
     _unassigned(unassigned) {
@@ -111,8 +113,8 @@ void PriorityReplace::compute_gain() {
 
   if (replace_start_valid && replace_end_valid) {
     // Decide based on priority and cost.
-    if (std::tie(_end_priority_gain, t_gain) <
-        std::tie(_start_priority_gain, s_gain)) {
+    if (std::tie(_end_priority_gain, _end_assigned_number, t_gain) <
+        std::tie(_start_priority_gain, _start_assigned_number, s_gain)) {
       replace_end_valid = false;
     } else {
       replace_start_valid = false;

--- a/src/problems/cvrp/operators/priority_replace.cpp
+++ b/src/problems/cvrp/operators/priority_replace.cpp
@@ -139,12 +139,13 @@ bool PriorityReplace::is_valid() {
   replace_start_valid =
     (0 < _start_priority_gain) &&
     (_best_known_priority_gain <= _start_priority_gain) && (s_rank > 0) &&
-    (!source.has_pending_delivery_after_rank(s_rank)) &&
     source.is_valid_addition_for_capacity_margins(_input,
                                                   j.pickup,
                                                   j.delivery,
                                                   0,
                                                   s_rank + 1);
+  assert(!replace_start_valid ||
+         !source.has_pending_delivery_after_rank(s_rank));
 
   // Don't bother if the candidate end portion is empty or with a
   // single job (that would be an UnassignedExchange move).

--- a/src/problems/cvrp/operators/priority_replace.cpp
+++ b/src/problems/cvrp/operators/priority_replace.cpp
@@ -223,6 +223,13 @@ Priority PriorityReplace::priority_gain() {
   return replace_start_valid ? _start_priority_gain : _end_priority_gain;
 }
 
+unsigned PriorityReplace::assigned() const {
+  assert(gain_computed);
+  assert(replace_start_valid xor replace_end_valid);
+
+  return replace_start_valid ? _start_assigned_number : _end_assigned_number;
+}
+
 std::vector<Index> PriorityReplace::addition_candidates() const {
   return {s_vehicle};
 }

--- a/src/problems/cvrp/operators/priority_replace.h
+++ b/src/problems/cvrp/operators/priority_replace.h
@@ -20,6 +20,8 @@ private:
   bool _end_gain_computed{false};
   const Priority _start_priority_gain;
   const Priority _end_priority_gain;
+  const unsigned _start_assigned_number;
+  const unsigned _end_assigned_number;
 
 protected:
   const Index _u; // Unassigned job to insert.

--- a/src/problems/cvrp/operators/priority_replace.h
+++ b/src/problems/cvrp/operators/priority_replace.h
@@ -57,6 +57,8 @@ public:
 
   Priority priority_gain();
 
+  unsigned assigned() const;
+
   std::vector<Index> addition_candidates() const override;
 
   std::vector<Index> update_candidates() const override;


### PR DESCRIPTION
## Issue

Fixes #1162 

## Tasks

 - [x] Add checks for pending deliveries for `PriorityReplace`
 - [x] If start route replacement split has a pending delivery problem, try finding a smaller start route without splitting problem
 - [x] If end route replacement split has a pending delivery problem, try finding a smaller end route without splitting problem
 - [x] Account for number of tasks after applying to discriminate between start or end replacement if both are valid
 - [x] Update `CHANGELOG.md`
 - [x] review
