### PR TITLE
Use cost bound in heuristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 #### Internals
 
 - Bypass matrix request in `plan` mode (#444)
+- Heuristics speed-up (#1219)
 - Account for heuristic time in timeout (#1196)
 - Refactor heuristics to reduce code duplication (#1181)
 - Refactor `Matrix` template class (#1089)

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -213,6 +213,16 @@ inline Eval fill_route(const Input& input,
         continue;
       }
 
+      // Bypass going through whole route if we're sure insertion cost
+      // is not good enough.
+      const double lower_cost_bound =
+        static_cast<double>(min_route_to_unassigned[job_rank] +
+                            min_unassigned_to_route[job_rank] - max_edge_cost) -
+        lambda * static_cast<double>(regrets[job_rank]);
+      if (best_cost < lower_cost_bound) {
+        continue;
+      }
+
       if (current_job.type == JOB_TYPE::SINGLE &&
           route.size() + 1 <= vehicle.max_tasks) {
         for (Index r = 0; r <= route.size(); ++r) {

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -143,7 +143,9 @@ template <class Route> struct UnassignedCosts {
   std::vector<Cost> min_route_to_unassigned;
   std::vector<Cost> min_unassigned_to_route;
 
-  UnassignedCosts(const Input& input, Route& route, std::set<Index>& unassigned)
+  UnassignedCosts(const Input& input,
+                  Route& route,
+                  const std::set<Index>& unassigned)
     : vehicle(input.vehicles[route.vehicle_rank]),
       max_edge_cost(utils::max_edge_eval(input, vehicle, route.route).cost),
       min_route_to_unassigned(input.jobs.size(),
@@ -212,7 +214,7 @@ template <class Route> struct UnassignedCosts {
   }
 
   void update_min_costs(const Input& input,
-                        std::set<Index>& unassigned,
+                        const std::set<Index>& unassigned,
                         Index inserted_index) {
     for (const auto j : unassigned) {
       const auto unassigned_job_index = input.jobs[j].index();

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -451,6 +451,13 @@ inline Eval fill_route(const Input& input,
         unassigned.erase(best_job_rank);
         unassigned.erase(best_job_rank + 1);
         keep_going = true;
+
+        unassigned_costs.update_max_edge(input, route);
+        unassigned_costs.update_min_costs(input, unassigned, best_job.index());
+        unassigned_costs
+          .update_min_costs(input,
+                            unassigned,
+                            input.jobs[best_job_rank + 1].index());
       }
 
       route_eval += best_eval;

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -153,8 +153,6 @@ template <class Route> struct UnassignedCosts {
       min_unassigned_to_route(input.jobs.size(),
                               std::numeric_limits<Cost>::max()) {
     for (const auto job_rank : unassigned) {
-      // TODO if unassigned job is a pickup, consider cost to pickup
-      // then cost from delivery.
       const auto unassigned_job_index = input.jobs[job_rank].index();
 
       if (vehicle.has_start()) {

--- a/src/algorithms/heuristics/heuristics.cpp
+++ b/src/algorithms/heuristics/heuristics.cpp
@@ -302,6 +302,15 @@ inline Eval fill_route(const Input& input,
 
       if (current_job.type == JOB_TYPE::PICKUP &&
           route.size() + 2 <= vehicle.max_tasks) {
+
+        if (best_cost <
+            unassigned_costs.get_pd_insertion_lower_bound(input, job_rank) -
+              lambda * static_cast<double>(regrets[job_rank])) {
+          // Bypass going through whole route if we're sure insertion
+          // cost is not good enough.
+          continue;
+        }
+
         // Pre-compute cost of addition for matching delivery.
         std::vector<Eval> d_adds(route.route.size() + 1);
         std::vector<unsigned char> valid_delivery_insertions(

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -181,6 +181,34 @@ inline Eval addition_cost(const Input& input,
   return eval;
 }
 
+inline Eval max_edge_eval(const Input& input,
+                          const Vehicle& v,
+                          const std::vector<Index>& route) {
+  Eval max_eval;
+
+  if (!route.empty()) {
+    if (v.has_start()) {
+      const auto start_to_first =
+        v.eval(v.start.value().index(), input.jobs[route.front()].index());
+      max_eval = std::max(max_eval, start_to_first);
+    }
+
+    for (std::size_t i = 0; i < route.size() - 1; ++i) {
+      const auto job_to_next =
+        v.eval(input.jobs[route[i]].index(), input.jobs[route[i + 1]].index());
+      max_eval = std::max(max_eval, job_to_next);
+    }
+
+    if (v.has_end()) {
+      const auto last_to_end =
+        v.eval(input.jobs[route.back()].index(), v.end.value().index());
+      max_eval = std::max(max_eval, last_to_end);
+    }
+  }
+
+  return max_eval;
+}
+
 // Helper function for SwapStar operator, computing part of the eval
 // for in-place replacing of job at rank in route with job at
 // job_rank.


### PR DESCRIPTION
## Issue

Fixes #1219

## Tasks

 - [x] Store and update relevant data to compute the bound
 - [x] Avoid going through whole route for rank-based insertion tests based on bound
 - [x] Same but for pickup and delivery
 - [ ] ~~Try ordering unassigned jobs to increase bound efficiency~~
 - [x] Update `CHANGELOG.md`
 - [x] review
