### PR TITLE
Add task times in costs

### DIFF
--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -74,6 +74,7 @@ constexpr Cost COST_FACTOR = 3600;
 // outputting exact same values for duration and cost if per_hour
 // values are not set.
 constexpr UserCost DEFAULT_COST_PER_HOUR = 3600;
+constexpr UserCost DEFAULT_COST_PER_TASK_HOUR = 0;
 constexpr UserCost DEFAULT_COST_PER_KM = 0;
 
 constexpr Priority MAX_PRIORITY = 100;

--- a/src/structures/vroom/vehicle.h
+++ b/src/structures/vroom/vehicle.h
@@ -29,20 +29,23 @@ struct VehicleCosts {
   const Cost fixed;
   const Cost per_hour;
   const Cost per_km;
+  const Cost per_task_hour;
 
   VehicleCosts(UserCost fixed = 0,
                UserCost per_hour = DEFAULT_COST_PER_HOUR,
-               UserCost per_km = DEFAULT_COST_PER_KM)
+               UserCost per_km = DEFAULT_COST_PER_KM,
+               UserCost per_task_hour = DEFAULT_COST_PER_TASK_HOUR)
     : fixed(utils::scale_from_user_cost(fixed)),
       per_hour(static_cast<Cost>(per_hour)),
-      per_km(static_cast<Cost>(per_km)){};
+      per_km(static_cast<Cost>(per_km)),
+      per_task_hour(static_cast<Cost>(per_task_hour)){};
 
   friend bool operator==(const VehicleCosts& lhs,
                          const VehicleCosts& rhs) = default;
 
   friend bool operator<(const VehicleCosts& lhs, const VehicleCosts& rhs) {
-    return std::tie(lhs.fixed, lhs.per_hour, lhs.per_km) <
-           std::tie(rhs.fixed, rhs.per_hour, rhs.per_km);
+    return std::tie(lhs.fixed, lhs.per_hour, lhs.per_km, lhs.per_task_hour) <
+           std::tie(rhs.fixed, rhs.per_hour, rhs.per_km, rhs.per_task_hour);
   }
 };
 

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -269,6 +269,7 @@ inline VehicleCosts get_vehicle_costs(const rapidjson::Value& v) {
   UserCost fixed = 0;
   UserCost per_hour = DEFAULT_COST_PER_HOUR;
   UserCost per_km = DEFAULT_COST_PER_KM;
+  UserCost per_task_hour = DEFAULT_COST_PER_TASK_HOUR;
 
   if (v.HasMember("costs")) {
     if (!v["costs"].IsObject()) {
@@ -303,9 +304,19 @@ inline VehicleCosts get_vehicle_costs(const rapidjson::Value& v) {
 
       per_km = v["costs"]["per_km"].GetUint();
     }
+
+    if (v["costs"].HasMember("per_task_hour")) {
+      if (!v["costs"]["per_task_hour"].IsUint()) {
+        throw InputException(
+          std::format("Invalid per_task_hour cost for vehicle {}.",
+                      v["id"].GetUint64()));
+      }
+
+      per_task_hour = v["costs"]["per_task_hour"].GetUint();
+    }
   }
 
-  return VehicleCosts(fixed, per_hour, per_km);
+  return VehicleCosts(fixed, per_hour, per_km, per_task_hour);
 }
 
 inline std::vector<VehicleStep> get_vehicle_steps(const rapidjson::Value& v) {


### PR DESCRIPTION
## Issue

Fixes #1130 

## Tasks

- [ ] Add new cost factor in `VehicleCosts`
 - [ ] Parse new cost factor at vehicle level in json input
 - [ ] Add task cost in output
 - [ ] Extend `eval` struct to include a task cost component
 - [ ] Store necessary forward/backward task costs in `SolutionState`
 - [ ] Adjust `cross_exchange` operator to manage task cost gain
 - [ ] Adjust `mixed_exchange` operator to manage task cost gain
 - [ ] Adjust `or_opt` operator to manage task cost gain
 - [ ] Adjust `pd_shift` operator to manage task cost gain
 - [ ] Adjust `priority_replace` operator to manage task cost gain
 - [ ] Adjust `relocate` operator to manage task cost gain
 - [ ] Adjust `reverse_two_opt` operator to manage task cost gain
 - [ ] Adjust `route_exchange` operator to manage task cost gain
 - [ ] Adjust `route_split` operator to manage task cost gain
 - [ ] Adjust `swap_star` operator to manage task cost gain
 - [ ] Adjust `tsp_fix` operator to manage task cost gain
 - [ ] Adjust `two_opt` operator to manage task cost gain
 - [ ] Adjust `unassigned_exchange` operator to manage task cost gain
 - [ ] Adjust cost evaluation in heuristics
 - [ ] Update `docs/API.md`
 - [ ] Update `CHANGELOG.md`
 - [ ] review
