### PR TITLE
Add max_transit_time for shipments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+#### Features
+
+- Support for `max_transit_time` on shipments, bounding time from pickup departure to delivery start (#703)
+
 ### Fixed
 
 #### Internals

--- a/docs/API.md
+++ b/docs/API.md
@@ -441,7 +441,7 @@ A `violation` object has the following properties:
 | Key         | Description |
 | ----------- | ----------- |
 | `cause` | string describing the cause of violation |
-| [`duration`] |  Earliness (resp. lateness) if `cause` is "lead_time" (resp "delay") |
+| [`duration`] | Earliness (resp. lateness) if `cause` is "lead_time" (resp. "delay") |
 
 Possible violation causes are:
 - "delay" if actual service start does not meet a task time window and is late on a time window end
@@ -454,6 +454,7 @@ Possible violation causes are:
 - "max_travel_time" if the vehicle has more travel time than its `max_travel_time` value
 - "max_distance" if the vehicle has a longer travel distance than its `max_distance` value
 - "max_load" if the load during a break exceed its `max_load` value
+- "max_transit_time" if a shipment transit time exceeds its `max_transit_time` value
 
 Note on violations: reporting only really makes sense when using `-c`
 to choose ETA for custom routes described in input using the `steps`

--- a/docs/API.md
+++ b/docs/API.md
@@ -84,6 +84,7 @@ A `shipment` object has the following properties:
 | [`amount`] | an array of integers describing multidimensional quantities |
 | [`skills`] | an array of integers defining mandatory skills |
 | [`priority`] | an integer in the `[0, 100]` range describing priority level (defaults to 0) |
+| [`max_transit_time`] | an integer defining the maximum time from pickup departure to delivery start |
 
 A `shipment_step` is similar to a `job` object (expect for shared keys already present in `shipment`):
 

--- a/libvroom_examples/libvroom.cpp
+++ b/libvroom_examples/libvroom.cpp
@@ -120,6 +120,7 @@ void run_example_with_osrm() {
 
   vroom::UserDuration setup = 0;
   vroom::UserDuration service = 5 * 60; // 5 minutes
+  std::optional<vroom::UserDuration> max_transit_time = 30 * 60;
 
   // Define vehicle breaks.
   vroom::Break break_1(1, {vroom::TimeWindow(32400, 34200)}, 300);
@@ -201,7 +202,13 @@ void run_example_with_osrm() {
                     setup,
                     service,
                     pd_amount,
-                    pd_skills);
+                    pd_skills,
+                    0,
+                    std::vector<vroom::TimeWindow>(1, vroom::TimeWindow()),
+                    "",
+                    {},
+                    {},
+                    max_transit_time);
 
   vroom::Job delivery(3,
                       vroom::JOB_TYPE::DELIVERY,
@@ -209,7 +216,13 @@ void run_example_with_osrm() {
                       setup,
                       service,
                       pd_amount,
-                      pd_skills);
+                      pd_skills,
+                      0,
+                      std::vector<vroom::TimeWindow>(1, vroom::TimeWindow()),
+                      "",
+                      {},
+                      {},
+                      max_transit_time);
   problem_instance.add_shipment(pickup, delivery);
 
   // Skills definitions set the following constraints:

--- a/src/algorithms/validation/choose_ETA.cpp
+++ b/src/algorithms/validation/choose_ETA.cpp
@@ -203,6 +203,67 @@ Route choose_ETA(const Input& input,
   assert(current_index == n + 1);
   assert(relative_ETA.size() == steps.size());
 
+  // Action time per step (indexed by position in steps). Matches the
+  // engine's A_P formula: setup suppressed when same location as
+  // predecessor.
+  std::vector<Duration> step_action_time(steps.size(), 0);
+  {
+    unsigned ri = 0;
+    for (unsigned s = 0; s < steps.size(); ++s) {
+      switch (steps[s].type) {
+        using enum STEP_TYPE;
+      case START:
+        step_action_time[s] = action_times[ri++];
+        break;
+      case JOB:
+        step_action_time[s] = action_times[ri++];
+        break;
+      case BREAK:
+        step_action_time[s] = v.breaks[steps[s].rank].service;
+        break;
+      case END:
+        step_action_time[s] = 0;
+        break;
+      }
+    }
+    assert(ri == action_times.size());
+  }
+
+  // Collect constrained shipment pairs for transit-time MIP soft terms.
+  struct RidePair {
+    unsigned pickup_step;
+    unsigned delivery_step;
+    Duration cap;
+    Duration action_time; // A_P: must match engine exactly
+  };
+  std::vector<RidePair> ride_pairs;
+  {
+    std::unordered_map<Index, unsigned> delivery_step_of;
+    for (unsigned s = 1; s + 1 < steps.size(); ++s) {
+      if (steps[s].type == STEP_TYPE::JOB &&
+          input.jobs[steps[s].rank].type == JOB_TYPE::DELIVERY) {
+        delivery_step_of[steps[s].rank] = s;
+      }
+    }
+    for (unsigned s = 1; s + 1 < steps.size(); ++s) {
+      if (steps[s].type != STEP_TYPE::JOB)
+        continue;
+      const auto& job = input.jobs[steps[s].rank];
+      if (job.type != JOB_TYPE::PICKUP)
+        continue;
+      if (!job.max_transit_time.has_value())
+        continue;
+      const Index delivery_rank = steps[s].rank + 1;
+      auto it = delivery_step_of.find(delivery_rank);
+      // Skip if delivery absent or comes before pickup (precedence violation).
+      if (it == delivery_step_of.end() || it->second < s)
+        continue;
+      ride_pairs.push_back(
+        {s, it->second, job.max_transit_time.value(), step_action_time[s]});
+    }
+  }
+  const unsigned P = static_cast<unsigned>(ride_pairs.size());
+
   // Determine earliest possible start based on "service_at" and
   // "service_before" constraints.
   std::vector<Duration> latest_dates(steps.size(),
@@ -979,6 +1040,62 @@ Route choose_ETA(const Input& input,
   delete[] ja;
   delete[] ar;
 
+  // Per-pair transit-time soft terms: excess variables e_p >= 0 with
+  // constraint t_{s_D} - t_{s_P} - e_p <= A_P + cap_P, weighted in
+  // phase-1 objective like delay. A_P formula matches the engine exactly
+  // (setup suppression when same location as predecessor).
+  unsigned excess_col_start = 0;
+  unsigned sigma_e_row = 0;
+  if (P > 0) {
+    const int first_excess = glp_add_cols(lp, static_cast<int>(P));
+    excess_col_start = static_cast<unsigned>(first_excess);
+    for (unsigned p = 0; p < P; ++p) {
+      const int col = first_excess + static_cast<int>(p);
+      auto e_name = std::format("e{}", p);
+      glp_set_col_name(lp, col, e_name.c_str());
+      glp_set_col_bnds(lp, col, GLP_LO, 0.0, 0.0);
+      glp_set_obj_coef(lp, col, makespan_estimate);
+    }
+
+    const int first_ride_row = glp_add_rows(lp, static_cast<int>(P));
+    for (unsigned p = 0; p < P; ++p) {
+      const int row = first_ride_row + static_cast<int>(p);
+      const auto& rp = ride_pairs[p];
+      auto r_name = std::format("R{}", p);
+      glp_set_row_name(lp, row, r_name.c_str());
+      // t_{s_D} - t_{s_P} - e_p <= A_P + cap_P
+      const double rhs = static_cast<double>(rp.action_time + rp.cap);
+      glp_set_row_bnds(lp, row, GLP_UP, 0.0, rhs);
+      int ind[4];
+      double val[4];
+      ind[1] = static_cast<int>(rp.delivery_step + 1); // t_{s_D}
+      val[1] = 1.0;
+      ind[2] = static_cast<int>(rp.pickup_step + 1); // t_{s_P}
+      val[2] = -1.0;
+      ind[3] = first_excess + static_cast<int>(p); // e_p
+      val[3] = -1.0;
+      glp_set_mat_row(lp, row, 3, ind, val);
+    }
+
+    // Sigma_E: sum of excess vars, pinned in phase 2.
+    sigma_e_row = static_cast<unsigned>(glp_add_rows(lp, 1));
+    glp_set_row_name(lp, static_cast<int>(sigma_e_row), "Sigma_E");
+    glp_set_row_bnds(lp, static_cast<int>(sigma_e_row), GLP_LO, 0.0, 0.0);
+    {
+      std::vector<int> ind(P + 1);
+      std::vector<double> val(P + 1);
+      for (unsigned p = 0; p < P; ++p) {
+        ind[p + 1] = first_excess + static_cast<int>(p);
+        val[p + 1] = 1.0;
+      }
+      glp_set_mat_row(lp,
+                      static_cast<int>(sigma_e_row),
+                      static_cast<int>(P),
+                      ind.data(),
+                      val.data());
+    }
+  }
+
   // 4. Solve for violations and makespan.
   glp_term_out(GLP_OFF);
   glp_iocp parm;
@@ -1014,6 +1131,12 @@ Route choose_ETA(const Input& input,
   for (unsigned i = 0; i <= n + 1; ++i) {
     glp_set_obj_coef(lp, start_Y_col + i, 0);
   }
+  // Zero excess objective coefficients for phase 2.
+  if (P > 0) {
+    for (unsigned p = 0; p < P; ++p) {
+      glp_set_obj_coef(lp, static_cast<int>(excess_col_start + p), 0.0);
+    }
+  }
   glp_set_obj_coef(lp, n + 2, 0);
   glp_set_obj_coef(lp, 1, 0);
 
@@ -1036,6 +1159,20 @@ Route choose_ETA(const Input& input,
     sum_y_i += get_duration(glp_mip_col_val(lp, i));
   }
   glp_set_row_bnds(lp, nb_constraints, GLP_FX, sum_y_i, sum_y_i);
+
+  // Pin sum of excess variables for phase 2.
+  if (P > 0) {
+    Duration sum_e = 0;
+    for (unsigned p = 0; p < P; ++p) {
+      sum_e += get_duration(
+        glp_mip_col_val(lp, static_cast<int>(excess_col_start + p)));
+    }
+    glp_set_row_bnds(lp,
+                     static_cast<int>(sigma_e_row),
+                     GLP_FX,
+                     static_cast<double>(sum_e),
+                     static_cast<double>(sum_e));
+  }
 
   glp_intopt(lp, &parm);
 

--- a/src/algorithms/validation/choose_ETA.cpp
+++ b/src/algorithms/validation/choose_ETA.cpp
@@ -1124,6 +1124,12 @@ Route choose_ETA(const Input& input,
   unsigned number_of_tasks = 0;
   std::unordered_set<VIOLATION> v_types;
 
+  // Ride-time tracking for constrained shipments, keyed by pickup
+  // job_rank, holding departure times in internal Duration units. Empty
+  // when no shipment has max_transit_time.
+  std::unordered_map<Index, Duration> pickup_departure_map;
+  UserDuration user_transit_time_excess = 0;
+
   // Startup load is the sum of deliveries for (single) jobs.
   Amount current_load(input.zero_amount());
   for (const auto& step : steps) {
@@ -1295,8 +1301,13 @@ Route choose_ETA(const Input& input,
           delivery_to_pickup_step_rank.emplace(job_rank + 1,
                                                sol_steps.size() - 1);
         }
+        // Record pickup departure for the transit-time check at delivery.
+        if (job.max_transit_time.has_value()) {
+          pickup_departure_map[job_rank] =
+            service_start + current_setup + current_service;
+        }
         break;
-      case JOB_TYPE::DELIVERY:
+      case JOB_TYPE::DELIVERY: {
         auto search = expected_delivery_ranks.find(job_rank);
         if (search == expected_delivery_ranks.end()) {
           current.violations.types.insert(VIOLATION::PRECEDENCE);
@@ -1305,7 +1316,25 @@ Route choose_ETA(const Input& input,
         } else {
           expected_delivery_ranks.erase(search);
         }
+        // Transit time is only defined when the pickup was already served
+        // (delivery-first orders carry a PRECEDENCE violation instead).
+        if (job.max_transit_time.has_value()) {
+          const auto pit =
+            pickup_departure_map.find(static_cast<Index>(job_rank - 1));
+          if (pit != pickup_departure_map.end()) {
+            const Duration transit_time = service_start - pit->second;
+            if (transit_time > job.max_transit_time.value()) {
+              const auto excess = utils::scale_to_user_duration(
+                transit_time - job.max_transit_time.value());
+              current.violations.transit_time_excess = excess;
+              current.violations.types.insert(VIOLATION::MAX_TRANSIT_TIME);
+              v_types.insert(VIOLATION::MAX_TRANSIT_TIME);
+              user_transit_time_excess += excess;
+            }
+          }
+        }
         break;
+      }
       }
 
       previous_start = service_start;
@@ -1489,7 +1518,10 @@ Route choose_ETA(const Input& input,
                sum_pickups,
                v.profile,
                v.description,
-               Violations(user_lead_time, user_delay, std::move(v_types)));
+               Violations(user_lead_time,
+                          user_delay,
+                          std::move(v_types),
+                          user_transit_time_excess));
 }
 
 } // namespace vroom::validation

--- a/src/problems/vrptw/operators/route_split.cpp
+++ b/src/problems/vrptw/operators/route_split.cpp
@@ -52,6 +52,10 @@ void RouteSplit::compute_gain() {
 void RouteSplit::apply() {
   assert(choice.gain != NO_GAIN);
 
+  // RouteSplit never cuts through a shipment pair: split ranks always fall
+  // between complete pairs.
+  assert(!_tw_s_route.has_pending_delivery_after_rank(choice.split_rank - 1));
+
   // Empty route holding the end of the split.
   auto& end_route = _tw_sol[_end_route_rank];
   assert(end_route.empty());

--- a/src/problems/vrptw/operators/swap_star.cpp
+++ b/src/problems/vrptw/operators/swap_star.cpp
@@ -46,6 +46,11 @@ void SwapStar::compute_gain() {
 }
 
 void SwapStar::apply() {
+  // SwapStar only operates on single jobs, so shipment halves are never
+  // swapped and max_transit_time enforcement cannot be bypassed here.
+  assert(_input.jobs[s_route[choice.s_rank]].type == JOB_TYPE::SINGLE);
+  assert(_input.jobs[t_route[choice.t_rank]].type == JOB_TYPE::SINGLE);
+
   const auto s_insert = ls::get_insert_range(s_route,
                                              choice.s_rank,
                                              t_route[choice.t_rank],

--- a/src/structures/typedefs.h
+++ b/src/structures/typedefs.h
@@ -153,7 +153,8 @@ enum class VIOLATION : std::uint8_t {
   MISSING_BREAK,
   MAX_TRAVEL_TIME,
   MAX_LOAD,
-  MAX_DISTANCE
+  MAX_DISTANCE,
+  MAX_TRANSIT_TIME
 };
 
 enum OperatorName : std::uint8_t {

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -567,6 +567,92 @@ void Input::set_extra_compatibility() {
   // they apply).
   compatible_vehicles_for_job = std::vector<std::vector<Index>>(jobs.size());
 
+  // Route-independent max_transit_time infeasibility precheck.
+  // Lower bound on transit time for any feasible schedule:
+  //   lb = max(travel_lb_across_compatible_vehicles,
+  //            delivery.tws.front().start - pickup.tws.back().end
+  //              - max_action_across_compatible_vehicles)
+  // where max_action = max over compatible vehicles of
+  //   (setups[v.type] + services[v.type]).
+  // A larger action time means a later possible departure and a smaller
+  // forced gap, so soundness requires the maximum over vehicles.
+  // The travel term must stay valid for arbitrary (possibly non-metric)
+  // matrices, where a path through intermediate stops can be shorter than
+  // the direct pickup-to-delivery leg: any such path still starts with an
+  // edge leaving the pickup and ends with an edge entering the delivery, so
+  // min(direct, cheapest_out_edge + cheapest_in_edge) lower-bounds every
+  // routing. The edge scan only runs when the direct leg alone would reject.
+  // If lb > max_transit_time, no schedule can comply: mark incompatible with
+  // all vehicles so heuristics never attempt it and it surfaces unassigned.
+  if (_has_max_transit_time) {
+    for (Index j = 0; j + 1 < static_cast<Index>(jobs.size()); ++j) {
+      if (jobs[j].type != JOB_TYPE::PICKUP ||
+          !jobs[j].max_transit_time.has_value()) {
+        continue;
+      }
+
+      // Minimum sound travel bound and maximum action time across compatible
+      // vehicles.
+      bool any_compatible = false;
+      Duration travel_lb = 0;
+      Duration max_action = 0;
+      const Index p_loc = jobs[j].index();
+      const Index d_loc = jobs[j + 1].index();
+      for (std::size_t v = 0; v < vehicles.size(); ++v) {
+        if (!_vehicle_to_job_compatibility[v][j]) {
+          continue;
+        }
+        const Duration direct = vehicles[v].duration(p_loc, d_loc);
+        Duration t = direct;
+        if (direct > *jobs[j].max_transit_time) {
+          // Direct leg alone would reject: bound indirect paths too before
+          // trusting that conclusion.
+          Duration out_min = std::numeric_limits<Duration>::max();
+          Duration in_min = std::numeric_limits<Duration>::max();
+          for (Index k = 0; k < static_cast<Index>(_locations.size()); ++k) {
+            if (k != p_loc) {
+              out_min = std::min(out_min, vehicles[v].duration(p_loc, k));
+            }
+            if (k != d_loc) {
+              in_min = std::min(in_min, vehicles[v].duration(k, d_loc));
+            }
+          }
+          if (out_min != std::numeric_limits<Duration>::max() &&
+              in_min != std::numeric_limits<Duration>::max()) {
+            t = std::min(direct, out_min + in_min);
+          }
+        }
+        if (!any_compatible || t < travel_lb) {
+          travel_lb = t;
+        }
+        const Duration act =
+          jobs[j].setups[vehicles[v].type] + jobs[j].services[vehicles[v].type];
+        if (!any_compatible || act > max_action) {
+          max_action = act;
+        }
+        any_compatible = true;
+      }
+      if (!any_compatible) {
+        // Already incompatible with all vehicles; nothing to do.
+        continue;
+      }
+
+      // TW gap term: earliest delivery start minus the latest achievable
+      // pickup departure (pickup TW end plus maximum compatible-vehicle
+      // action time).
+      const Duration latest_pickup_end = jobs[j].tws.back().end + max_action;
+      const Duration tw_gap = jobs[j + 1].tws.front().start - latest_pickup_end;
+
+      const Duration lb = std::max(travel_lb, tw_gap);
+      if (lb > *jobs[j].max_transit_time) {
+        for (std::size_t v = 0; v < vehicles.size(); ++v) {
+          _vehicle_to_job_compatibility[v][j] = false;
+          _vehicle_to_job_compatibility[v][j + 1] = false;
+        }
+      }
+    }
+  }
+
   for (std::size_t v = 0; v < vehicles.size(); ++v) {
     const TWRoute empty_route(*this, v, _zero.size());
     for (Index j = 0; j < jobs.size(); ++j) {

--- a/src/structures/vroom/input/input.cpp
+++ b/src/structures/vroom/input/input.cpp
@@ -200,6 +200,8 @@ void Input::add_job(const Job& job) {
 }
 
 void Input::add_shipment(const Job& pickup, const Job& delivery) {
+  // Preflight checks prevent partial pair insertion; check_job may still throw
+  // after insertion for the existing amount, location, and matrix checks.
   if (pickup.priority != delivery.priority) {
     throw InputException(
       std::
@@ -219,6 +221,14 @@ void Input::add_shipment(const Job& pickup, const Job& delivery) {
                   pickup.id,
                   delivery.id));
   }
+
+  if (pickup.max_transit_time != delivery.max_transit_time) {
+    throw InputException(
+      std::format("Inconsistent shipment max_transit_time for pickup {} and "
+                  "delivery {}.",
+                  pickup.id,
+                  delivery.id));
+  }
   for (const auto s : pickup.skills) {
     if (!delivery.skills.contains(s)) {
       throw InputException(
@@ -234,10 +244,6 @@ void Input::add_shipment(const Job& pickup, const Job& delivery) {
   if (pickup_id_to_rank.contains(pickup.id)) {
     throw InputException(std::format("Duplicate pickup id: {}.", pickup.id));
   }
-  pickup_id_to_rank[pickup.id] = jobs.size();
-  jobs.push_back(pickup);
-  check_job(jobs.back());
-
   if (delivery.type != JOB_TYPE::DELIVERY) {
     throw InputException(
       std::format("Wrong type for delivery {}.", delivery.id));
@@ -246,10 +252,17 @@ void Input::add_shipment(const Job& pickup, const Job& delivery) {
     throw InputException(
       std::format("Duplicate delivery id: {}.", delivery.id));
   }
+
+  pickup_id_to_rank[pickup.id] = jobs.size();
+  jobs.push_back(pickup);
+  check_job(jobs.back());
+
   delivery_id_to_rank[delivery.id] = jobs.size();
   jobs.push_back(delivery);
   check_job(jobs.back());
   _has_shipments = true;
+  _has_max_transit_time =
+    _has_max_transit_time || pickup.max_transit_time.has_value();
 }
 
 void Input::add_vehicle(const Vehicle& vehicle) {
@@ -447,6 +460,10 @@ bool Input::has_jobs() const {
 
 bool Input::has_shipments() const {
   return _has_shipments;
+}
+
+bool Input::has_max_transit_time() const {
+  return _has_max_transit_time;
 }
 
 bool Input::report_distances() const {
@@ -1191,7 +1208,7 @@ void Input::set_matrices(unsigned nb_thread, bool sparse_filling) {
 }
 
 std::unique_ptr<VRP> Input::get_problem() const {
-  if (_has_TW) {
+  if (_has_TW || _has_max_transit_time) {
     return std::make_unique<VRPTW>(*this);
   }
 

--- a/src/structures/vroom/input/input.h
+++ b/src/structures/vroom/input/input.h
@@ -56,6 +56,7 @@ private:
   bool _report_distances;
   bool _has_jobs{false};
   bool _has_shipments{false};
+  bool _has_max_transit_time{false};
   std::unordered_map<std::string,
                      Matrix<UserDuration>,
                      StringHash,
@@ -175,6 +176,8 @@ public:
   bool has_jobs() const;
 
   bool has_shipments() const;
+
+  bool has_max_transit_time() const;
 
   bool report_distances() const;
 

--- a/src/structures/vroom/job.cpp
+++ b/src/structures/vroom/job.cpp
@@ -57,7 +57,8 @@ Job::Job(Id id,
          const std::vector<TimeWindow>& tws,
          std::string description,
          const TypeToUserDurationMap& setup_per_type,
-         const TypeToUserDurationMap& service_per_type)
+         const TypeToUserDurationMap& service_per_type,
+         std::optional<UserDuration> max_transit_time)
   : location(location),
     id(id),
     type(type),
@@ -70,7 +71,12 @@ Job::Job(Id id,
     tws(tws),
     description(std::move(description)),
     setup_per_type(utils::scale_from_user_duration(setup_per_type)),
-    service_per_type(utils::scale_from_user_duration(service_per_type)) {
+    service_per_type(utils::scale_from_user_duration(service_per_type)),
+    max_transit_time(
+      max_transit_time.has_value()
+        ? std::optional<Duration>(
+            utils::scale_from_user_duration(max_transit_time.value()))
+        : std::nullopt) {
   assert(type == JOB_TYPE::PICKUP || type == JOB_TYPE::DELIVERY);
   std::string type_str = (type == JOB_TYPE::PICKUP) ? "pickup" : "delivery";
   utils::check_tws(tws, id, type_str);

--- a/src/structures/vroom/job.h
+++ b/src/structures/vroom/job.h
@@ -10,6 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <optional>
 #include <string>
 
 #include "structures/typedefs.h"
@@ -33,6 +34,7 @@ struct Job {
   const std::string description;
   const TypeToDurationMap setup_per_type;
   const TypeToDurationMap service_per_type;
+  const std::optional<Duration> max_transit_time;
   std::vector<Duration> setups;
   std::vector<Duration> services;
 
@@ -65,7 +67,8 @@ struct Job {
         std::vector<TimeWindow>(1, TimeWindow()),
       std::string description = "",
       const TypeToUserDurationMap& setup_per_type = TypeToUserDurationMap(),
-      const TypeToUserDurationMap& service_per_type = TypeToUserDurationMap());
+      const TypeToUserDurationMap& service_per_type = TypeToUserDurationMap(),
+      std::optional<UserDuration> max_transit_time = std::nullopt);
 
   Index index() const {
     return location.index();

--- a/src/structures/vroom/solution/violations.cpp
+++ b/src/structures/vroom/solution/violations.cpp
@@ -13,18 +13,23 @@ All rights reserved (see LICENSE).
 
 namespace vroom {
 
-Violations::Violations() : lead_time(0), delay(0) {
+Violations::Violations() : lead_time(0), delay(0), transit_time_excess(0) {
 }
 
 Violations::Violations(const UserDuration lead_time,
                        const UserDuration delay,
-                       std::unordered_set<VIOLATION>&& types)
-  : lead_time(lead_time), delay(delay), types(std::move(types)) {
+                       std::unordered_set<VIOLATION>&& types,
+                       const UserDuration transit_time_excess)
+  : lead_time(lead_time),
+    delay(delay),
+    transit_time_excess(transit_time_excess),
+    types(std::move(types)) {
 }
 
 Violations& Violations::operator+=(const Violations& rhs) {
   this->lead_time += rhs.lead_time;
   this->delay += rhs.delay;
+  this->transit_time_excess += rhs.transit_time_excess;
 
   for (const auto t : rhs.types) {
     this->types.insert(t);

--- a/src/structures/vroom/solution/violations.h
+++ b/src/structures/vroom/solution/violations.h
@@ -17,6 +17,7 @@ namespace vroom {
 struct Violations {
   UserDuration lead_time;
   UserDuration delay;
+  UserDuration transit_time_excess;
 
   std::unordered_set<VIOLATION> types;
 
@@ -27,7 +28,8 @@ struct Violations {
   Violations(
     UserDuration lead_time,
     UserDuration delay,
-    std::unordered_set<VIOLATION>&& types = std::unordered_set<VIOLATION>());
+    std::unordered_set<VIOLATION>&& types = std::unordered_set<VIOLATION>(),
+    UserDuration transit_time_excess = 0);
 
   Violations& operator+=(const Violations& rhs);
 };

--- a/src/structures/vroom/tw_route.cpp
+++ b/src/structures/vroom/tw_route.cpp
@@ -8,6 +8,7 @@ All rights reserved (see LICENSE).
 */
 
 #include <algorithm>
+#include <optional>
 
 #include "structures/vroom/tw_route.h"
 #include "utils/helpers.h"
@@ -88,6 +89,7 @@ bool apply_break_latest(const Break& b,
   }
   return true;
 }
+
 } // namespace
 
 TWRoute::TWRoute(const Input& input, Index v, unsigned amount_size)
@@ -680,6 +682,207 @@ OrderChoice TWRoute::order_choice(const Input& input,
   return oc;
 }
 
+bool TWRoute::check_max_transit_time(const Input& input,
+                                     const std::vector<TraceEvent>& trace,
+                                     const Index first_rank,
+                                     const Index last_rank,
+                                     const Index inserted_job_count) const {
+  // Candidate-path LB filter: reject only when the path lower bound alone
+  // exceeds the cap. Exact scheduling is handled by the engine downstream.
+  const auto& v = input.vehicles[v_rank];
+
+  const auto event_for = [&](const Index rank) -> const TraceEvent* {
+    const auto found = std::ranges::find_if(trace, [&](const auto& event) {
+      return event.kind == TraceEvent::Kind::JOB && event.rank == rank;
+    });
+    return (found == trace.end()) ? nullptr : &*found;
+  };
+  const auto trace_candidate_rank =
+    [&](const Index rank) -> std::optional<Index> {
+    Index candidate_rank = first_rank;
+    for (const auto& event : trace) {
+      if (event.kind == TraceEvent::Kind::JOB) {
+        if (event.rank == rank) {
+          return candidate_rank;
+        }
+        ++candidate_rank;
+      }
+    }
+    return std::nullopt;
+  };
+  // Returns the candidate-route rank of an external (non-inserted) job, or
+  // nullopt when it is not part of the candidate route.
+  const auto external_rank = [&](const Index rank) -> std::optional<Index> {
+    const auto removed_count = last_rank - first_rank;
+    for (Index i = 0; i < route.size(); ++i) {
+      if ((i < first_rank || last_rank <= i) && route[i] == rank) {
+        return (i < first_rank)
+                 ? i
+                 : static_cast<Index>(i + inserted_job_count - removed_count);
+      }
+    }
+    return std::nullopt;
+  };
+
+  std::vector<Index> checked_pickups;
+  checked_pickups.reserve(inserted_job_count);
+  const auto candidate_route_size = static_cast<Index>(
+    route.size() - (last_rank - first_rank) + inserted_job_count);
+
+  // Returns the job rank at candidate-route position k. The candidate route
+  // is: route[0..first_rank), trace JOB events, route[last_rank..end).
+  const auto candidate_job_at = [&](const Index k) -> Index {
+    const auto removed_count = last_rank - first_rank;
+    if (k < first_rank) {
+      return route[k];
+    }
+    if (k < first_rank + inserted_job_count) {
+      Index job_pos = k - first_rank;
+      for (const auto& evt : trace) {
+        if (evt.kind == TraceEvent::Kind::JOB) {
+          if (job_pos == 0) {
+            return evt.rank;
+          }
+          --job_pos;
+        }
+      }
+      return std::numeric_limits<Index>::max();
+    }
+    const auto orig_k = k - inserted_job_count + removed_count;
+    return route[orig_k];
+  };
+
+  // Candidate-path lower bound: walk the candidate sequence from the pickup
+  // at position pcr to the delivery at position dcr, summing travel between
+  // consecutive stops and intermediate action times (breaks skipped
+  // conservatively: they only add time). Valid for arbitrary non-metric
+  // matrices: the cargo traverses exactly this path, so the sum lower-bounds
+  // transit time for every feasible schedule. Returns nullopt when a
+  // candidate position cannot be resolved.
+  const auto path_lower_bound =
+    [&](const Index pickup_rank,
+        const Index pcr,
+        const Index dcr) -> std::optional<Duration> {
+    Index prev_loc = input.jobs[pickup_rank].index();
+    Duration path_lb = 0;
+    for (Index k = pcr + 1; k <= dcr; ++k) {
+      const auto job_r = candidate_job_at(k);
+      if (job_r == std::numeric_limits<Index>::max()) {
+        return std::nullopt;
+      }
+      const auto& jk = input.jobs[job_r];
+      const Index curr_loc = jk.index();
+      path_lb = saturating_add(path_lb, v.duration(prev_loc, curr_loc));
+      if (k < dcr) {
+        // Intermediate stop: suppress setup when the candidate predecessor
+        // location matches, mirroring the forward-trace action-time rule.
+        const Duration at = action_time_for(jk, v_type, prev_loc);
+        path_lb = saturating_add(path_lb, at);
+      }
+      prev_loc = curr_loc;
+    }
+    return path_lb;
+  };
+
+  for (const auto& event : trace) {
+    if (event.kind != TraceEvent::Kind::JOB ||
+        !input.jobs[event.rank].max_transit_time.has_value()) {
+      continue;
+    }
+    // A delivery's input rank is always its pickup's rank plus one, so the
+    // subtraction below cannot underflow for valid input.
+    assert(input.jobs[event.rank].type == JOB_TYPE::PICKUP || event.rank >= 1);
+    const Index pickup_rank = (input.jobs[event.rank].type == JOB_TYPE::PICKUP)
+                                ? event.rank
+                                : event.rank - 1;
+    // A trace contains only a few events, so linear deduplication avoids an
+    // input-sized allocation in this local-search hot path.
+    if (std::ranges::find(checked_pickups, pickup_rank) !=
+        checked_pickups.end()) {
+      continue;
+    }
+    checked_pickups.push_back(pickup_rank);
+
+    const auto delivery_rank = pickup_rank + 1;
+    const auto* pickup_event = event_for(pickup_rank);
+    const auto* delivery_event = event_for(delivery_rank);
+    const auto pickup_external =
+      pickup_event ? std::optional<Index>() : external_rank(pickup_rank);
+    const auto delivery_external =
+      delivery_event ? std::optional<Index>() : external_rank(delivery_rank);
+    const auto pickup_candidate_rank =
+      pickup_event ? trace_candidate_rank(pickup_rank) : pickup_external;
+    const auto delivery_candidate_rank =
+      delivery_event ? trace_candidate_rank(delivery_rank) : delivery_external;
+    if ((!pickup_event && (!pickup_external.has_value() ||
+                           pickup_external.value() >= candidate_route_size)) ||
+        (!delivery_event &&
+         (!delivery_external.has_value() ||
+          delivery_external.value() >= candidate_route_size))) {
+      continue;
+    }
+
+    Duration lower_bound = 0;
+    if (pickup_candidate_rank.has_value() &&
+        delivery_candidate_rank.has_value() &&
+        pickup_candidate_rank.value() < delivery_candidate_rank.value()) {
+      const auto path_lb = path_lower_bound(pickup_rank,
+                                            pickup_candidate_rank.value(),
+                                            delivery_candidate_rank.value());
+      if (path_lb.has_value()) {
+        lower_bound = path_lb.value();
+      }
+    }
+    // Reject only when the path lower bound exceeds the cap.
+    if (lower_bound > input.jobs[pickup_rank].max_transit_time.value()) {
+      return false;
+    }
+  }
+
+  // Also check constrained shipment pairs where both halves are external to
+  // the trace (pickup in route[0..first_rank), delivery in
+  // route[last_rank..end)). The trace loop above misses these because neither
+  // half appears as a trace event: this happens when only unrelated jobs are
+  // inserted between an existing pickup/delivery pair. Path lower bound only.
+  for (Index i = 0; i < first_rank; ++i) {
+    const Index job_r = route[i];
+    if (input.jobs[job_r].type != JOB_TYPE::PICKUP ||
+        !input.jobs[job_r].max_transit_time.has_value()) {
+      continue;
+    }
+    const Index pickup_rank = job_r;
+    if (std::ranges::find(checked_pickups, pickup_rank) !=
+        checked_pickups.end()) {
+      continue;
+    }
+    const Index delivery_rank = pickup_rank + 1;
+    std::optional<Index> delivery_ext_rank;
+    for (Index j = last_rank; j < route.size(); ++j) {
+      if (route[j] == delivery_rank) {
+        delivery_ext_rank = j;
+        break;
+      }
+    }
+    if (!delivery_ext_rank.has_value()) {
+      continue;
+    }
+    checked_pickups.push_back(pickup_rank);
+    const Index removed_count = last_rank - first_rank;
+    const Index pcr = i;
+    const Index dcr =
+      delivery_ext_rank.value() + inserted_job_count - removed_count;
+    if (pcr >= dcr) {
+      continue;
+    }
+    const auto path_lb = path_lower_bound(pickup_rank, pcr, dcr);
+    if (path_lb.has_value() &&
+        path_lb.value() > input.jobs[pickup_rank].max_transit_time.value()) {
+      return false;
+    }
+  }
+  return true;
+}
+
 template <std::forward_iterator Iter>
 bool TWRoute::is_valid_addition_for_tw(const Input& input,
                                        const Amount& delivery,
@@ -696,6 +899,35 @@ bool TWRoute::is_valid_addition_for_tw(const Input& input,
   // Override this value if vehicle does not need this check anyway to
   // spare some work.
   check_max_load = v.has_break_max_load && check_max_load;
+
+  // Gate trace recording and the cap checks: when no constrained pickups
+  // are currently in the route (constrained_job_count_ == 0) and no inserted
+  // job is a constrained pickup, no cap pair can span this route.
+  // Mirror of the has_break_max_load idiom for the max_load check above.
+  bool any_inserted_constrained = false;
+  if (input.has_max_transit_time() && constrained_job_count_ == 0) {
+    for (auto it = first_job; it != last_job; ++it) {
+      const auto& ij = input.jobs[*it];
+      if (ij.type == JOB_TYPE::PICKUP && ij.max_transit_time.has_value()) {
+        any_inserted_constrained = true;
+        break;
+      }
+    }
+  }
+  const bool filter_max_transit_time =
+    input.has_max_transit_time() &&
+    (constrained_job_count_ > 0 || any_inserted_constrained);
+
+  const auto inserted_job_count =
+    static_cast<size_t>(std::distance(first_job, last_job));
+  // Reused per-thread scratch, cleared each call; nothing holds a reference
+  // across calls (same contract as the engine's tls buffers).
+  static thread_local std::vector<TraceEvent> trace;
+  trace.clear();
+  if (filter_max_transit_time) {
+    trace.reserve(inserted_job_count + breaks_counts[last_rank] -
+                  (breaks_counts[first_rank] - breaks_at_rank[first_rank]));
+  }
 
   PreviousInfo current(0, 0);
   NextInfo next(0, 0);
@@ -796,6 +1028,13 @@ bool TWRoute::is_valid_addition_for_tw(const Input& input,
         current.earliest = b_tw->start;
       }
 
+      if (filter_max_transit_time) {
+        trace.push_back({TraceEvent::Kind::BREAK,
+                         current_break,
+                         current.earliest,
+                         b.service,
+                         std::numeric_limits<Index>::max()});
+      }
       current.earliest += b.service;
 
       ++current_break;
@@ -815,12 +1054,18 @@ bool TWRoute::is_valid_addition_for_tw(const Input& input,
       if (j_tw == j.tws.end()) {
         return false;
       }
-      const auto job_action_time = (j.index() == current.location_index)
-                                     ? j.services[v_type]
-                                     : j.setups[v_type] + j.services[v_type];
+      const auto job_action_time =
+        action_time_for(j, v_type, current.location_index);
+      current.earliest = std::max(current.earliest, j_tw->start);
+      if (filter_max_transit_time) {
+        trace.push_back({TraceEvent::Kind::JOB,
+                         *current_job,
+                         current.earliest,
+                         job_action_time,
+                         j.index()});
+      }
       current.location_index = j.index();
-      current.earliest =
-        std::max(current.earliest, j_tw->start) + job_action_time;
+      current.earliest += job_action_time;
 
       if (check_max_load) {
         assert(j.delivery <= current_load);
@@ -839,9 +1084,8 @@ bool TWRoute::is_valid_addition_for_tw(const Input& input,
     // We still have both jobs and breaks to go through, so decide on
     // ordering.
     const auto& b = v.breaks[current_break];
-    const auto job_action_time = (j.index() == current.location_index)
-                                   ? j.services[v_type]
-                                   : j.setups[v_type] + j.services[v_type];
+    const auto job_action_time =
+      action_time_for(j, v_type, current.location_index);
 
     // Use next info after insertion range for ordering decision,
     // except if there are still jobs to insert after j, in which case
@@ -889,16 +1133,29 @@ bool TWRoute::is_valid_addition_for_tw(const Input& input,
         current.earliest = oc.b_tw->start;
       }
 
+      if (filter_max_transit_time) {
+        trace.push_back({TraceEvent::Kind::BREAK,
+                         current_break,
+                         current.earliest,
+                         b.service,
+                         std::numeric_limits<Index>::max()});
+      }
       current.earliest += b.service;
 
       ++current_break;
     }
     if (oc.add_job_first) {
-      current.location_index = j.index();
-
       current.earliest =
-        std::max(current.earliest + current.travel, oc.j_tw->start) +
-        job_action_time;
+        std::max(current.earliest + current.travel, oc.j_tw->start);
+      if (filter_max_transit_time) {
+        trace.push_back({TraceEvent::Kind::JOB,
+                         *current_job,
+                         current.earliest,
+                         job_action_time,
+                         j.index()});
+      }
+      current.location_index = j.index();
+      current.earliest += job_action_time;
 
       if (check_max_load) {
         assert(j.delivery <= current_load);
@@ -987,7 +1244,20 @@ bool TWRoute::is_valid_addition_for_tw(const Input& input,
     }
   }
 
-  return current.earliest + next.travel <= next.latest;
+  if (current.earliest + next.travel > next.latest) {
+    return false;
+  }
+  if (!filter_max_transit_time) {
+    return true;
+  }
+
+  // Margin filter: proven-sound rejections only. A move that survives this
+  // may still break a cap; nothing here accepts a move as compliant.
+  return check_max_transit_time(input,
+                                trace,
+                                first_rank,
+                                last_rank,
+                                static_cast<Index>(inserted_job_count));
 }
 
 template <std::random_access_iterator Iter>
@@ -1074,6 +1344,21 @@ void TWRoute::replace(const Input& input,
         fwd_smallest_breaks_load_margin[i][a] =
           std::numeric_limits<Capacity>::max();
       }
+    }
+  }
+
+  // Maintain constrained_job_count_: decrement for constrained pickups
+  // removed from [first_rank, last_rank), increment for those inserted.
+  for (Index r = first_rank; r < last_rank; ++r) {
+    const auto& rj = input.jobs[route[r]];
+    if (rj.type == JOB_TYPE::PICKUP && rj.max_transit_time.has_value()) {
+      --constrained_job_count_;
+    }
+  }
+  for (auto it = first_job; it != last_job; ++it) {
+    const auto& ij = input.jobs[*it];
+    if (ij.type == JOB_TYPE::PICKUP && ij.max_transit_time.has_value()) {
+      ++constrained_job_count_;
     }
   }
 

--- a/src/structures/vroom/tw_route.cpp
+++ b/src/structures/vroom/tw_route.cpp
@@ -23,6 +23,10 @@ Duration saturating_add(const Duration lhs, const Duration rhs) {
            : lhs + rhs;
 }
 
+Duration saturating_sub(const Duration lhs, const Duration rhs) {
+  return (lhs <= rhs) ? 0 : lhs - rhs;
+}
+
 // Setup only applies when the vehicle arrives from a different location;
 // action time is service plus that conditional setup.
 Duration action_time_for(const Job& j,
@@ -89,6 +93,127 @@ bool apply_break_latest(const Break& b,
   }
   return true;
 }
+
+// ---------------------------------------------------------------------------
+// Cap-aware scheduler engine: shared forward-simulation helper.
+//
+// Runs an ASAP forward pass over job_seq[from_pos..N) where N = job_seq.size().
+// For each job position pos, first processes brk_cnt[pos] breaks (vehicle-break
+// ranks brk_fst[pos]..brk_fst[pos]+brk_cnt[pos]-1) then the job itself.
+//
+// Parameters entering from_pos's break slot:
+//   cur_dep      : departure time of the preceding stop (job or vehicle start)
+//   cur_loc      : predecessor job location (or
+//   std::numeric_limits<Index>::max()
+//                  when there is no predecessor with a known location)
+//   rem_travel   : remaining leg travel on the current leg (from cur_loc to
+//                  job_seq[from_pos]'s location), for break absorption
+//
+// Fills S[], A[], dep[], tw_idx[], loc[], break_S[].
+// Returns false if any job or break cannot fit in its TWs (infeasible).
+// ---------------------------------------------------------------------------
+bool cap_asap_forward(const Input& input,
+                      const Vehicle& v,
+                      const Index v_type,
+                      const Duration v_end,
+                      const std::vector<Index>& job_seq,
+                      const std::vector<unsigned>& brk_cnt,
+                      const std::vector<unsigned>& brk_fst,
+                      const std::size_t from_pos,
+                      Duration cur_dep,
+                      Index cur_loc,
+                      Duration rem_travel,
+                      std::vector<Duration>& S,
+                      std::vector<Duration>& A,
+                      std::vector<Duration>& dep,
+                      std::vector<std::size_t>& tw_idx,
+                      std::vector<Index>& loc,
+                      std::vector<Duration>& break_S) {
+  const std::size_t N = job_seq.size();
+  for (std::size_t pos = from_pos; pos < N; ++pos) {
+    // Process breaks before job at pos.
+    for (unsigned b = 0; b < brk_cnt[pos]; ++b) {
+      const unsigned brk_rank = brk_fst[pos] + b;
+      if (!apply_break_earliest(v.breaks[brk_rank],
+                                cur_dep,
+                                rem_travel,
+                                break_S[brk_rank])) {
+        return false;
+      }
+    }
+
+    // Process job at pos.
+    const Index job_rank = job_seq[pos];
+    const auto& j = input.jobs[job_rank];
+    const Index job_loc = j.index();
+    const Duration arrival = saturating_add(cur_dep, rem_travel);
+
+    const auto j_tw_it = first_reachable_tw(j.tws, arrival);
+    if (j_tw_it == j.tws.end()) {
+      return false;
+    }
+    const std::size_t sel_tw =
+      static_cast<std::size_t>(j_tw_it - j.tws.begin());
+    S[pos] = std::max(arrival, j_tw_it->start);
+    tw_idx[pos] = sel_tw;
+    const Duration action = action_time_for(j, v_type, cur_loc);
+    A[pos] = action;
+    dep[pos] = saturating_add(S[pos], action);
+    loc[pos] = job_loc;
+    cur_dep = dep[pos];
+    cur_loc = job_loc;
+
+    if (pos + 1 < N) {
+      rem_travel = v.duration(job_loc, input.jobs[job_seq[pos + 1]].index());
+    }
+  }
+
+  // Process terminal breaks (after the last job, before the vehicle end),
+  // mirroring fwd_update_earliest_from's handling of breaks_at_rank[N].
+  // brk_cnt has size N+1; slot N holds the terminal break count.
+  const Duration end_travel =
+    v.has_end() ? v.duration(cur_loc, v.end.value().index()) : 0;
+  Duration term_rem = end_travel;
+  for (unsigned b = 0; b < brk_cnt[N]; ++b) {
+    const unsigned brk_rank = brk_fst[N] + b;
+    if (!apply_break_earliest(v.breaks[brk_rank],
+                              cur_dep,
+                              term_rem,
+                              break_S[brk_rank])) {
+      return false;
+    }
+  }
+  // Check vehicle end feasibility (mirrors fwd_update_earliest_from's
+  // assert(earliest_end <= v_end) and the current.earliest + next.travel >
+  // next.latest guard in is_valid_addition_for_tw).
+  if (v.has_end() && saturating_add(cur_dep, term_rem) > v_end) {
+    return false;
+  }
+  return true;
+}
+
+// Scratch buffers for compute_cap_compliant_schedule (candidate overload),
+// avoiding per-call allocations on a path hit millions of times per solve.
+// Reuse contract: every buffer is cleared or assign()-initialized at the
+// start of each call, no reference outlives a call (the function returns by
+// value), and thread_local rules out cross-thread aliasing.
+struct CapPairBuf {
+  std::size_t p_pos;
+  std::size_t d_pos;
+  Duration cap;
+};
+
+thread_local std::vector<Index> tls_job_seq;
+thread_local std::vector<unsigned> tls_brk_cnt;
+thread_local std::vector<unsigned> tls_brk_fst;
+thread_local std::vector<Duration> tls_S;
+thread_local std::vector<Duration> tls_A;
+thread_local std::vector<Duration> tls_dep;
+thread_local std::vector<std::size_t> tls_tw_idx;
+thread_local std::vector<Index> tls_loc;
+thread_local std::vector<Duration> tls_break_S;
+thread_local std::vector<Index> tls_pred_loc;
+thread_local std::vector<CapPairBuf> tls_pairs;
 
 } // namespace
 
@@ -883,6 +1008,480 @@ bool TWRoute::check_max_transit_time(const Input& input,
   return true;
 }
 
+// ---------------------------------------------------------------------------
+// Cap-aware scheduler engine: whole-route overload. The committed route is
+// the degenerate candidate: an empty insertion range at rank 0 leaves the
+// entire route as suffix, so one implementation serves both.
+// ---------------------------------------------------------------------------
+std::optional<std::vector<Duration>> TWRoute::compute_cap_compliant_schedule(
+  const Input& input,
+  const std::size_t iter_budget_factor) const {
+  assert(!route.empty());
+  return compute_cap_compliant_schedule(input,
+                                        std::vector<TraceEvent>(),
+                                        0,
+                                        0,
+                                        0,
+                                        iter_budget_factor);
+}
+
+// ---------------------------------------------------------------------------
+// Cap-aware scheduler engine: virtual-candidate overload.
+// ---------------------------------------------------------------------------
+std::optional<std::vector<Duration>> TWRoute::compute_cap_compliant_schedule(
+  const Input& input,
+  const std::vector<TraceEvent>& trace,
+  const Index first_rank,
+  const Index last_rank,
+  const Index inserted_job_count,
+  const std::size_t iter_budget_factor) const {
+
+  const auto& v = input.vehicles[v_rank];
+  const Index NO_LOC = std::numeric_limits<Index>::max();
+
+  // -------------------------------------------------------------------------
+  // Build the virtual job sequence and break layout from:
+  //   route[0..first_rank)  : prefix (committed, unchanged)
+  //   trace JOB events      : insertion range (with trace BREAK events)
+  //   route[last_rank..)    : suffix (committed, unchanged)
+  //
+  // Trace BREAK events carry vehicle-break ranks in
+  //   [breaks_counts[first_rank]-breaks_at_rank[first_rank],
+  //   breaks_counts[last_rank]-1].
+  // All committed breaks at positions first_rank..last_rank ARE in the trace;
+  // suffix positions > last_rank use their committed layout.
+  // -------------------------------------------------------------------------
+  const std::size_t removed_count = last_rank - first_rank;
+  const std::size_t virt_N = route.size() + inserted_job_count - removed_count;
+
+  if (virt_N == 0) {
+    return std::vector<Duration>{};
+  }
+
+  // Reuse thread_local scratch buffers; Invariant 5: no cross-call aliasing
+  // (function returns by value; callers hold no references to these vectors).
+  auto& job_seq = tls_job_seq;
+  auto& brk_cnt = tls_brk_cnt;
+  auto& brk_fst = tls_brk_fst;
+  job_seq.clear();
+  brk_cnt.clear();
+  brk_fst.clear();
+  job_seq.reserve(virt_N);
+  brk_cnt.reserve(virt_N + 1);
+  brk_fst.reserve(virt_N + 1);
+
+  // Prefix: route[0..first_rank).
+  for (Index r = 0; r < first_rank; ++r) {
+    job_seq.push_back(route[r]);
+    brk_cnt.push_back(breaks_at_rank[r]);
+    brk_fst.push_back(breaks_counts[r] - breaks_at_rank[r]);
+  }
+
+  // Insertion range: parse trace for JOB events with preceding BREAKs.
+  // Contiguous BREAK events before each JOB → (brk_fst, brk_cnt) pair.
+  unsigned trace_cur_brk_fst = 0;
+  unsigned trace_cur_brk_cnt = 0;
+  unsigned trailing_brk_fst = 0;
+  unsigned trailing_brk_cnt = 0;
+  bool have_pending_break = false;
+
+  for (const auto& ev : trace) {
+    if (ev.kind == TraceEvent::Kind::BREAK) {
+      if (!have_pending_break) {
+        trace_cur_brk_fst = static_cast<unsigned>(ev.rank);
+        have_pending_break = true;
+      }
+      ++trace_cur_brk_cnt;
+    } else { // JOB
+      job_seq.push_back(ev.rank);
+      brk_cnt.push_back(trace_cur_brk_cnt);
+      brk_fst.push_back(trace_cur_brk_cnt > 0 ? trace_cur_brk_fst : 0);
+      trace_cur_brk_fst = 0;
+      trace_cur_brk_cnt = 0;
+      have_pending_break = false;
+    }
+  }
+  // Trailing breaks after last trace JOB → go before first suffix job.
+  trailing_brk_cnt = trace_cur_brk_cnt;
+  trailing_brk_fst = (trace_cur_brk_cnt > 0) ? trace_cur_brk_fst : 0;
+
+  // With an empty edit (no trace, empty insertion range) no committed
+  // position was replaced, so no break ever entered a trace and every slot
+  // reads the committed layout; the whole-route overload reduces to this.
+  const bool empty_edit = trace.empty() && first_rank == last_rank;
+
+  // Suffix: route[last_rank..route.size()).
+  for (Index r = last_rank; r < static_cast<Index>(route.size()); ++r) {
+    job_seq.push_back(route[r]);
+    if (r == last_rank && !empty_edit) {
+      // Breaks at committed position last_rank were processed by order_choice
+      // inside the insertion range and appear in the trace (possibly as
+      // trailing trace BREAKs). Use trailing trace breaks here.
+      brk_cnt.push_back(trailing_brk_cnt);
+      brk_fst.push_back(trailing_brk_fst);
+    } else {
+      // r > last_rank: committed breaks NOT in the trace.
+      brk_cnt.push_back(breaks_at_rank[r]);
+      brk_fst.push_back(breaks_counts[r] - breaks_at_rank[r]);
+    }
+  }
+
+  assert(job_seq.size() == virt_N);
+
+  // Terminal slot (index virt_N): breaks after the last virtual job.
+  // When a suffix exists, terminal breaks are the committed terminal breaks
+  // (not covered by the trace range). When no suffix, all breaks including
+  // terminal were routed through order_choice into the trace, so trailing
+  // trace breaks ARE the committed terminal breaks.
+  if (empty_edit || last_rank < static_cast<Index>(route.size())) {
+    brk_cnt.push_back(breaks_at_rank[route.size()]);
+    brk_fst.push_back(breaks_counts[route.size()] -
+                      breaks_at_rank[route.size()]);
+  } else {
+    brk_cnt.push_back(trailing_brk_cnt);
+    brk_fst.push_back(trailing_brk_fst);
+  }
+  // Every vehicle break is assigned to exactly one virtual-route slot.
+  // Rank agreement with the layout replace() later commits is not asserted
+  // here; output realization re-certifies the schedule against the
+  // committed layout, so any divergence surfaces there rather than
+  // silently.
+  {
+    unsigned total = 0;
+    for (const auto c : brk_cnt) {
+      total += c;
+    }
+    assert(total == static_cast<unsigned>(v.breaks.size()));
+  }
+
+  // Mutable schedule state: thread_local scratch buffers (Invariants 2 to 4:
+  // assign/resize here; zero-init via assign where the algorithm requires it).
+  auto& S = tls_S;
+  auto& A = tls_A;
+  auto& dep = tls_dep;
+  auto& tw_idx = tls_tw_idx;
+  auto& loc = tls_loc;
+  auto& break_S = tls_break_S;
+  S.resize(virt_N);
+  A.resize(virt_N);
+  dep.resize(virt_N);
+  tw_idx.assign(virt_N, 0); // Invariant 2: must zero-init each call.
+  loc.resize(virt_N);
+  break_S.assign(v.breaks.size(), 0); // Invariant 3: must zero-init each call.
+
+  // Initial ASAP pass. With a committed prefix (first_rank > 0), positions
+  // 0..first_rank-1 are not re-simulated: cap_asap_forward mirrors
+  // fwd_update_earliest_from, so their ASAP values equal the committed
+  // earliest[]/action_time[] arrays and the forward pass can start at
+  // first_rank. Any returned schedule is still re-verified from scratch by
+  // the self-verification block below, so seeding can only cause rejection,
+  // never a false acceptance.
+  const Index init_loc = has_start ? v.start.value().index() : NO_LOC;
+
+  if (first_rank > 0) {
+    // First break index at position first_rank in the virtual route, by the
+    // cumulative-count invariant maintained in replace(). Breaks before it
+    // are committed prefix breaks; later ones are filled by cap_asap_forward.
+    const Index B_fst = breaks_counts[first_rank] - breaks_at_rank[first_rank];
+    for (Index b = 0; b < B_fst; ++b) {
+      break_S[b] = break_earliest[b];
+    }
+
+    for (Index r = 0; r < first_rank; ++r) {
+      const auto& j = input.jobs[job_seq[r]];
+      S[r] = earliest[r];
+      A[r] = action_time[r];
+      dep[r] = saturating_add(earliest[r], action_time[r]);
+      loc[r] = j.index();
+      // Committed route validity guarantees earliest[r] lies inside the TW
+      // selected when the route was built, so the first window whose end
+      // covers it is exactly the one cap_asap_forward would pick.
+      const auto j_tw_it = std::ranges::find_if(j.tws, [&](const auto& tw) {
+        return earliest[r] <= tw.end;
+      });
+      assert(j_tw_it != j.tws.end());
+      assert(j_tw_it->start <= earliest[r]);
+      tw_idx[r] = static_cast<std::size_t>(j_tw_it - j.tws.begin());
+    }
+
+    if (first_rank < virt_N) {
+      // Depart from the last committed prefix job. When first_rank == virt_N
+      // (pure suffix removal, no insertion) there is nothing to simulate
+      // after the prefix; self-verification below still checks vehicle end.
+      const Duration seed_dep = dep[first_rank - 1];
+      const Index seed_loc = loc[first_rank - 1];
+      const Duration seed_rem =
+        v.duration(seed_loc, input.jobs[job_seq[first_rank]].index());
+
+      if (!cap_asap_forward(input,
+                            v,
+                            v_type,
+                            v_end,
+                            job_seq,
+                            brk_cnt,
+                            brk_fst,
+                            first_rank,
+                            seed_dep,
+                            seed_loc,
+                            seed_rem,
+                            S,
+                            A,
+                            dep,
+                            tw_idx,
+                            loc,
+                            break_S)) {
+        return std::nullopt;
+      }
+    }
+  } else {
+    // No prefix: start from vehicle origin.
+    const Duration init_rem =
+      (init_loc != NO_LOC)
+        ? v.duration(init_loc, input.jobs[job_seq[0]].index())
+        : 0;
+    if (!cap_asap_forward(input,
+                          v,
+                          v_type,
+                          v_end,
+                          job_seq,
+                          brk_cnt,
+                          brk_fst,
+                          0,
+                          v_start,
+                          init_loc,
+                          init_rem,
+                          S,
+                          A,
+                          dep,
+                          tw_idx,
+                          loc,
+                          break_S)) {
+      return std::nullopt;
+    }
+  }
+
+  // Build constrained-pair list for the virtual route.
+  // Invariant 1: pairs.clear() before the loop; must not be moved after.
+  auto& pairs = tls_pairs;
+  pairs.clear();
+  for (std::size_t pos = 0; pos < virt_N; ++pos) {
+    const Index job_rank = job_seq[pos];
+    const auto& j = input.jobs[job_rank];
+    if (j.type != JOB_TYPE::PICKUP || !j.max_transit_time.has_value()) {
+      continue;
+    }
+    const Index del_input_rank = job_rank + 1;
+    for (std::size_t d = pos + 1; d < virt_N; ++d) {
+      if (job_seq[d] == del_input_rank) {
+        pairs.push_back({pos, d, j.max_transit_time.value()});
+        break;
+      }
+    }
+  }
+
+  const std::size_t K = pairs.size();
+  // A factor of 0 removes the budget: service starts are monotone
+  // non-decreasing and bounded by time-window ends, so the fixpoint
+  // terminates without it. Realization retries use that.
+  const std::size_t max_iters = (iter_budget_factor == 0)
+                                  ? std::numeric_limits<std::size_t>::max()
+                                  : iter_budget_factor * (2 * K + 2);
+
+  // Fixpoint loop.
+  bool found_compliant = false;
+  for (std::size_t outer = 0;; ++outer) {
+    Duration worst_excess = 0;
+    const CapPairBuf* worst = nullptr;
+    for (const auto& pr : pairs) {
+      const Duration transit_time = saturating_sub(S[pr.d_pos], dep[pr.p_pos]);
+      const Duration excess = saturating_sub(transit_time, pr.cap);
+      if (excess > worst_excess) {
+        worst_excess = excess;
+        worst = &pr;
+      }
+    }
+    if (worst == nullptr) {
+      found_compliant = true;
+      break;
+    }
+    if (outer >= max_iters) {
+      break;
+    }
+
+    const std::size_t P = worst->p_pos;
+    const auto& pickup_j = input.jobs[job_seq[P]];
+
+    Duration candidate_S = saturating_add(S[P], worst_excess);
+    std::size_t attempt_tw = tw_idx[P];
+
+    while (candidate_S > pickup_j.tws[attempt_tw].end) {
+      ++attempt_tw;
+      if (attempt_tw >= pickup_j.tws.size()) {
+        return std::nullopt;
+      }
+      // The required delay is a lower bound on the pickup start; entering a
+      // later window must not undershoot it.
+      candidate_S = std::max(candidate_S, pickup_j.tws[attempt_tw].start);
+    }
+
+    S[P] = candidate_S;
+    tw_idx[P] = attempt_tw;
+    dep[P] = saturating_add(S[P], A[P]);
+
+    const Duration next_rem =
+      v.duration(loc[P], input.jobs[job_seq[P + 1]].index());
+    if (!cap_asap_forward(input,
+                          v,
+                          v_type,
+                          v_end,
+                          job_seq,
+                          brk_cnt,
+                          brk_fst,
+                          P + 1,
+                          dep[P],
+                          loc[P],
+                          next_rem,
+                          S,
+                          A,
+                          dep,
+                          tw_idx,
+                          loc,
+                          break_S)) {
+      return std::nullopt;
+    }
+  }
+
+  if (!found_compliant) {
+    return std::nullopt;
+  }
+
+  // Self-verification: rebuild the schedule from raw input and check it.
+  {
+    Duration sv_dep = v_start;
+    Index sv_loc = init_loc;
+    // Invariant 4: pred_loc.assign(virt_N, NO_LOC) zero-inits each call.
+    auto& pred_loc = tls_pred_loc;
+    pred_loc.assign(virt_N, NO_LOC);
+
+    for (std::size_t pos = 0; pos < virt_N; ++pos) {
+      const Index job_rank = job_seq[pos];
+      const auto& j = input.jobs[job_rank];
+      const Index job_loc = j.index();
+
+      Duration rem = (sv_loc != NO_LOC) ? v.duration(sv_loc, job_loc) : 0;
+
+      for (unsigned b = 0; b < brk_cnt[pos]; ++b) {
+        const unsigned brk_rank = brk_fst[pos] + b;
+        const auto& bk = v.breaks[brk_rank];
+        const Duration bS = break_S[brk_rank];
+        if (sv_dep > bS) {
+          return std::nullopt;
+        }
+        const auto b_tw = std::ranges::find_if(bk.tws, [&](const auto& tw) {
+          return bS <= tw.end;
+        });
+        if (b_tw == bk.tws.end() || bS < b_tw->start) {
+          return std::nullopt;
+        }
+        if (sv_dep < bS) {
+          const Duration margin = bS - sv_dep;
+          rem = (margin < rem) ? rem - margin : 0;
+        }
+        sv_dep = saturating_add(bS, bk.service);
+      }
+
+      const Duration arrival = saturating_add(sv_dep, rem);
+      if (arrival > S[pos]) {
+        return std::nullopt;
+      }
+      const auto& tw = j.tws[tw_idx[pos]];
+      if (S[pos] < tw.start || S[pos] > tw.end) {
+        return std::nullopt;
+      }
+      pred_loc[pos] = sv_loc;
+      const Duration A_raw = action_time_for(j, v_type, sv_loc);
+      sv_dep = saturating_add(S[pos], A_raw);
+      sv_loc = job_loc;
+    }
+
+    for (const auto& pr : pairs) {
+      const auto& pj = input.jobs[job_seq[pr.p_pos]];
+      const Duration A_P_raw = action_time_for(pj, v_type, pred_loc[pr.p_pos]);
+      const Duration dep_P = saturating_add(S[pr.p_pos], A_P_raw);
+      if (S[pr.d_pos] < dep_P) {
+        return std::nullopt;
+      }
+      const Duration transit_time = S[pr.d_pos] - dep_P;
+      if (transit_time > pr.cap) {
+        return std::nullopt;
+      }
+    }
+
+    // Self-verify terminal breaks (after last virtual job, before vehicle end).
+    const Duration term_end_travel =
+      v.has_end() ? v.duration(sv_loc, v.end.value().index()) : 0;
+    Duration term_rem = term_end_travel;
+    for (unsigned b = 0; b < brk_cnt[virt_N]; ++b) {
+      const unsigned brk_rank = brk_fst[virt_N] + b;
+      const auto& bk = v.breaks[brk_rank];
+      const Duration bS = break_S[brk_rank];
+      if (sv_dep > bS) {
+        return std::nullopt; // Arrival past terminal break service start.
+      }
+      const auto b_tw = std::ranges::find_if(bk.tws, [&](const auto& tw) {
+        return bS <= tw.end;
+      });
+      if (b_tw == bk.tws.end() || bS < b_tw->start) {
+        return std::nullopt; // Terminal break outside any TW.
+      }
+      if (sv_dep < bS) {
+        const Duration margin = bS - sv_dep;
+        term_rem = (margin < term_rem) ? term_rem - margin : 0;
+      }
+      sv_dep = saturating_add(bS, bk.service);
+    }
+    // Self-verify vehicle end feasibility.
+    if (v.has_end() && saturating_add(sv_dep, term_rem) > v_end) {
+      return std::nullopt;
+    }
+  }
+
+  return std::vector<Duration>(S.begin(), S.end());
+}
+
+std::optional<std::vector<Duration>> TWRoute::realize_cap_compliant_schedule(
+  const Input& input,
+  std::vector<Duration>* break_starts) const {
+  // The counter gates enforcement, so a bookkeeping slip in replace()
+  // would disable it silently; reconcile against route contents here, off
+  // the hot path (once per route at output), since default builds keep
+  // asserts enabled.
+  assert(
+    !input.has_max_transit_time() ||
+    constrained_job_count_ ==
+      static_cast<Index>(std::ranges::count_if(route, [&input](const Index r) {
+        const auto& j = input.jobs[r];
+        return j.type == JOB_TYPE::PICKUP && j.max_transit_time.has_value();
+      })));
+  if (!input.has_max_transit_time() || constrained_job_count_ == 0) {
+    return std::nullopt;
+  }
+  auto sched = compute_cap_compliant_schedule(input);
+  if (!sched.has_value()) {
+    // Realization runs once per route at output time, off the hot path, and
+    // a failure here would otherwise surface as an internal error. Retry
+    // without an iteration budget: extra iterations only continue the same
+    // monotone trajectory and recover deep pair interactions the hot-path
+    // budget truncates.
+    sched = compute_cap_compliant_schedule(input, 0);
+  }
+  if (sched.has_value() && break_starts != nullptr) {
+    // tls_break_S was filled by the successful engine run on this thread.
+    *break_starts = tls_break_S;
+  }
+  return sched;
+}
+
 template <std::forward_iterator Iter>
 bool TWRoute::is_valid_addition_for_tw(const Input& input,
                                        const Amount& delivery,
@@ -1251,13 +1850,154 @@ bool TWRoute::is_valid_addition_for_tw(const Input& input,
     return true;
   }
 
-  // Margin filter: proven-sound rejections only. A move that survives this
-  // may still break a cap; nothing here accepts a move as compliant.
-  return check_max_transit_time(input,
-                                trace,
-                                first_rank,
-                                last_rank,
-                                static_cast<Index>(inserted_job_count));
+  // Candidate-path lower bound: proven-sound rejections only. Optimistic
+  // acceptances pass through to the exact engine check below.
+  if (!check_max_transit_time(input,
+                              trace,
+                              first_rank,
+                              last_rank,
+                              static_cast<Index>(inserted_job_count))) {
+    return false;
+  }
+
+  // ASAP-witness short-circuit.
+  //
+  // When the ASAP schedule satisfies every constrained pair's cap, it is a
+  // sound feasibility witness and the full engine call is unnecessary.
+  //
+  // ASAP departure from a stop = earliest_start + action_time.
+  // Exact ASAP is available for:
+  //   prefix stops (rank < first_rank): committed earliest[] / action_time[].
+  //   trace JOB events:                ev.earliest / ev.action_time.
+  // Suffix stops have no exact ASAP without an engine forward pass.
+  //
+  // Three soundness invariants that must hold for every future code change:
+  //   I1. Witness may only ACCEPT (return true), never reject: any case that
+  //       cannot be proven safe must fall through to the engine below.
+  //   I2. Any constrained delivery at route rank >= last_rank (suffix) must
+  //       set witness_eligible = false; there is no exact ASAP for suffix
+  //       stops.
+  //   I3. Any constrained pickup at route rank >= last_rank also disqualifies;
+  //       its delivery is in the suffix too (pickup precedes delivery).
+  {
+    bool witness_eligible = true;
+    bool asap_all_ok = true;
+
+    // Returns the trace JOB event for the given input-job rank, or nullptr.
+    const auto trace_ev = [&](const Index job_rank) -> const TraceEvent* {
+      for (const auto& ev : trace) {
+        if (ev.kind == TraceEvent::Kind::JOB && ev.rank == job_rank)
+          return &ev;
+      }
+      return nullptr;
+    };
+    // Whether the given input-job rank appears in the candidate suffix.
+    const auto in_suffix = [&](const Index job_rank) {
+      for (Index r = last_rank; r < route.size(); ++r) {
+        if (route[r] == job_rank)
+          return true;
+      }
+      return false;
+    };
+
+    // Prefix pickups (rank < first_rank): delivery is in prefix or trace.
+    for (Index r = 0; r < first_rank && witness_eligible; ++r) {
+      const auto& j = input.jobs[route[r]];
+      if (j.type != JOB_TYPE::PICKUP || !j.max_transit_time.has_value())
+        continue;
+      const Index del_rank = route[r] + 1; // input rank of paired delivery
+      std::optional<Index> prefix_del_pos;
+      for (Index dr = r + 1; dr < first_rank; ++dr) {
+        if (route[dr] == del_rank) {
+          prefix_del_pos = dr;
+          break;
+        }
+      }
+      if (prefix_del_pos.has_value()) {
+        // Both stops in prefix. The committed route may be compliant only
+        // through a delayed schedule; the witness certifies the ASAP
+        // schedule, so an ASAP violation here means ASAP is not a valid
+        // whole-route witness and the engine must decide (Invariant I1:
+        // fall through, never reject).
+        const Duration depart_P = earliest[r] + action_time[r];
+        const Duration arrive_D = earliest[prefix_del_pos.value()];
+        if (arrive_D < depart_P ||
+            arrive_D - depart_P > j.max_transit_time.value())
+          asap_all_ok = false;
+        continue;
+      }
+      const TraceEvent* de = trace_ev(del_rank);
+      if (!de) {
+        if (in_suffix(del_rank)) {
+          // Delivery in suffix (Invariant I2): must not accept via witness.
+          witness_eligible = false;
+          break;
+        }
+        // Delivery absent from the candidate (being removed): the pair is
+        // incomplete and constrains nothing yet.
+        continue;
+      }
+      // Pickup in prefix (exact committed), delivery in trace (exact ASAP).
+      const Duration depart_P = earliest[r] + action_time[r];
+      if (de->earliest < depart_P ||
+          de->earliest - depart_P > j.max_transit_time.value())
+        asap_all_ok = false;
+    }
+
+    // Trace pickups: delivery must also appear in the trace for exact ASAP.
+    for (const auto& ev : trace) {
+      if (!witness_eligible)
+        break;
+      if (ev.kind != TraceEvent::Kind::JOB)
+        continue;
+      const auto& j = input.jobs[ev.rank];
+      if (j.type != JOB_TYPE::PICKUP || !j.max_transit_time.has_value())
+        continue;
+      const TraceEvent* de = trace_ev(ev.rank + 1);
+      if (!de) {
+        if (in_suffix(ev.rank + 1)) {
+          // Delivery in suffix (Invariant I2): must not accept via witness.
+          witness_eligible = false;
+          break;
+        }
+        // Delivery absent from the candidate: the pair is incomplete and
+        // constrains nothing yet. Half-pair insertion probes
+        // (insertion_search evaluates the pickup alone before the full
+        // pair) land here and keep the witness fast path.
+        continue;
+      }
+      if (!asap_all_ok)
+        continue; // Already failing; finish eligibility scan before returning.
+      const Duration depart_P = ev.earliest + ev.action_time;
+      if (de->earliest < depart_P ||
+          de->earliest - depart_P > j.max_transit_time.value())
+        asap_all_ok = false;
+    }
+
+    // Suffix pickups (Invariant I3): disqualify witness.
+    if (witness_eligible) {
+      for (Index r = last_rank;
+           r < static_cast<Index>(route.size()) && witness_eligible;
+           ++r) {
+        const auto& j = input.jobs[route[r]];
+        if (j.type == JOB_TYPE::PICKUP && j.max_transit_time.has_value() &&
+            in_suffix(route[r] + 1))
+          witness_eligible = false; // Invariant I3 (complete suffix pair).
+      }
+    }
+
+    if (witness_eligible && asap_all_ok)
+      return true; // ASAP schedule is a cap-compliant witness; engine skipped.
+    // Invariant I1: no return false here; fall through to the engine.
+  }
+
+  // Exact cap-aware engine: eliminates the optimistic acceptances.
+  return compute_cap_compliant_schedule(input,
+                                        trace,
+                                        first_rank,
+                                        last_rank,
+                                        static_cast<Index>(inserted_job_count))
+    .has_value();
 }
 
 template <std::random_access_iterator Iter>

--- a/src/structures/vroom/tw_route.cpp
+++ b/src/structures/vroom/tw_route.cpp
@@ -14,6 +14,82 @@ All rights reserved (see LICENSE).
 
 namespace vroom {
 
+namespace {
+
+Duration saturating_add(const Duration lhs, const Duration rhs) {
+  return (std::numeric_limits<Duration>::max() - lhs < rhs)
+           ? std::numeric_limits<Duration>::max()
+           : lhs + rhs;
+}
+
+// Setup only applies when the vehicle arrives from a different location;
+// action time is service plus that conditional setup.
+Duration action_time_for(const Job& j,
+                         const Index v_type,
+                         const Index previous_location) {
+  return (j.index() == previous_location)
+           ? j.services[v_type]
+           : j.setups[v_type] + j.services[v_type];
+}
+
+// First time window whose end can accommodate time t, or tws.end().
+std::vector<TimeWindow>::const_iterator
+first_reachable_tw(const std::vector<TimeWindow>& tws, const Duration t) {
+  return std::ranges::find_if(tws, [&](const auto& tw) { return t <= tw.end; });
+}
+
+// Apply one forward break step: from departure time t, place the break in
+// its first reachable time window, absorbing any wait into the remaining
+// travel of the current leg; record its start and advance t past its
+// service. Forward twin of apply_break_latest below. Returns false when no
+// window can take the break.
+bool apply_break_earliest(const Break& b,
+                          Duration& t,
+                          Duration& remaining_travel,
+                          Duration& break_start) {
+  const auto b_tw = first_reachable_tw(b.tws, t);
+  if (b_tw == b.tws.end()) {
+    return false;
+  }
+  if (t < b_tw->start) {
+    const auto margin = b_tw->start - t;
+    remaining_travel =
+      (margin < remaining_travel) ? remaining_travel - margin : 0;
+    t = b_tw->start;
+  }
+  break_start = t;
+  t = saturating_add(t, b.service);
+  return true;
+}
+
+// Apply one backward break step: subtract its service, select the last
+// compatible time window, clamp to its end and absorb that clamp in travel.
+// The result only changes the supplied local values, never route state.
+bool apply_break_latest(const Break& b,
+                        Duration& current_latest,
+                        Duration& remaining_travel) {
+  if (b.service > current_latest) {
+    return false;
+  }
+  current_latest -= b.service;
+
+  const auto b_tw =
+    std::find_if(b.tws.rbegin(), b.tws.rend(), [&](const auto& tw) {
+      return tw.start <= current_latest;
+    });
+  if (b_tw == b.tws.rend()) {
+    return false;
+  }
+  if (b_tw->end < current_latest) {
+    const auto margin = current_latest - b_tw->end;
+    remaining_travel =
+      (margin < remaining_travel) ? remaining_travel - margin : 0;
+    current_latest = b_tw->end;
+  }
+  return true;
+}
+} // namespace
+
 TWRoute::TWRoute(const Input& input, Index v, unsigned amount_size)
   : RawRoute(input, v, amount_size),
     v_start(input.vehicles[v].tw.start),
@@ -64,20 +140,12 @@ TWRoute::TWRoute(const Input& input, Index v, unsigned amount_size)
     const Index i = breaks.size() - 1 - r_i;
     const auto& b = breaks[i];
 
-    if (next_latest < b.service) {
-      throw InputException(break_error);
-    }
-    next_latest -= b.service;
-
-    const auto b_tw =
-      std::find_if(b.tws.rbegin(), b.tws.rend(), [&](const auto& tw) {
-        return tw.start <= next_latest;
-      });
-    if (b_tw == b.tws.rend()) {
+    Duration unused_travel = 0;
+    if (!apply_break_latest(b, next_latest, unused_travel)) {
       throw InputException(break_error);
     }
 
-    break_latest[i] = std::min(next_latest, b_tw->end);
+    break_latest[i] = next_latest;
 
     next_latest = break_latest[i];
 
@@ -148,43 +216,26 @@ void TWRoute::fwd_update_earliest_from(const Input& input, Index rank) {
     const auto& next_j = input.jobs[route[i]];
     Duration remaining_travel_time =
       v.duration(input.jobs[route[i - 1]].index(), next_j.index());
-    Duration previous_action_time = action_time[i - 1];
+    // Departure from the previous job; breaks advance it in place.
+    Duration current_departure = current_earliest + action_time[i - 1];
 
     // Update earliest dates and margins for breaks.
     assert(breaks_at_rank[i] <= breaks_counts[i]);
     Index break_rank = breaks_counts[i] - breaks_at_rank[i];
 
     for (Index r = 0; r < breaks_at_rank[i]; ++r, ++break_rank) {
-      const auto& b = v.breaks[break_rank];
-
-      current_earliest += previous_action_time;
-
-      const auto b_tw = std::ranges::find_if(b.tws, [&](const auto& tw) {
-        return current_earliest <= tw.end;
-      });
-      assert(b_tw != b.tws.end());
-
-      if (current_earliest < b_tw->start) {
-        if (const auto margin = b_tw->start - current_earliest;
-            margin < remaining_travel_time) {
-          remaining_travel_time -= margin;
-        } else {
-          remaining_travel_time = 0;
-        }
-
-        current_earliest = b_tw->start;
-      }
-
-      break_earliest[break_rank] = current_earliest;
-      previous_action_time = v.breaks[break_rank].service;
+      const bool break_is_valid =
+        apply_break_earliest(v.breaks[break_rank],
+                             current_departure,
+                             remaining_travel_time,
+                             break_earliest[break_rank]);
+      assert(break_is_valid);
     }
 
     // Back to the job after breaks.
-    current_earliest += previous_action_time + remaining_travel_time;
+    current_earliest = current_departure + remaining_travel_time;
 
-    const auto j_tw = std::ranges::find_if(next_j.tws, [&](const auto& tw) {
-      return current_earliest <= tw.end;
-    });
+    const auto j_tw = first_reachable_tw(next_j.tws, current_earliest);
     assert(j_tw != next_j.tws.end());
 
     current_earliest = std::max(current_earliest, j_tw->start);
@@ -212,37 +263,22 @@ void TWRoute::fwd_update_earliest_from(const Input& input, Index rank) {
         ? v.duration(input.jobs[route[i - 1]].index(), v.end.value().index())
         : 0;
 
-    Duration previous_action_time = action_time[i - 1];
+    // Departure from the last job; breaks advance it in place.
+    Duration current_departure = current_earliest + action_time[i - 1];
 
     assert(breaks_at_rank[i] <= breaks_counts[i]);
     Index break_rank = breaks_counts[i] - breaks_at_rank[i];
 
     for (Index r = 0; r < breaks_at_rank[i]; ++r, ++break_rank) {
-      const auto& b = v.breaks[break_rank];
-      current_earliest += previous_action_time;
-
-      const auto b_tw = std::ranges::find_if(b.tws, [&](const auto& tw) {
-        return current_earliest <= tw.end;
-      });
-      assert(b_tw != b.tws.end());
-
-      if (current_earliest < b_tw->start) {
-        if (const auto margin = b_tw->start - current_earliest;
-            margin < remaining_travel_time) {
-          remaining_travel_time -= margin;
-        } else {
-          remaining_travel_time = 0;
-        }
-
-        current_earliest = b_tw->start;
-      }
-
-      break_earliest[break_rank] = current_earliest;
-      previous_action_time = v.breaks[break_rank].service;
+      const bool break_is_valid =
+        apply_break_earliest(v.breaks[break_rank],
+                             current_departure,
+                             remaining_travel_time,
+                             break_earliest[break_rank]);
+      assert(break_is_valid);
     }
 
-    earliest_end =
-      current_earliest + previous_action_time + remaining_travel_time;
+    earliest_end = current_departure + remaining_travel_time;
     assert(earliest_end <= v_end);
   }
 }
@@ -266,25 +302,9 @@ void TWRoute::bwd_update_latest_from(const Input& input, Index rank) {
       --break_rank;
 
       const auto& b = v.breaks[break_rank];
-      assert(b.service <= current_latest);
-      current_latest -= b.service;
-
-      const auto b_tw =
-        std::find_if(b.tws.rbegin(), b.tws.rend(), [&](const auto& tw) {
-          return tw.start <= current_latest;
-        });
-      assert(b_tw != b.tws.rend());
-
-      if (b_tw->end < current_latest) {
-        if (const auto margin = current_latest - b_tw->end;
-            margin < remaining_travel_time) {
-          remaining_travel_time -= margin;
-        } else {
-          remaining_travel_time = 0;
-        }
-
-        current_latest = b_tw->end;
-      }
+      const bool break_is_valid =
+        apply_break_latest(b, current_latest, remaining_travel_time);
+      assert(break_is_valid);
 
       break_latest[break_rank] = current_latest;
     }
@@ -324,18 +344,10 @@ void TWRoute::bwd_update_latest_from(const Input& input, Index rank) {
     for (Index r = 0; r < breaks_at_rank[next_i]; ++r) {
       --break_rank;
       const auto& b = v.breaks[break_rank];
-
-      assert(b.service <= current_latest);
-      current_latest -= b.service;
-
-      const auto b_tw =
-        std::find_if(b.tws.rbegin(), b.tws.rend(), [&](const auto& tw) {
-          return tw.start <= current_latest;
-        });
-      assert(b_tw != b.tws.rend());
-      if (b_tw->end < current_latest) {
-        current_latest = b_tw->end;
-      }
+      Duration unused_travel = 0;
+      const bool break_is_valid =
+        apply_break_latest(b, current_latest, unused_travel);
+      assert(break_is_valid);
 
       break_latest[break_rank] = current_latest;
     }
@@ -353,25 +365,8 @@ void TWRoute::update_last_latest_date(const Input& input) {
   for (Index r = 0; r < breaks_at_rank[route.size()]; ++r) {
     --break_rank;
     const auto& b = v.breaks[break_rank];
-
-    assert(b.service <= next.latest);
-    next.latest -= b.service;
-
-    const auto b_tw =
-      std::find_if(b.tws.rbegin(), b.tws.rend(), [&](const auto& tw) {
-        return tw.start <= next.latest;
-      });
-    assert(b_tw != b.tws.rend());
-
-    if (b_tw->end < next.latest) {
-      if (const auto margin = next.latest - b_tw->end; margin < next.travel) {
-        next.travel -= margin;
-      } else {
-        next.travel = 0;
-      }
-
-      next.latest = b_tw->end;
-    }
+    const bool break_is_valid = apply_break_latest(b, next.latest, next.travel);
+    assert(break_is_valid);
 
     break_latest[break_rank] = next.latest;
   }
@@ -399,9 +394,7 @@ void TWRoute::fwd_update_action_time_from(const Input& input, Index rank) {
     const auto next_index = next_j.index();
 
     const auto next_action_time =
-      (next_index == current_index)
-        ? next_j.services[v_type]
-        : next_j.setups[v_type] + next_j.services[v_type];
+      action_time_for(next_j, v_type, current_index);
 
     action_time[i] = next_action_time;
     current_index = next_index;
@@ -643,9 +636,7 @@ OrderChoice TWRoute::order_choice(const Input& input,
                                                });
         d_tw != matching_d.tws.end()) {
       const auto matching_d_action_time =
-        (matching_d.index() == j.index())
-          ? matching_d.services[v_type]
-          : matching_d.setups[v_type] + matching_d.services[v_type];
+        action_time_for(matching_d, v_type, j.index());
 
       const Duration break_candidate =
         std::max(delivery_candidate, d_tw->start) + matching_d_action_time;
@@ -1209,9 +1200,8 @@ void TWRoute::replace(const Input& input,
       breaks_at_rank[current_job_rank] = breaks_before;
       breaks_counts[current_job_rank] = previous_breaks_counts + breaks_before;
 
-      action_time[current_job_rank] = (j.index() == current.location_index)
-                                        ? j.services[v_type]
-                                        : j.setups[v_type] + j.services[v_type];
+      action_time[current_job_rank] =
+        action_time_for(j, v_type, current.location_index);
       current.location_index = j.index();
       current.earliest += action_time[current_job_rank];
 
@@ -1235,9 +1225,8 @@ void TWRoute::replace(const Input& input,
     // ordering.
     const auto& b = v.breaks[current_break];
 
-    const auto job_action_time = (j.index() == current.location_index)
-                                   ? j.services[v_type]
-                                   : j.setups[v_type] + j.services[v_type];
+    const auto job_action_time =
+      action_time_for(j, v_type, current.location_index);
 
     // Use next info after insertion range for ordering decision,
     // except if there are still jobs to insert after j, in which case
@@ -1368,9 +1357,8 @@ void TWRoute::replace(const Input& input,
       // current_job_rank is the rank of the first non-replaced job.
       const auto& j = input.jobs[route[current_job_rank]];
 
-      const auto new_action_time = (j.index() == current.location_index)
-                                     ? j.services[v_type]
-                                     : j.setups[v_type] + j.services[v_type];
+      const auto new_action_time =
+        action_time_for(j, v_type, current.location_index);
       assert(action_time[current_job_rank] == j.services[v_type] ||
              action_time[current_job_rank] ==
                j.services[v_type] + j.setups[v_type]);

--- a/src/structures/vroom/tw_route.h
+++ b/src/structures/vroom/tw_route.h
@@ -10,6 +10,8 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <vector>
+
 #include "structures/typedefs.h"
 #include "structures/vroom/input/input.h"
 #include "structures/vroom/raw_route.h"
@@ -58,6 +60,19 @@ struct OrderChoice {
 
 class TWRoute : public RawRoute {
 private:
+  struct TraceEvent {
+    enum class Kind { JOB, BREAK } kind;
+    // Job input rank for jobs; vehicle-break rank for breaks.
+    Index rank;
+    // Service-start time selected by the forward simulation.
+    Duration earliest;
+    // Job setup plus service (or just service at the same location); break
+    // service for breaks.
+    Duration action_time;
+    // Job location index. Breaks use max(Index), as they have no location.
+    Index location;
+  };
+
   PreviousInfo previous_info(const Input& input,
                              Index job_rank,
                              Index rank) const;
@@ -66,9 +81,24 @@ private:
   void fwd_update_earliest_from(const Input& input, Index rank);
   void bwd_update_latest_from(const Input& input, Index rank);
 
+  // Reject (return false) when some constrained shipment pair provably
+  // exceeds its max_transit_time via the candidate-path lower bound.
+  // Sound: only rejects when the path-LB alone exceeds the cap.
+  bool check_max_transit_time(const Input& input,
+                              const std::vector<TraceEvent>& trace,
+                              Index first_rank,
+                              Index last_rank,
+                              Index inserted_job_count) const;
+
   void update_last_latest_date(const Input& input);
 
   void fwd_update_action_time_from(const Input& input, Index rank);
+
+  // Number of PICKUP jobs with max_transit_time currently in the route,
+  // maintained exclusively by replace(). Gates trace recording and the cap
+  // checks: when this is 0 and no inserted job is a constrained pickup, no
+  // cap pair can span this route.
+  Index constrained_job_count_{0};
 
   void fwd_update_breaks_load_margin_from(const Input& input, Index rank);
   void bwd_update_breaks_load_margin_from(const Input& input, Index rank);

--- a/src/structures/vroom/tw_route.h
+++ b/src/structures/vroom/tw_route.h
@@ -10,6 +10,7 @@ All rights reserved (see LICENSE).
 
 */
 
+#include <optional>
 #include <vector>
 
 #include "structures/typedefs.h"
@@ -89,6 +90,26 @@ private:
                               Index first_rank,
                               Index last_rank,
                               Index inserted_job_count) const;
+
+  // Cap-aware scheduler engine: whole committed route. Returns service-start
+  // times per job (indexed by route rank) or nullopt if no compliant schedule
+  // exists. Includes self-verification before returning a schedule.
+  // iter_budget_factor widens the fixpoint iteration budget; the default is
+  // the hot-path budget, realization retries with a wider one.
+  std::optional<std::vector<Duration>>
+  compute_cap_compliant_schedule(const Input& input,
+                                 std::size_t iter_budget_factor = 1) const;
+
+  // Cap-aware scheduler engine: virtual candidate route (same shape as
+  // check_max_transit_time's inputs). Returns service starts for all jobs in
+  // the virtual candidate route in candidate-route order, or nullopt.
+  std::optional<std::vector<Duration>>
+  compute_cap_compliant_schedule(const Input& input,
+                                 const std::vector<TraceEvent>& trace,
+                                 Index first_rank,
+                                 Index last_rank,
+                                 Index inserted_job_count,
+                                 std::size_t iter_budget_factor = 1) const;
 
   void update_last_latest_date(const Input& input);
 
@@ -224,6 +245,22 @@ public:
                                     rank,
                                     rank + count);
   };
+
+  // Produce cap-compliant service-start schedule (per job, indexed by route
+  // rank) for committed route, or nullopt. Returns nullopt at zero cost when
+  // the input has no max_transit_time constraint or when this route carries no
+  // constrained pickup (constrained_job_count_ == 0). When break_starts is
+  // given and a schedule exists, it receives the engine's break service
+  // starts (indexed by vehicle break rank), the authoritative break timing
+  // for output.
+  std::optional<std::vector<Duration>> realize_cap_compliant_schedule(
+    const Input& input,
+    std::vector<Duration>* break_starts = nullptr) const;
+
+  // True when this route contains at least one pickup with max_transit_time.
+  bool has_constrained_pickups() const {
+    return constrained_job_count_ > 0;
+  }
 
   void remove(const Input& input, const Index rank, const unsigned count) {
     assert(rank + count <= route.size());

--- a/src/utils/helpers.cpp
+++ b/src/utils/helpers.cpp
@@ -330,6 +330,25 @@ Route format_route(const Input& input,
 
   assert(tw_r.size() <= v.max_tasks);
 
+  // For constrained routes, obtain a cap-compliant schedule from the
+  // cap-aware scheduling engine. Tier-2 validity guarantees this succeeds
+  // for every accepted route that carries constrained pairs (acceptance was
+  // backed by a schedule the realization fixpoint must find again); routes
+  // with no constrained pickups return nullopt intentionally and use stock
+  // backward-minimized timing. A nullopt on a constrained route is an
+  // invariant breach: solve mode never emits a cap-violating route, so
+  // throw rather than emit wrong-looking-right output.
+  std::vector<Duration> eng_breaks;
+  const auto eng_sched =
+    tw_r.realize_cap_compliant_schedule(input, &eng_breaks);
+  assert(!input.has_max_transit_time() || !tw_r.has_constrained_pickups() ||
+         eng_sched.has_value());
+  if (input.has_max_transit_time() && tw_r.has_constrained_pickups() &&
+      !eng_sched.has_value()) {
+    throw InternalException(
+      "cap-compliant schedule engine returned nullopt for an accepted route");
+  }
+
   // ETA logic: aim at earliest possible arrival then determine latest
   // possible start time in order to minimize waiting times.
   Duration step_start = tw_r.earliest_end;
@@ -417,6 +436,13 @@ Route format_route(const Input& input,
       backward_wt += (candidate_start - step_start);
     }
     assert(previous_job.is_valid_start(step_start));
+  }
+
+  // For constrained routes, anchor backward-break processing on the engine's
+  // first-job service start rather than the backward-sweep value, so that the
+  // vehicle departure and forward pass reflect the cap-compliant schedule.
+  if (eng_sched.has_value()) {
+    step_start = eng_sched->front();
   }
 
   // Now pack everything ASAP based on first job start date.
@@ -522,15 +548,19 @@ Route format_route(const Input& input,
         return step_start <= tw.end;
       });
       assert(b_tw != b.tws.end());
+      // Engine-certified break timing for constrained routes; window
+      // placement otherwise.
+      const Duration placed = eng_sched.has_value()
+                                ? eng_breaks[break_rank]
+                                : std::max(step_start, b_tw->start);
 
-      if (step_start < b_tw->start) {
-        if (const auto margin = b_tw->start - step_start;
-            margin <= travel_time) {
+      if (step_start < placed) {
+        if (const auto margin = placed - step_start; margin <= travel_time) {
           // Part of the remaining travel time is spent before this
           // break, filling the whole margin.
           duration += margin;
           travel_time -= margin;
-          current_break.arrival = scale_to_user_duration(b_tw->start);
+          current_break.arrival = scale_to_user_duration(placed);
         } else {
           // The whole remaining travel time is spent before this
           // break, not filling the whole margin.
@@ -544,23 +574,23 @@ Route format_route(const Input& input,
           // Recompute user-reported waiting time rather than using
           // scale_to_user_duration(wt) to avoid rounding problems.
           current_break.waiting_time =
-            scale_to_user_duration(b_tw->start) - current_break.arrival;
+            scale_to_user_duration(placed) - current_break.arrival;
           user_waiting_time += current_break.waiting_time;
 
           duration += travel_time;
           travel_time = 0;
         }
 
-        step_start = b_tw->start;
+        step_start = placed;
       } else {
         current_break.arrival = scale_to_user_duration(step_start);
       }
 
-      assert(b_tw->start % DURATION_FACTOR == 0 &&
-             scale_to_user_duration(b_tw->start) <=
+      assert(placed % DURATION_FACTOR == 0 &&
+             scale_to_user_duration(placed) <=
                current_break.arrival + current_break.waiting_time &&
              (current_break.waiting_time == 0 ||
-              scale_to_user_duration(b_tw->start) ==
+              scale_to_user_duration(placed) ==
                 current_break.arrival + current_break.waiting_time));
 
       // Recompute cumulated durations in a consistent way as seen
@@ -636,23 +666,47 @@ Route format_route(const Input& input,
     current.arrival = scale_to_user_duration(step_start);
     current.distance = eval_sum.distance;
 
-    const auto j_tw =
-      std::ranges::find_if(current_job.tws, [&](const auto& tw) {
-        return step_start <= tw.end;
-      });
-    assert(j_tw != current_job.tws.end());
+    if (eng_sched.has_value()) {
+      // Engine schedule: use cap-compliant service start directly.
+      const Duration eng_S = (*eng_sched)[r];
+      // Derived invariant, not an input guarantee: this forward pass and the
+      // engine share the same anchor (engine front value, then identical
+      // break and travel handling), so arrivals match, and the engine's
+      // self-verification enforced S[r] >= arrival before returning.
+      assert(step_start <= eng_S);
+      if (step_start < eng_S) {
+        const Duration wt = eng_S - step_start;
+        forward_wt += wt;
+        current.waiting_time = scale_to_user_duration(eng_S) - current.arrival;
+        user_waiting_time += current.waiting_time;
+        step_start = eng_S;
+      }
+    } else {
+      const auto j_tw =
+        std::ranges::find_if(current_job.tws, [&](const auto& tw) {
+          return step_start <= tw.end;
+        });
+      assert(j_tw != current_job.tws.end());
 
-    if (step_start < j_tw->start) {
-      const Duration wt = j_tw->start - step_start;
-      forward_wt += wt;
+      if (step_start < j_tw->start) {
+        const Duration wt = j_tw->start - step_start;
+        forward_wt += wt;
 
-      // Recompute user-reported waiting time rather than using
-      // scale_to_user_duration(wt) to avoid rounding problems.
-      current.waiting_time =
-        scale_to_user_duration(j_tw->start) - current.arrival;
-      user_waiting_time += current.waiting_time;
+        // Recompute user-reported waiting time rather than using
+        // scale_to_user_duration(wt) to avoid rounding problems.
+        current.waiting_time =
+          scale_to_user_duration(j_tw->start) - current.arrival;
+        user_waiting_time += current.waiting_time;
 
-      step_start = j_tw->start;
+        step_start = j_tw->start;
+      }
+
+      assert(j_tw->start % DURATION_FACTOR == 0 &&
+             scale_to_user_duration(j_tw->start) <=
+               current.arrival + current.waiting_time &&
+             (current.waiting_time == 0 ||
+              scale_to_user_duration(j_tw->start) ==
+                current.arrival + current.waiting_time));
     }
 
     // Recompute cumulated durations in a consistent way as seen from
@@ -663,13 +717,6 @@ Route format_route(const Input& input,
     current.duration = user_duration;
     user_previous_end =
       current.arrival + current.waiting_time + current.setup + current.service;
-
-    assert(
-      j_tw->start % DURATION_FACTOR == 0 &&
-      scale_to_user_duration(j_tw->start) <=
-        current.arrival + current.waiting_time &&
-      (current.waiting_time == 0 || scale_to_user_duration(j_tw->start) ==
-                                      current.arrival + current.waiting_time));
 
     step_start += (current_setup + current_service);
 
@@ -685,6 +732,7 @@ Route format_route(const Input& input,
 
   auto r = tw_r.route.size();
   emit_breaks_before(r, user_distance);
+
   steps.emplace_back(STEP_TYPE::END, last_location.value(), current_load);
   auto& end_step = steps.back();
   if (v.has_end()) {
@@ -703,8 +751,8 @@ Route format_route(const Input& input,
   user_duration += user_travel_time;
   end_step.duration = user_duration;
 
-  assert(step_start == tw_r.earliest_end);
-  assert(forward_wt == backward_wt);
+  assert(eng_sched.has_value() || step_start == tw_r.earliest_end);
+  assert(eng_sched.has_value() || forward_wt == backward_wt);
 
   assert(step_start ==
          front_step_arrival + duration + setup + service + forward_wt);

--- a/src/utils/helpers.cpp
+++ b/src/utils/helpers.cpp
@@ -503,22 +503,12 @@ Route format_route(const Input& input,
 
   Duration travel_time = current_eval.duration;
 
-  for (std::size_t r = 0; r < tw_r.route.size(); ++r) {
-    assert(input.vehicle_ok_with_job(tw_r.v_rank, tw_r.route[r]));
-    const auto& current_job = input.jobs[tw_r.route[r]];
-    auto user_distance = eval_sum.distance;
-
-    if (r > 0) {
-      // For r == 0, travel_time already holds the relevant value
-      // depending on whether there is a start.
-      current_eval =
-        v.eval(input.jobs[tw_r.route[r - 1]].index(), current_job.index());
-      travel_time = current_eval.duration;
-    }
-
-    // Handles breaks before this job.
+  // Emit the breaks scheduled before the stop at rank r, advancing the
+  // running schedule. Used between jobs and before the route end alike.
+  const auto emit_breaks_before = [&](const std::size_t r,
+                                      auto& user_distance) {
     assert(tw_r.breaks_at_rank[r] <= tw_r.breaks_counts[r]);
-    break_rank = tw_r.breaks_counts[r] - tw_r.breaks_at_rank[r];
+    Index break_rank = tw_r.breaks_counts[r] - tw_r.breaks_at_rank[r];
 
     for (Index i = 0; i < tw_r.breaks_at_rank[r]; ++i, ++break_rank) {
       const auto& b = v.breaks[break_rank];
@@ -594,6 +584,22 @@ Route format_route(const Input& input,
       service += b.service;
       step_start += b.service;
     }
+  };
+  for (std::size_t r = 0; r < tw_r.route.size(); ++r) {
+    assert(input.vehicle_ok_with_job(tw_r.v_rank, tw_r.route[r]));
+    const auto& current_job = input.jobs[tw_r.route[r]];
+    auto user_distance = eval_sum.distance;
+
+    if (r > 0) {
+      // For r == 0, travel_time already holds the relevant value
+      // depending on whether there is a start.
+      current_eval =
+        v.eval(input.jobs[tw_r.route[r - 1]].index(), current_job.index());
+      travel_time = current_eval.duration;
+    }
+
+    // Handles breaks before this job.
+    emit_breaks_before(r, user_distance);
 
     // Back to current job.
     duration += travel_time;
@@ -678,83 +684,7 @@ Route format_route(const Input& input,
   auto user_distance = eval_sum.distance;
 
   auto r = tw_r.route.size();
-  assert(tw_r.breaks_at_rank[r] <= tw_r.breaks_counts[r]);
-  break_rank = tw_r.breaks_counts[r] - tw_r.breaks_at_rank[r];
-
-  for (Index i = 0; i < tw_r.breaks_at_rank[r]; ++i, ++break_rank) {
-    const auto& b = v.breaks[break_rank];
-
-    assert(b.is_valid_for_load(current_load));
-
-    steps.emplace_back(b, current_load);
-    auto& current_break = steps.back();
-
-    const auto b_tw = std::ranges::find_if(b.tws, [&](const auto& tw) {
-      return step_start <= tw.end;
-    });
-    assert(b_tw != b.tws.end());
-
-    if (step_start < b_tw->start) {
-      if (const auto margin = b_tw->start - step_start; margin <= travel_time) {
-        // Part of the remaining travel time is spent before this
-        // break, filling the whole margin.
-        duration += margin;
-        travel_time -= margin;
-        current_break.arrival = scale_to_user_duration(b_tw->start);
-      } else {
-        // The whole remaining travel time is spent before this
-        // break, not filling the whole margin.
-
-        const Duration wt = margin - travel_time;
-        forward_wt += wt;
-
-        current_break.arrival =
-          scale_to_user_duration(step_start + travel_time);
-
-        // Recompute user-reported waiting time rather than using
-        // scale_to_user_duration(wt) to avoid rounding problems.
-        current_break.waiting_time =
-          scale_to_user_duration(b_tw->start) - current_break.arrival;
-        user_waiting_time += current_break.waiting_time;
-
-        duration += travel_time;
-        travel_time = 0;
-      }
-
-      step_start = b_tw->start;
-    } else {
-      current_break.arrival = scale_to_user_duration(step_start);
-    }
-
-    assert(b_tw->start % DURATION_FACTOR == 0 &&
-           scale_to_user_duration(b_tw->start) <=
-             current_break.arrival + current_break.waiting_time &&
-           (current_break.waiting_time == 0 ||
-            scale_to_user_duration(b_tw->start) ==
-              current_break.arrival + current_break.waiting_time));
-
-    // Recompute cumulated durations in a consistent way as seen from
-    // UserDuration.
-    assert(user_previous_end <= current_break.arrival);
-    auto user_travel_time = current_break.arrival - user_previous_end;
-    user_duration += user_travel_time;
-    current_break.duration = user_duration;
-
-    // Pro rata temporis distance increase.
-    if (current_eval.duration != 0) {
-      user_distance += round<UserDistance>(
-        static_cast<double>(user_travel_time * current_eval.distance) /
-        scale_to_user_duration(current_eval.duration));
-    }
-    current_break.distance = user_distance;
-
-    user_previous_end = current_break.arrival + current_break.waiting_time +
-                        current_break.service;
-
-    service += b.service;
-    step_start += b.service;
-  }
-
+  emit_breaks_before(r, user_distance);
   steps.emplace_back(STEP_TYPE::END, last_location.value(), current_load);
   auto& end_step = steps.back();
   if (v.has_end()) {

--- a/src/utils/input_parser.cpp
+++ b/src/utils/input_parser.cpp
@@ -617,27 +617,27 @@ void parse(Input& input, const std::string& input_str, bool geometry) {
       auto amount = get_amount(json_shipment, "amount", amount_size);
       auto skills = get_skills(json_shipment);
       auto priority = get_priority(json_shipment);
+      auto max_transit_time =
+        get_value_for<UserDuration>(json_shipment, "max_transit_time");
 
       // Defining pickup job.
       auto& json_pickup = json_shipment["pickup"];
       check_id(json_pickup, "pickup");
 
-      const Job pickup(json_pickup["id"].GetUint64(),
-                       JOB_TYPE::PICKUP,
-                       get_task_location(json_pickup, "pickup"),
-                       get_duration(json_pickup, "setup"),
-                       get_duration(json_pickup, "service"),
-                       amount,
-                       skills,
-                       priority,
-                       get_time_windows(json_pickup, "pickup"),
-                       get_string(json_pickup, "description"),
-                       get_duration_per_type(json_pickup,
-                                             "setup_per_type",
-                                             "pickup"),
-                       get_duration_per_type(json_pickup,
-                                             "service_per_type",
-                                             "pickup"));
+      const Job
+        pickup(json_pickup["id"].GetUint64(),
+               JOB_TYPE::PICKUP,
+               get_task_location(json_pickup, "pickup"),
+               get_duration(json_pickup, "setup"),
+               get_duration(json_pickup, "service"),
+               amount,
+               skills,
+               priority,
+               get_time_windows(json_pickup, "pickup"),
+               get_string(json_pickup, "description"),
+               get_duration_per_type(json_pickup, "setup_per_type", "pickup"),
+               get_duration_per_type(json_pickup, "service_per_type", "pickup"),
+               max_transit_time);
 
       // Defining delivery job.
       auto& json_delivery = json_shipment["delivery"];
@@ -658,7 +658,8 @@ void parse(Input& input, const std::string& input_str, bool geometry) {
                                                "delivery"),
                          get_duration_per_type(json_delivery,
                                                "service_per_type",
-                                               "delivery"));
+                                               "delivery"),
+                         max_transit_time);
 
       input.add_shipment(pickup, delivery);
     }

--- a/src/utils/output_json.cpp
+++ b/src/utils/output_json.cpp
@@ -60,6 +60,12 @@ get_violations(const Violations& violations,
     case MAX_DISTANCE:
       cause = "max_distance";
       break;
+    case MAX_TRANSIT_TIME:
+      cause = "max_transit_time";
+      json_violation.AddMember("duration",
+                               violations.transit_time_excess,
+                               allocator);
+      break;
     default:
       assert(false);
     }


### PR DESCRIPTION
Hi @jcoupey — this is another attempt at #703, so I want to be upfront that I've read why the previous ones didn't work and tried to build around those objections rather than past them. Happy to be told it's still the wrong shape. I put detailed design notes and performance findings in the collapsed review note to try and make the review easier for you.

---

Some shipments carry a hard bound on how long the load may stay on the vehicle:

```
transit_time(shipment) <= max_transit_time
```

The requests behind this span several domains: a contractual delivery time measured from collection (#1241), perishable and temperature-sensitive goods (#870), cargo with a usable lifetime (#1275), and passenger transport, where the bound is time on board (#703, #1330, #1339). What they share is a limit on elapsed time between the two ends of one shipment, rather than on when either end happens.

Transit time runs from the end of the pickup action to the start of delivery service, so travel, waiting, delivery-side setup and any break taken while the load is on the vehicle all count.

The bound couples the times of two stops on the same route, which absolute per-step time windows cannot express. The usual workaround shaves the delivery window down to `pickup_early + max_transit_time`. That never breaks the bound, but it assumes the worst case: whenever the pickup actually happens later than `pickup_early`, the shipment gets less transit time than it is entitled to, and servable requests become unassignable. **On identical instances the shave serves 886 of 1532 shipments; exact enforcement serves all 1532, both fully cap-compliant.** That gap is the reason for the feature.

A transit bound would turn into a backward arc if a delivery's latest date were allowed to constrain its pickup's latest date, which is the cycle #703 describes. Nothing here propagates the constraint backward, so the forward and backward margin passes keep the shape they have today. Enforcement is layered instead: each candidate move pays the cheapest test that can decide it, and an exact scheduler settles only what the cheap tests cannot. The cap stays a hard validity constraint rather than a cost, so operator gain evaluation is untouched, there are no penalty magnitudes to tune, and solve mode never reports violations.

**1,686 insertions and 299 deletions across 18 files, 72% of the insertions in `tw_route.{h,cpp}`.**

## Commits

Each builds on its own and was verified before the next was applied.

| # | Commit | Verification |
|---|--------|--------------|
| 1 | Extract shared forward step primitives in TWRoute | byte-identical output on 116 benchmark instances against master, apart from `lc106`, which produces several different outputs across repeated runs of the unchanged binary too |
| 2 | Extract repeated break emission in format_route | byte-identical against master (same `lc106` caveat) |
| 3 | Add max_transit_time input field for shipments | field parses and validates; output with no cap present byte-identical |
| 4 | Report max_transit_time violations in plan mode | `-c` reports the excess at the delivery step and in the summary |
| 5 | Reject provably cap-violating shipments and moves | an impossible cap unassigns the shipment; no-cap output byte-identical (29/29) |
| 6 | Enforce max_transit_time exactly during solving | 31/31 feature tests; 29 capped instances with 0 cap violations and 0 unassigned |
| 7 | Bias plan-mode ETA selection toward cap compliance | 31/31; solve output fed back through `-c` reports no transit violations |
| 8 | Add changelog entry for max_transit_time | — |

Commits 1, 2 and 4 are individually useful. The first two are behavior-neutral refactors of existing code, both byte-identical against master, and are meant to be read apart from the feature. Plan-mode reporting makes existing plans auditable against a cap before anything enforces one. Commit 5 adds only sound rejection: it turns down shipments and moves no schedule could have served, and accepts nothing. Commit 6 is where exactness and its cost live.

Commit 6 carries output realization rather than deferring it, since splitting them would leave a tree whose search enforces caps but whose printed timestamps can still show a violation for a route that is in fact feasible.

Happy to split this into separate pull requests if that reads better.

## What it costs

- **Inputs with no `max_transit_time` anywhere keep the existing code path and produce byte-identical output.**
- Fully-capped instances run about 1.95x single-threaded (1.3x to 3.9x per instance); about 1.4x with 20% of shipments capped. A witness built on the committed compliant schedule rather than the ASAP one would recover much of that; it is not implemented.
- On the adversarial stress set (caps 10% above the theoretical minimum, setup times, mid- and end-of-shift breaks on every vehicle): **zero cap violations, and solve time 0.4–1.6x the same instances without caps, geometric mean ~0.9x**, since tight caps prune the search as fast as the machinery costs. The two runs do not do equal work, so this is not a like-for-like overhead figure.
- Routing cost rises by a median 1.34x against the same instances with caps removed, which is the price of the constraint itself rather than of the machinery.
- On a deliberate worst case (one vehicle, every second stop a constrained pickup) the cap multiplier is 3.7x at 50 stops rising to 24.5x at 400 stops, tracking the one extra factor of P the per-check bound predicts. Both the capped and the caps-removed runs grow steeply there, because a forced single route is a quadratic move neighborhood for the stock solver too. Table in the design note.

## What it does not do

- The engine decides against the committed break layout. A delay that would need a different break placement is a conservative rejection rather than a relayout, and how much that loses is not measured.
- The brute-force comparisons use break-free routes. Breaks are still verified on every accepted schedule, so what's untested is over-rejection, not correctness.
- Solve-mode output compresses time on the vehicle only where a cap would otherwise be broken. It is not the general "schedule pickups as late as possible" policy suggested in #1330.

---

<details>
<summary><b>Design note: <code>max_transit_time</code> for shipments</b></summary>

Baseline: upstream `master` @ `07be776f`

## Problem

Some shipments carry a hard bound on how long the load may stay on the
vehicle:

```
transit_time(shipment) <= max_transit_time
```

The requests behind this span several domains: a contractual delivery time
measured from collection (#1241), perishable and temperature-sensitive
goods (#870), cargo with a usable lifetime (#1275), and passenger
transport, where the bound is time on board (#703, #1330, #1339). What they
share is a limit on elapsed time between the two ends of one shipment,
rather than on when either end happens.

This couples the *times* of two steps of the same shipment. VROOM's time
windows are absolute per-step constraints, so the bound is not expressible
through them. The standard workaround is to shave the delivery window down to
`pickup_early + max_transit_time`, assuming the worst case (earliest possible
pickup). That never violates the bound, but it is lossy: whenever the pickup
actually happens later than `pickup_early`, the shipment is granted less
transit time than it is entitled to, which can make legally servable requests
unassignable.

## Prior art

- [#703](https://github.com/VROOM-Project/vroom/issues/703): `time_gap`
  feature request. Maintainer's objection: exact enforcement adds a backward
  arc (delivery latest constrains pickup latest) to the scheduling dependency
  graph, creating a cycle; the linear forward/backward margin propagation that
  makes validity checks cheap no longer suffices.
- [#870](https://github.com/VROOM-Project/vroom/issues/870): the same
  requester's soft-cost alternative, a per-hour shipment cost starting after a
  free gap, closed as not actionable. Maintainer's objection: moving the idea
  from validity to cost evaluation does not help, because the reason the gap
  cannot be asserted also prevents measuring the penalty; only margins are
  stored during search and actual ETAs are decided when formatting the
  solution.
- [#1241](https://github.com/VROOM-Project/vroom/issues/1241):
  `max_shipment_time` request, closed as duplicate of #703.
- [#1275](https://github.com/VROOM-Project/vroom/pull/1275): `max_lifetime`
  attempt, closed: soft penalty with ad-hoc magnitudes and a `mutable` field on
  shared `Job` state (data race under multithreaded solving).
- [#1330](https://github.com/VROOM-Project/vroom/issues/1330): ETA
  presentation for passenger transport. Maintainer suggestion: schedule
  pickups as late as possible to compress on-board dwell. Solve-mode output
  realization below implements that policy for constrained routes.
- [#1339](https://github.com/VROOM-Project/vroom/issues/1339):
  `max_onboard_time` request, redirected to #703.

## Semantics

`max_transit_time` (integer seconds, `>= 0`) on a `shipment`. The measure is
wall-clock:

```
transit_time = service_start(delivery) - departure(pickup)
```

The clock starts when the pickup action ends (setup plus service, where
setup is skipped when the vehicle is already at that location) and stops when
delivery service begins. Everything in between counts: travel, waiting,
delivery-side setup, and any break the vehicle takes while the cargo is on
board. Enforcement, output
timestamps, plan-mode ETA selection and violation reporting all use this one
definition.

## Design: layered exact enforcement

A transit bound turns into a backward arc as soon as a delivery's latest
date is allowed to constrain its pickup's latest date, which is the cycle
#703 describes. Nothing here propagates the constraint backward through
route margins, so the forward and backward passes keep the shape they have
today. Enforcement is layered instead: each candidate move pays the
cheapest test that can decide it, and an exact scheduler settles what the
cheap tests cannot. Every move the search accepts is backed by a schedule
meeting every cap. Plan mode reports violations on user-supplied routes,
like `lead_time`/`delay`.

The cap stays a hard validity constraint rather than a cost, which is where
the soft-penalty attempts in #870 and #1275 ran into trouble. Operator gain
evaluation is untouched: no penalty magnitudes to tune, no unit clash with
`vehicle.costs`, no violations in solve mode, and none of the
operator-gain surface catalogued in
[#1266](https://github.com/VROOM-Project/vroom/issues/1266) to modify.

Green nodes with heavy borders are added by this feature; every other color
marks the pipeline stage of existing VROOM machinery (blue input, amber
solve, violet output, rose plan mode; teal/red for the accept and reject
outcomes).

```mermaid
flowchart TD
  subgraph SG_IN["Input setup"]
    parse["parse + validate input"] --> pre{"shipment can never
meet its cap?"}
    pre -- "yes" --> unas["mark unassignable, report
like skill incompatibility"]
    pre -- "no" --> disp["dispatch to VRPTW solver"]
  end

  subgraph SG_SOLVE["Solve: construction + local search"]
    heur["construction heuristics
build initial routes"] --> ls["local search operators
propose candidate moves"]
    ls --> tw["TW / load / break
feasibility simulation"]
    tw -- "infeasible" --> reject["reject move"]
    tw -- "feasible" --> gate{"route carries a
constrained pickup?"}
    gate -- "no" --> accept["accept move"]
    gate -- "yes" --> lb{"path lower bound
exceeds a cap?"}
    lb -- "yes" --> reject
    lb -- "no" --> wit{"ASAP schedule meets
every cap?"}
    wit -- "yes" --> accept
    wit -- "no" --> eng{"exact engine finds a
compliant schedule?"}
    eng -- "yes" --> accept
    eng -- "no" --> reject
    accept --> commit["replace(): update committed
route and cached margins"]
    commit -. "repeat until no
improving move" .-> ls
  end

  subgraph SG_OUT["Output"]
    sol["best solution"] --> real["realize cap-compliant
timestamps"]
    real --> fmt["format_route: emit solution"]
  end

  subgraph SG_PLAN["Plan mode (-c)"]
    mip["choose_ETA MIP selects
service times"] --> exc["soft transit-excess terms"]
    exc --> viol["report max_transit_time
violations"]
  end

  disp --> heur
  ls -- "search exhausted" --> sol
  disp -.-> mip

  classDef added fill:#c9e5a5,stroke:#3f7d1c,color:#1d330b,stroke-width:2.5px;
  classDef inStage fill:#dbe8fa,stroke:#4a7ab5,color:#16324f;
  classDef solveStage fill:#fdf2d0,stroke:#b8933a,color:#4a3a10;
  classDef outStage fill:#e8def2,stroke:#8a63ad,color:#32204a;
  classDef planStage fill:#fadde3,stroke:#b55a72,color:#4a1e2a;
  classDef acceptNode fill:#d2ede4,stroke:#3d8a70,color:#123528;
  classDef rejectNode fill:#f5d9d9,stroke:#a84848,color:#3d1414;
  class pre,unas,gate,lb,wit,eng,real,exc,viol added;
  class parse,disp inStage;
  class heur,ls,tw,commit solveStage;
  class sol,fmt outStage;
  class mip planStage;
  class accept acceptNode;
  class reject rejectNode;
  style SG_IN fill:#f7fafe,stroke:#a8c4e4;
  style SG_SOLVE fill:#fffdf4,stroke:#d9c58a;
  style SG_OUT fill:#faf7fd,stroke:#c3aed6;
  style SG_PLAN fill:#fdf6f8,stroke:#d9a8b5;
```

### Input-time rejection

A shipment whose minimum conceivable transit time already exceeds its cap
can never be served. That minimum is the larger of a travel bound and the
wait forced by its own time windows, measured from the latest achievable
pickup departure (end of the pickup's last window plus the largest
setup-plus-service among compatible vehicles) to the start of the delivery's
first window. The travel bound stays valid for arbitrary, including
non-metric, matrices: it is the smaller of the direct pickup-to-delivery leg
and the cheapest edge out of the pickup plus the cheapest edge into the
delivery, minimized over vehicle profiles. Such
shipments are marked incompatible with every vehicle during input setup and
surface immediately as unassigned, exactly like skill incompatibility. Both
bound terms deliberately underestimate, so no servable shipment is rejected.

Presence of `max_transit_time` forces the VRPTW solver path (like time windows
do): enforcement machinery lives in `TWRoute`, and constrained inputs must
never solve on the CVRP path.

### Cheap screen inside route validity

`TWRoute::is_valid_addition_for_tw`, the choke point for construction
heuristics and local-search operators, evaluates constrained pairs on the
candidate route:

- **Candidate-path lower bound** (sound rejection): the travel plus
  intermediate action time along the actual candidate sequence between pickup
  and delivery lower-bounds every schedule's transit time, for arbitrary
  (including non-metric) duration matrices. Exceeding the cap proves the move
  infeasible.
- **ASAP witness** (sound acceptance): the forward simulation already produces
  a concrete as-soon-as-possible schedule; if that schedule meets every cap
  on the route, it is a proof by example that the move is feasible and no
  further work is needed. Every pair is checked, including pairs entirely in
  the unmodified prefix: the committed route may be compliant only through
  a delayed schedule, and with multiple time windows that delay can
  overshoot into a later window and push every downstream stop. Pairs whose
  delivery lies in the unmodified suffix have no exact ASAP time, so they
  disqualify the witness. This check may only accept, never reject.

This choke point covers the whole search: every construction heuristic and
every local-search operator, SWAP* included, validates candidate routes
through `is_valid_addition_for_tw` (SWAP* additionally exchanges single
jobs only, so it can never separate a pickup from its delivery). Removals
go through the same choke point (`is_valid_removal` is an empty-range
addition), so they pay the same screens and engine; removing a stop can
invalidate a route on non-metric matrices, which is why that check already
exists upstream.

Route-level gating keeps all of this off routes that carry no constrained
pickup (a counter maintained in `replace()`, mirroring the existing
per-vehicle capability gating), and a single `Input::has_max_transit_time()`
flag keeps unconstrained inputs on the exact master code path: their
behavior and performance are unchanged.

### Exact scheduling engine

Candidates the screen cannot decide go to the engine
(`compute_cap_compliant_schedule`): given a fixed stop sequence, it searches
for a full schedule satisfying every time window, break and cap. Its
contract is asymmetric by design: acceptance is always backed by a concrete
schedule re-verified from scratch against raw input, so it can never accept
unsoundly; rejection is conservative only when the hot-path iteration
budget runs out, quantified below.

The engine decides against the committed break layout: breaks keep the
positions the search assigned them, and a delay that would need a different
break placement to stay feasible is a conservative rejection, not a
relayout. Exactness below is therefore stated relative to that layout. How
much this loses is not measured: the break-bearing stress set shows zero cap
violations, which is a soundness result and says nothing about how many
servable shipments a relayout would recover.

When evaluating a candidate move, the engine follows the codebase's
incremental idiom: it seeds its forward simulation from the committed route's
cached schedule arrays at the edit boundary instead of re-simulating the
unchanged prefix, exactly as `fwd_update_earliest_from` does. Any schedule it
returns is still re-verified from scratch against raw input, so seeding
cannot introduce false acceptances.

The core idea: when an as-soon-as-possible schedule breaks a cap, the excess
is usually waiting time sitting *after* the pickup, with the cargo on
board, that could equally sit *before* it. The engine shifts pickups later
within the room their own windows and every downstream stop allow (their
"forward slack", the classic DARP scheduling device), then re-simulates the
whole route and re-checks every cap, repeating until a compliant schedule
appears or none can. Slack analysis only ever *proposes* a shift; the
decision is always a full re-simulation. When a delay pushes a pickup past
its current time window, the engine advances to the next window and starts
at the later of the window start and the required delay, so the computed
delay is carried across window gaps.

On the hot path iterations are bounded at 2P+2 for P constrained pairs.
Termination does not depend on the bound (service starts only ever move
later and are capped by their time windows); the bound turns eventual
convergence into a linear-in-P cost guarantee, sized so each pair can be
delayed once and revisited once after another pair's delay propagates
through it. Budget exhaustion is a conservative rejection, measured at
0.007% of 95 million engine calls (see the complexity section).

Each delay is the smallest one that can remove the violation, and a later
start never makes any other start earlier, so the trajectory is the minimal
one: the engine is exact up to the iteration budget. To check that, the engine is
compared against a brute-force search that enumerates every schedule a
route admits. Over 32500 randomized routes carrying two to five
constrained pairs with multiple time windows (14058 of them feasible on
windows alone), calling the engine from scratch on each, there is no
schedule the brute-force search found that the engine missed, and none the
engine accepted that breaks a cap. A second comparison drives the full
validity entry point (`is_valid_addition_for_tw`) with random committed
routes and random insertions: over 1369 insertions every accept and every
reject matched the brute-force answer, so the entry point turned away
nothing it could have served. Two
configurations are pinned as regression tests: one that requires carrying
the delay across a window gap, and one where a prefix pair's window-gap
overshoot makes an insertion infeasible that the ASAP schedule alone would
accept.

The brute-force comparisons use break-free routes. Breaks are still
verified on every accepted schedule, so what's untested is over-rejection,
not correctness.

### Output realization and plan mode

Solve-mode timestamps for constrained routes are the engine's compliant
schedule rather than raw ASAP times, which moves waiting from after a
pickup to before it wherever that is what meets a cap.

It applies to the whole route: a stop with no cap that shares a vehicle
with a constrained pair follows the compliant schedule's timing too, which
can place waiting earlier than the backward-minimized policy used on
unconstrained routes. Break service times come from the engine as well, so
output timing has a single authority rather than a second placement rule to
keep in step with the certified schedule.

This is narrower than the "schedule pickups as late as possible" policy
suggested in #1330. The engine delays a pickup by exactly the amount that
clears its cap and then stops, so on-board time is compressed only for a
pair that a cap would otherwise catch. A pair whose ASAP schedule already
fits its cap is left where it is, and a shipment with no cap is never
affected. Minimizing on-board time in general is a separate change.

Every accepted move was proven by the witness (the ASAP schedule itself, which
is the engine's starting point) or by the engine, so a compliant schedule
exists for every committed route. Realization runs once per route off the
hot path: if the hot-path budget is exhausted it reruns the fixpoint with
no iteration bound, which terminates because service starts are monotone
and bounded by window ends. A failure past that point would be an internal
invariant breach and throws: solve mode never emits a cap-violating route
and never reports violations — those are plan mode's job on user-supplied
routes. No test or benchmark set has reached that path.

Plan mode (`-c`) biases ETA selection with soft transit-time excess terms in
the existing MIP. The LP is untouched when no shipment carries a cap; with P
constrained pairs on a route it gains P excess variables and P+1 rows of
three nonzeros each, weighted at the same makespan scale as the existing
delay terms. The excess uses the identical action-time formula as the
engine, so a solve-mode schedule is a zero-excess point of this MIP;
residual excess is reported as a `max_transit_time` violation with its
duration, aggregated like `lead_time`/`delay`. Feeding every solve-mode
route from the single- and multi-window benchmark sets back through plan
mode reports zero `max_transit_time` violations. The soft terms do not move
LP solve time measurably (capped vs caps-stripped plan inputs: within 2% at
100 tasks, within 1% at 400 tasks, about a millisecond in absolute terms),
and with the field absent plan-mode output is byte-identical to upstream
master.

All candidate evaluation works on stack and thread-local scratch state; no
mutable state is ever added to shared `Job` objects, and solving is safe at
any thread count.

## Performance characteristics

Li&Lim PDPTW benchmarks (single time window per stop unless noted), caps
synthesized time-window-aware so instances are cap-feasible by
construction. Timing is single-threaded for run-to-run determinism, except
the default-thread pass noted below; matched builds, identical flags. Every
measured claim below comes from a script kept with the test assets rather
than from a hand-run: the instance generators, a two-binary output
comparator that reruns each mismatch and prints the set of output hashes
per binary, so run-to-run nondeterminism cannot be mistaken for a
behavioral difference, the plan-mode timing and parity harness, and the
brute-force comparisons described above:

- **Inputs with no cap anywhere produce byte-identical output to master,
  with no measurable overhead**, at every tested size (100–1000 tasks).
- Constrained instances: every shipment served and every cap met, at a
  higher routing cost than the same instance solved with the caps removed:
  median 1.34x, range 1.02x to 1.75x across 29 instances. That is the price
  of the constraint itself, not of the machinery enforcing it.
- Solve-time overhead vs unconstrained, single-threaded: ~1.4x on mixed
  workloads (20% of shipments capped, a realistic mixed shape);
  fully capped sets pay more, geometric mean ~1.95x (1.3–3.9x per instance):
  once a route's committed pairs comply only through delayed pickups, the
  ASAP witness can no longer vouch for it and every candidate on that route
  goes to the engine. A witness built on the committed compliant schedule
  rather than ASAP would recover much of this; it is not implemented. At
  the default thread count the difference is not resolvable at these
  instance sizes: capped median 336ms vs 384ms uncapped across the
  fully-capped set, within the run-to-run spread the solver already shows at
  this scale. Zero violations across repeated runs.
- Against the delivery-window-shaving workaround on identical instances:
  **shaving serves 886 of 1532 shipments (58%), exact enforcement serves all
  1532**, both fully cap-compliant. Against the other workaround, solving
  without caps and dropping every shipment whose transit exceeds its cap,
  872 of 1532 survive. This gap is the reason for the feature.
- Multi-window variant of the same set (every constrained pickup's window
  split into two disjoint windows with a gap, every third delivery given a
  second later window): 1529 of 1532 served, zero cap violations.
- Adversarial stress set (every shipment capped at 10% above its theoretical
  minimum transit, nonzero setup times, mandatory mid-shift and end-of-shift
  breaks on every vehicle): **zero cap violations and zero break-window
  violations on every instance**. **Solve time is 0.4–1.6x the same
  instances without caps (geometric mean ~0.9x)**, but the two runs do not do
  equal work: the capped run leaves 654 shipments unassigned, so this is not
  a like-for-like overhead measurement. Each of those 654 is also unassigned
  when solved alone on a dedicated vehicle from the same instance. That is a
  self-consistency check rather than an independent infeasibility proof,
  since the same engine answers both times.

### Worst-case complexity per validity check

For a candidate route of length L with P constrained pairs, B breaks and at
most W time windows per stop (stock validity simulation: O((L+B)W)):

- **Gating**: routes with no constrained pickup pay O(1); inputs without the
  field pay nothing anywhere.
- **Trace recording**: O(1) per simulated event, only on constrained routes.
- **Cheap screen**: O(S·L) where S is the number of constrained pairs
  spanning the edit, from one O(L) path walk per spanning pair. S is bounded
  by the vehicle's simultaneous on-board shipment count, worst case O(L).
- **ASAP witness**: O(L) for the schedule scan, plus one O(L) suffix lookup
  per constrained pickup whose delivery is not in the trace (the lookup that
  separates "delivery in the suffix", which needs the engine, from "delivery
  absent from the candidate", which constrains nothing): O(S·L) worst case,
  same S as above.
- **Exact engine** (undecided candidates only): O(P·(L+B)·W). The fixpoint
  runs at most 2P+2 iterations, each an O(P) worst-pair scan plus one
  O((L+B)W) re-simulation; the pair list build adds O(P·L); prefix seeding
  reduces the simulated span but not the class.

So the worst case per validity check is O(P·(L+B)·W), a factor P over the
stock check, reaching O(L²) when every second stop is a constrained pickup.
A synthetic scaling harness confirms the classes empirically (log-log slopes
over route doublings up to L=1024): engine-saturated checks scale at slope
~2 (quadratic, ~2ms per check at L=1024), screen-plus-one-engine-pass checks
at slope ~2, witness-decided checks at slope ~1 (linear, ~3µs at L=1024).
At the adversarial corner the per-check cost compounds with the number of
candidates: a single vehicle, so nothing bounds route length, and every
second stop a constrained pickup, so P grows with the route. Solving the
same instances with the caps removed separates what the caps cost from what
the shape costs.

**This is the deliberate worst case, not a realistic instance** (one
vehicle, every second stop a constrained pickup, caps at 1.5x the minimum
leg):

| adversarial route length | with caps | caps removed | cap multiplier |
| ------------------------ | --------- | ------------ | -------------- |
| 50 stops                 | 0.11s     | 0.03s        | 3.7x           |
| 100 stops                | 0.89s     | 0.13s        | 6.8x           |
| 200 stops                | 13.6s     | 1.1s         | 12.5x          |
| 400 stops                | 289.5s    | 11.8s        | 24.5x          |

Single runs, single-threaded. Both columns grow steeply: a forced single
route is a quadratic move neighborhood for the stock solver too. The ratio
between them roughly doubles as the route doubles, which is the one extra
factor of P the per-check bound predicts, turning up in wall-clock time.

Real workloads sit far from this corner: a fleet bounds route length, P per
route is small, and the cheap screens decide most candidates. The benchmark
sections above reflect that gap. Instrumented across 95 million engine calls (fully-capped,
mixed and adversarial benchmark sets), the fixpoint converged in 0 or 1
iterations for 93% of calls, never used more than 11, and exhausted its
2P+2 budget in 0.007% of calls overall (0% on the mixed set), each
exhaustion resolving to a conservative rejection.

## Code footprint

1,686 insertions and 299 deletions across 18 files. 72% of the insertions
are in `tw_route.{h,cpp}`, whose main file grows from 1,512 to 2,525
lines; the rest is spread thinly, no other file gaining more than 171
lines.

The change is not confined to new code. The engine's forward pass and the
stock one need the same three scheduling rules — setup suppression, forward
time-window selection, and the break step with its wait absorbed into
remaining leg travel — so those rules are extracted into file-local
primitives that `fwd_update_earliest_from` and `bwd_update_latest_from` now
call. That is a deliberate trade: the existing margin machinery changes
shape, but no second copy of the scheduling semantics exists to drift out of
sync with the machinery the engine certifies. The extraction is
behavior-preserving: output is byte-identical across all four benchmark
sets, 116 instances, apart from lc106. On that instance the unchanged
binary also produces several different outputs across repeated runs, so it
is nondeterministic on its own account, independent of this change.

`format_route` gets the same treatment for a smaller reason: it emitted the
breaks scheduled before a stop in two places, between jobs and before the
route end, as the same 77 lines. Timing a break now happens in one lambda
rather than two copies. That extraction is byte-identical to master as
well.

On top of those primitives the feature adds one file-local forward simulator
(`cap_asap_forward`), the candidate-path screen, one engine implementation
(the committed-route entry point is a two-line delegate of the candidate
one) with the realization wrapper, and this state:

- `Input::has_max_transit_time()` and `Job::max_transit_time`, both const
  after input setup and never mutated during solving;
- `TWRoute::constrained_job_count_`, the route-level gating counter,
  reconciled against route contents by an assert at realization time, off
  the hot path, so a mutation path bypassing its bookkeeping cannot disable
  enforcement silently, and the private `TraceEvent` record;
- twelve thread-local scratch buffers, cleared per call, never aliased
  across threads and never referenced past a call;
- `Violations::transit_time_excess`, trailing and defaulted so existing
  constructor calls keep compiling, and `VIOLATION::MAX_TRANSIT_TIME`.

Every schedule the engine returns is self-verified from scratch against raw
input before acceptance. The brute-force comparisons and the pinned
regression configurations guard future changes to scheduling semantics.

</details>
