### PR TITLE
Fix non-metric matrix local search crash

### DIFF
--- a/.github/workflows/vroom.yml
+++ b/.github/workflows/vroom.yml
@@ -34,6 +34,8 @@ jobs:
         working-directory: src
       - name: Validate output
         run: diff <(bin/vroom -i docs/example_2.json  | jq '.routes[].steps[]' --sort-keys) <(jq '.routes[].steps[]' --sort-keys docs/example_2_sol.json)
+      - name: Regression test for non-metric duration matrix
+        run: bin/vroom -i tests/issue_1341_non_metric_matrix.json | jq -e '.code == 0'
       - name: Build libvroom example
         run: make -j
         env:

--- a/src/algorithms/local_search/local_search.cpp
+++ b/src/algorithms/local_search/local_search.cpp
@@ -1325,8 +1325,14 @@ void LocalSearch<Route,
         Index end_t_rank = _sol[source].size() - 1;
         const auto end_s_next =
           _sol_state.weak_insertion_ranks_end[source][s_next_job_rank];
-        assert(end_s_next > 1);
-        end_t_rank = std::min(end_t_rank, static_cast<Index>(end_s_next - 2));
+        if (end_s_next > 1) {
+          end_t_rank =
+            std::min(end_t_rank, static_cast<Index>(end_s_next - 2));
+        } else {
+          // The next job cannot be reinserted after the first route task.
+          // No intra cross-exchange candidate can satisfy that bound.
+          end_t_rank = std::min(end_t_rank, end_s_next);
+        }
 
         for (unsigned t_rank = s_rank + 3; t_rank < end_t_rank; ++t_rank) {
           const auto& job_t_type = _input.jobs[_sol[target].route[t_rank]].type;

--- a/tests/issue_1341_non_metric_matrix.json
+++ b/tests/issue_1341_non_metric_matrix.json
@@ -1,0 +1,42 @@
+{
+  "vehicles": [
+    {
+      "id": 1,
+      "start_index": 0,
+      "end_index": 0,
+      "steps": [
+        {"type": "start"},
+        {"type": "job", "id": 1},
+        {"type": "job", "id": 2},
+        {"type": "job", "id": 3},
+        {"type": "job", "id": 4},
+        {"type": "job", "id": 5},
+        {"type": "end"}
+      ]
+    }
+  ],
+  "jobs": [
+    {"id": 1, "location_index": 1, "service": 100},
+    {"id": 2, "location_index": 2, "service": 100},
+    {
+      "id": 3,
+      "location_index": 3,
+      "service": 100,
+      "time_windows": [[400, 400]]
+    },
+    {"id": 4, "location_index": 4, "service": 100},
+    {"id": 5, "location_index": 5, "service": 100}
+  ],
+  "matrices": {
+    "car": {
+      "durations": [
+        [0, 0, 100, 300, 200, 300],
+        [0, 0, 100, 10000, 200, 300],
+        [100, 100, 0, 100, 200, 300],
+        [300, 300, 100, 0, 100, 200],
+        [200, 200, 200, 100, 0, 100],
+        [300, 300, 300, 200, 100, 0]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Issue

Fixes #1341

## Summary

`weak_insertion_ranks_end` can validly be `0` or `1` when the second job in an intra cross exchange cannot be reinserted after the first route task. In that case there is no valid cross exchange target, but the code asserted before safely handling the bound.

This change handles the empty candidate range and adds a regression test using the reported non metric duration matrix input.

## Tasks

- [x] Guard the intra cross-exchange target-rank bound
- [x] Add and run a regression test for issue #1341
- [x] Review