### PR TITLE
Update deprecated asio io_service and query

### DIFF
--- a/src/routing/http_wrapper.cpp
+++ b/src/routing/http_wrapper.cpp
@@ -70,14 +70,12 @@ std::string HttpWrapper::send_then_receive(const std::string& query) const {
   std::string response;
 
   try {
-    asio::io_service io_service;
+    asio::io_context io_context;
 
-    tcp::resolver r(io_service);
+    tcp::resolver r(io_context);
 
-    const tcp::resolver::query q(_server.host, _server.port);
-
-    tcp::socket s(io_service);
-    asio::connect(s, r.resolve(q));
+    tcp::socket s(io_context);
+    asio::connect(s, r.resolve(_server.host, _server.port));
 
     asio::write(s, asio::buffer(query));
 
@@ -94,16 +92,14 @@ std::string HttpWrapper::ssl_send_then_receive(const std::string& query) const {
   std::string response;
 
   try {
-    asio::io_service io_service;
+    asio::io_context io_context;
 
     asio::ssl::context ctx(asio::ssl::context::method::sslv23_client);
-    asio::ssl::stream<asio::ip::tcp::socket> ssock(io_service, ctx);
+    asio::ssl::stream<asio::ip::tcp::socket> ssock(io_context, ctx);
 
-    tcp::resolver r(io_service);
+    tcp::resolver r(io_context);
 
-    const tcp::resolver::query q(_server.host, _server.port);
-
-    asio::connect(ssock.lowest_layer(), r.resolve(q));
+    asio::connect(ssock.lowest_layer(), r.resolve(_server.host, _server.port));
     ssock.handshake(asio::ssl::stream_base::handshake_type::client);
 
     asio::write(ssock, asio::buffer(query));


### PR DESCRIPTION
On ArchLinux, I get [asio v1.34.2](https://archlinux.org/packages/extra/any/asio/) in which `io_service` and `query` are not defined anymore so I get
```
$ make
g++ -MMD -MP -I. -std=c++20 -Wextra -Wpedantic -Wall -O3 -DASIO_STANDALONE -DUSE_ROUTING=true -D USE_LIBGLPK=true -c routing/http_wrapper.cpp -o routing/http_wrapper.o
routing/http_wrapper.cpp: In member function ‘std::string vroom::routing::HttpWrapper::send_then_receive(const std::string&) const’:
routing/http_wrapper.cpp:73:11: error: ‘io_service’ is not a member of ‘asio’; did you mean ‘use_service’?
   73 |     asio::io_service io_service;
      |           ^~~~~~~~~~
      |           use_service
routing/http_wrapper.cpp:75:21: error: ‘io_service’ was not declared in this scope
   75 |     tcp::resolver r(io_service);
      |                     ^~~~~~~~~~
routing/http_wrapper.cpp:77:26: error: ‘query’ in ‘asio::ip::tcp::resolver’ {aka ‘class asio::ip::basic_resolver<asio::ip::tcp>’} does not name a type
   77 |     const tcp::resolver::query q(_server.host, _server.port);
      |                          ^~~~~
routing/http_wrapper.cpp:80:32: error: ‘q’ was not declared in this scope
   80 |     asio::connect(s, r.resolve(q));
      |                                ^
routing/http_wrapper.cpp: In member function ‘std::string vroom::routing::HttpWrapper::ssl_send_then_receive(const std::string&) const’:
routing/http_wrapper.cpp:97:11: error: ‘io_service’ is not a member of ‘asio’; did you mean ‘use_service’?
   97 |     asio::io_service io_service;
      |           ^~~~~~~~~~
      |           use_service
routing/http_wrapper.cpp:100:52: error: ‘io_service’ was not declared in this scope
  100 |     asio::ssl::stream<asio::ip::tcp::socket> ssock(io_service, ctx);
      |                                                    ^~~~~~~~~~
routing/http_wrapper.cpp:104:26: error: ‘query’ in ‘asio::ip::tcp::resolver’ {aka ‘class asio::ip::basic_resolver<asio::ip::tcp>’} does not name a type
  104 |     const tcp::resolver::query q(_server.host, _server.port);
      |                          ^~~~~
routing/http_wrapper.cpp:106:51: error: ‘q’ was not declared in this scope
  106 |     asio::connect(ssock.lowest_layer(), r.resolve(q));
      |                                                   ^
make: *** [makefile:76: routing/http_wrapper.o] Error 1
```
This PR fixes the two issues.