### PR TITLE
Add include to fix std::counting_semaphore usage

### DIFF
--- a/src/problems/vrp.h
+++ b/src/problems/vrp.h
@@ -14,6 +14,7 @@ All rights reserved (see LICENSE).
 #include <mutex>
 #include <numeric>
 #include <ranges>
+#include <semaphore>
 #include <set>
 #include <thread>
 


### PR DESCRIPTION
## Issue

Build failure seen on macOS 26 when building with Clang:
```console
In file included from problems/vrp.cpp:10:
./problems/vrp.h:207:10: error: no member named 'counting_semaphore' in namespace 'std'
  207 |     std::counting_semaphore<32> semaphore(actual_nb_threads);
      |     ~~~~~^
./problems/vrp.h:207:33: error: use of undeclared identifier 'semaphore'
  207 |     std::counting_semaphore<32> semaphore(actual_nb_threads);
      |                                 ^
```

Seemed like simple change so directly opened pull request, but can create & reference a separate issue if preferred.

## Tasks

 - [x] review