### PR TITLE
Refactor/avoid allocating moved jobs ranges too early

### DIFF
--- a/src/problems/cvrp/operators/intra_cross_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_cross_exchange.cpp
@@ -32,7 +32,6 @@ IntraCrossExchange::IntraCrossExchange(const Input& input,
     // check_t_reverse are false.
     check_s_reverse(check_s_reverse),
     check_t_reverse(check_t_reverse),
-    _moved_jobs(t_rank - s_rank + 2),
     _first_rank(s_rank),
     _last_rank(t_rank + 2),
     _delivery(source.delivery_in_range(_first_rank, _last_rank)) {
@@ -56,6 +55,11 @@ IntraCrossExchange::IntraCrossExchange(const Input& input,
           _input.jobs[this->t_route[t_rank + 1]].type == JOB_TYPE::DELIVERY &&
           !check_t_reverse &&
           _sol_state.matching_delivery_rank[t_vehicle][t_rank] == t_rank + 1));
+}
+
+void IntraCrossExchange::prepare_moved_jobs() {
+  _moved_jobs.clear();
+  _moved_jobs.resize(t_rank - s_rank + 2);
 
   _moved_jobs[0] = s_route[t_rank];
   _moved_jobs[1] = s_route[t_rank + 1];
@@ -206,6 +210,7 @@ void IntraCrossExchange::compute_gain() {
 }
 
 bool IntraCrossExchange::is_valid() {
+  prepare_moved_jobs();
   assert(_gain_upper_bound_computed);
 
   const auto& s_v = _input.vehicles[s_vehicle];

--- a/src/problems/cvrp/operators/intra_cross_exchange.h
+++ b/src/problems/cvrp/operators/intra_cross_exchange.h
@@ -34,6 +34,8 @@ protected:
   bool s_reverse_t_normal_is_valid{false};
 
   std::vector<Index> _moved_jobs;
+  void prepare_moved_jobs();
+
   const Index _first_rank;
   const Index _last_rank;
   const Amount _delivery;

--- a/src/problems/cvrp/operators/intra_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_exchange.cpp
@@ -26,7 +26,6 @@ IntraExchange::IntraExchange(const Input& input,
              s_raw_route,
              s_vehicle,
              t_rank),
-    _moved_jobs(t_rank - s_rank + 1),
     _first_rank(s_rank),
     _last_rank(t_rank + 1),
     _delivery(source.delivery_in_range(_first_rank, _last_rank)) {
@@ -36,7 +35,13 @@ IntraExchange::IntraExchange(const Input& input,
   assert(s_rank < t_rank - 1);
   assert(s_route.size() >= 3);
   assert(t_rank < s_route.size());
-
+  // Note: _moved_jobs is not allocated or populated here. It is only
+  // allocated and populated in prepare_moved_jobs(), which is called
+  // only in is_valid() to avoid unnecessary allocations.
+}
+void IntraExchange::prepare_moved_jobs() {
+  _moved_jobs.clear();
+  _moved_jobs.resize(_last_rank - _first_rank);
   std::copy(s_route.begin() + _first_rank,
             s_route.begin() + _last_rank,
             _moved_jobs.begin());
@@ -99,6 +104,7 @@ void IntraExchange::compute_gain() {
 }
 
 bool IntraExchange::is_valid() {
+  prepare_moved_jobs();
   return is_valid_for_range_bounds() &&
          source.is_valid_addition_for_capacity_inclusion(_input,
                                                          _delivery,

--- a/src/problems/cvrp/operators/intra_exchange.h
+++ b/src/problems/cvrp/operators/intra_exchange.h
@@ -21,6 +21,7 @@ protected:
   const Index _last_rank;
   const Amount _delivery;
 
+  void prepare_moved_jobs();
   void compute_gain() override;
 
 public:

--- a/src/problems/cvrp/operators/intra_mixed_exchange.cpp
+++ b/src/problems/cvrp/operators/intra_mixed_exchange.cpp
@@ -30,7 +30,6 @@ IntraMixedExchange::IntraMixedExchange(const Input& input,
     // Required for consistency in compute_gain if check_t_reverse is
     // false.
     check_t_reverse(check_t_reverse),
-    _moved_jobs((s_rank < t_rank) ? t_rank - s_rank + 2 : s_rank - t_rank + 1),
     _first_rank(std::min(s_rank, t_rank)),
     _last_rank((t_rank < s_rank) ? s_rank + 1 : t_rank + 2),
     _delivery(source.delivery_in_range(_first_rank, _last_rank)) {
@@ -49,6 +48,12 @@ IntraMixedExchange::IntraMixedExchange(const Input& input,
           _input.jobs[this->t_route[t_rank + 1]].type == JOB_TYPE::DELIVERY &&
           !check_t_reverse &&
           _sol_state.matching_delivery_rank[t_vehicle][t_rank] == t_rank + 1));
+}
+
+void IntraMixedExchange::prepare_moved_jobs() {
+  _moved_jobs.clear();
+  _moved_jobs.resize((s_rank < t_rank) ? t_rank - s_rank + 2
+                                       : s_rank - t_rank + 1);
 
   Index s_node;
   if (t_rank < s_rank) {
@@ -193,6 +198,7 @@ void IntraMixedExchange::compute_gain() {
 }
 
 bool IntraMixedExchange::is_valid() {
+  prepare_moved_jobs();
   assert(_gain_upper_bound_computed);
 
   const auto& s_v = _input.vehicles[s_vehicle];

--- a/src/problems/cvrp/operators/intra_mixed_exchange.h
+++ b/src/problems/cvrp/operators/intra_mixed_exchange.h
@@ -28,6 +28,8 @@ protected:
   bool s_is_reverse_valid{false};
 
   std::vector<Index> _moved_jobs;
+  void prepare_moved_jobs();
+
   const Index _first_rank;
   const Index _last_rank;
   const Amount _delivery;

--- a/src/problems/cvrp/operators/intra_or_opt.cpp
+++ b/src/problems/cvrp/operators/intra_or_opt.cpp
@@ -30,7 +30,6 @@ IntraOrOpt::IntraOrOpt(const Input& input,
     // Required for consistency in compute_gain if check_reverse is
     // false.
     check_reverse(check_reverse),
-    _moved_jobs((s_rank < t_rank) ? t_rank - s_rank + 2 : s_rank - t_rank + 2),
     _first_rank(std::min(s_rank, t_rank)),
     _last_rank(std::max(s_rank, t_rank) + 2),
     _delivery(source.delivery_in_range(_first_rank, _last_rank)) {
@@ -46,23 +45,25 @@ IntraOrOpt::IntraOrOpt(const Input& input,
           _input.jobs[s_route[s_rank + 1]].type == JOB_TYPE::DELIVERY &&
           !check_reverse &&
           _sol_state.matching_delivery_rank[s_vehicle][s_rank] == s_rank + 1));
+}
 
+void IntraOrOpt::prepare_moved_jobs() {
+  _moved_jobs.clear();
+  _moved_jobs.resize((s_rank < t_rank) ? t_rank - s_rank + 2
+                                       : s_rank - t_rank + 2);
   if (t_rank < s_rank) {
     _s_edge_first = 0;
     _s_edge_last = 1;
-
     std::copy(s_route.begin() + t_rank,
               s_route.begin() + s_rank,
               _moved_jobs.begin() + 2);
   } else {
     _s_edge_first = _moved_jobs.size() - 2;
     _s_edge_last = _moved_jobs.size() - 1;
-
     std::copy(s_route.begin() + s_rank + 2,
               s_route.begin() + t_rank + 2,
               _moved_jobs.begin());
   }
-
   _moved_jobs[_s_edge_first] = s_route[s_rank];
   _moved_jobs[_s_edge_last] = s_route[s_rank + 1];
 }
@@ -171,6 +172,7 @@ void IntraOrOpt::compute_gain() {
 }
 
 bool IntraOrOpt::is_valid() {
+  prepare_moved_jobs();
   assert(_gain_upper_bound_computed);
 
   const auto& s_v = _input.vehicles[s_vehicle];

--- a/src/problems/cvrp/operators/intra_or_opt.h
+++ b/src/problems/cvrp/operators/intra_or_opt.h
@@ -28,6 +28,8 @@ protected:
   const bool check_reverse;
 
   std::vector<Index> _moved_jobs;
+  void prepare_moved_jobs();
+
   const Index _first_rank;
   const Index _last_rank;
   const Amount _delivery;

--- a/src/problems/cvrp/operators/intra_relocate.cpp
+++ b/src/problems/cvrp/operators/intra_relocate.cpp
@@ -27,7 +27,6 @@ IntraRelocate::IntraRelocate(const Input& input,
              s_raw_route,
              s_vehicle,
              t_rank),
-    _moved_jobs((s_rank < t_rank) ? t_rank - s_rank + 1 : s_rank - t_rank + 1),
     _first_rank(std::min(s_rank, t_rank)),
     _last_rank(std::max(s_rank, t_rank) + 1),
     _delivery(source.delivery_in_range(_first_rank, _last_rank)) {
@@ -35,7 +34,11 @@ IntraRelocate::IntraRelocate(const Input& input,
   assert(s_rank < s_route.size());
   assert(t_rank <= s_route.size() - 1);
   assert(s_rank != t_rank);
+}
 
+void IntraRelocate::prepare_moved_jobs() {
+  _moved_jobs.clear();
+  _moved_jobs.resize((_last_rank - _first_rank));
   if (t_rank < s_rank) {
     _moved_jobs[0] = s_route[s_rank];
     std::copy(s_route.begin() + t_rank,
@@ -69,6 +72,7 @@ void IntraRelocate::compute_gain() {
 }
 
 bool IntraRelocate::is_valid() {
+  prepare_moved_jobs();
   return is_valid_for_range_bounds() &&
          source.is_valid_addition_for_capacity_inclusion(_input,
                                                          _delivery,

--- a/src/problems/cvrp/operators/intra_relocate.h
+++ b/src/problems/cvrp/operators/intra_relocate.h
@@ -19,6 +19,8 @@ protected:
   void compute_gain() override;
 
   std::vector<Index> _moved_jobs;
+  void prepare_moved_jobs();
+
   const Index _first_rank;
   const Index _last_rank;
   const Amount _delivery;

--- a/src/problems/cvrp/operators/unassigned_exchange.cpp
+++ b/src/problems/cvrp/operators/unassigned_exchange.cpp
@@ -33,7 +33,6 @@ UnassignedExchange::UnassignedExchange(const Input& input,
     _unassigned(unassigned),
     _first_rank(std::min(s_rank, t_rank)),
     _last_rank((s_rank < t_rank) ? t_rank : s_rank + 1),
-    _moved_jobs(_last_rank - _first_rank),
     _removed(s_route[s_rank]),
     _delivery(source.delivery_in_range(_first_rank, _last_rank)) {
   assert(t_rank != s_rank + 1);
@@ -44,17 +43,21 @@ UnassignedExchange::UnassignedExchange(const Input& input,
   assert(_input.jobs[_removed].delivery <= _delivery);
   _delivery -= _input.jobs[_removed].delivery;
   _delivery += _input.jobs[_u].delivery;
+}
 
+void UnassignedExchange::prepare_moved_jobs() {
+  _moved_jobs.clear();
+  _moved_jobs.resize(_last_rank - _first_rank);
   if (s_rank < t_rank) {
     std::copy(s_route.begin() + s_rank + 1,
               s_route.begin() + t_rank,
               _moved_jobs.begin());
-    _moved_jobs.back() = u;
+    _moved_jobs.back() = _u;
   } else {
     std::copy(s_route.begin() + t_rank,
               s_route.begin() + s_rank,
               _moved_jobs.begin() + 1);
-    _moved_jobs.front() = u;
+    _moved_jobs.front() = _u;
   }
 }
 
@@ -96,6 +99,7 @@ void UnassignedExchange::compute_gain() {
 }
 
 bool UnassignedExchange::is_valid() {
+  prepare_moved_jobs();
   auto pickup = source.pickup_in_range(_first_rank, _last_rank);
   assert(_input.jobs[_removed].pickup <= pickup);
   pickup -= _input.jobs[_removed].pickup;

--- a/src/problems/cvrp/operators/unassigned_exchange.h
+++ b/src/problems/cvrp/operators/unassigned_exchange.h
@@ -21,6 +21,8 @@ protected:
   const Index _first_rank;
   const Index _last_rank;
   std::vector<Index> _moved_jobs;
+  void prepare_moved_jobs();
+
   const Index _removed;
   Amount _delivery;
 


### PR DESCRIPTION
## Issue

https://github.com/VROOM-Project/vroom/issues/1274

## Tasks

 - [ ] Refactoring: Avoid allocating moved jobs ranges too early
